### PR TITLE
Enable PHY_MODE_DMA_TIMER by default.

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
@@ -126,9 +126,7 @@ static void selectPhyMode()
 {
     int oldmode = g_scsi_phy_mode;
 
-    // TODO: Change to BEST_AVAILABLE once accelerated modes are tested enough.
-    // int default_mode = PHY_MODE_BEST_AVAILABLE;
-    int default_mode = PHY_MODE_GREENPAK_DMA;
+    int default_mode = PHY_MODE_BEST_AVAILABLE;
 
     // Read overriding setting from configuration file
     int wanted_mode = ini_getl("SCSI", "PhyMode", default_mode, CONFIGFILE);


### PR DESCRIPTION
This change affects V1.1 hardware without the optional GreenPAK accelerator chip.
This commit enables the DMA_TIMER mode by default, which improves performance compared to the PIO mode.

Tested on Linux and Mac LC III.