### PR TITLE
Remove apple quirks from defaulting to right align

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -395,11 +395,6 @@ static void setDefaultDriveInfo(int target_idx)
     }
 
     int rightAlign = img.rightAlignStrings;
-    if (rightAlign < 0)
-    {
-        // Default value based on quirks
-        rightAlign = (img.quirks == S2S_CFG_QUIRKS_APPLE);
-    }
 
     formatDriveInfoField(img.vendor, sizeof(img.vendor), rightAlign);
     formatDriveInfoField(img.prodId, sizeof(img.prodId), rightAlign);


### PR DESCRIPTION
Right-aligned strings break the ability of Apple's Disk Utility to initialize drives. Reverting this behavior.