### PR TITLE
Bug fixes for v1.0.3

### DIFF
--- a/lib/SdFat_NoArduino/src/ExFatLib/ExFatPartition.cpp
+++ b/lib/SdFat_NoArduino/src/ExFatLib/ExFatPartition.cpp
@@ -285,7 +285,7 @@ bool ExFatPartition::init(FsBlockDevice* dev, uint8_t part) {
   if (part >= 1) {
     mbr = reinterpret_cast<MbrSector_t*>(cache);
     mp = &mbr->part[part - 1];
-    if ((mp->boot != 0 && mp->boot != 0X80) || mp->type == 0) {
+    if (mp->type == 0) {
       DBG_FAIL_MACRO;
       goto fail;
     }

--- a/lib/SdFat_NoArduino/src/FatLib/FatPartition.cpp
+++ b/lib/SdFat_NoArduino/src/FatLib/FatPartition.cpp
@@ -416,7 +416,7 @@ bool FatPartition::init(FsBlockDevice* dev, uint8_t part) {
           (dataCachePrepare(0, FsCache::CACHE_FOR_READ));
     MbrPart_t* mp = mbr->part + part - 1;
 
-    if (!mbr || mp->type == 0 || (mp->boot != 0 && mp->boot != 0X80)) {
+    if (!mbr || mp->type == 0) {
       DBG_FAIL_MACRO;
       goto fail;
     }

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -2,7 +2,7 @@
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform.h"
 
-const char *g_azlog_firmwareversion = "1.0.1" " " __DATE__ " " __TIME__;
+const char *g_azlog_firmwareversion = "1.0.3" " " __DATE__ " " __TIME__;
 bool g_azlog_debug = true;
 
 // This memory buffer can be read by debugger and is also saved to zululog.txt


### PR DESCRIPTION
Patches from
============
Improve filename handling (#62, #63)
80228b6c01aa6e95e0060c07e3308f6217021996

GD32: fix reading of very last SD card sector
3c41957068ae87582e3ac65fd4e2a28beebe2b68

Fix spurious read error messages due to prefetch when image is at end…
cb6d102435c5c599ed110cb40875626f829699e8

Narrow down error for spec 1.x sd cards
7ed375d8e30f08226703d781b13a9c06777b6042
to
786dffd3476b64882c11f0525b24087354ebc6d6
skipping
e7c8fe7293276957b494ffa533fe4c7c2e954ff2

Remove boot flag check from SdFat
d004cc3d862a9b2cc7b8575c5833581c65308254