### PR TITLE
Rp2040 bugfixes

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -635,11 +635,12 @@ void scsi_accel_rp2040_init()
     g_scsi_dma.core1_active = false;
     multicore_reset_core1();
     multicore_launch_core1(&enable_irq_second_core);
-    delay(1);
+    delay(5);
 
     if (!g_scsi_dma.core1_active)
     {
         azlog("Failed to offload SCSI DMA interrupts to second core, using first core");
+        multicore_reset_core1();
         irq_set_exclusive_handler(DMA_IRQ_0, scsi_dma_write_irq);
         irq_set_enabled(DMA_IRQ_0, true);
     }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -85,9 +85,11 @@ public:
             m_israw = true;
             m_blockdev = SD.card();
 
-            if (m_endsector >= SD.card()->sectorCount())
+            uint32_t sectorCount = SD.card()->sectorCount();
+            if (m_endsector >= sectorCount)
             {
-                m_endsector = SD.card()->sectorCount() - 1;
+                azlog("Limiting RAW image mapping to SD card sector count: ", (int)sectorCount);
+                m_endsector = sectorCount - 1;
             }
         }
         else


### PR DESCRIPTION
Three bugfixes for RP2040 platform:

- RAW fallback mapping was not working
- Last write could be cut short when host reads slowly (#61)
- Increase timeout for second core initialization, not sure if it helps.