### PR TITLE
Perform reads in whole sector blocks by default

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1200,9 +1200,7 @@ void diskDataIn_callback(uint32_t bytes_complete)
 
     // Machintosh SCSI driver can get confused if pauses occur in middle of
     // a sector, so schedule the transfers in sector sized blocks.
-    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
-    if (bytes_complete < g_disk_transfer.bytes_sd &&
-        img.quirks == S2S_CFG_QUIRKS_APPLE)
+    if (bytes_complete < g_disk_transfer.bytes_sd)
     {
         uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
         if (bytes_complete % bytesPerSector != 0)


### PR DESCRIPTION
Always enable the whole block read code that is needed by some Mac models.
The latency difference should be negligible (less than 0.1 ms) and when enabled always there is one less "quirk" to test.