### PR TITLE
Report correct max rom size in log

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -472,8 +472,8 @@ const void * btldr_vectors[2] = {&__StackTop, (void*)&btldr_reset_handler};
 
 #ifdef PLATFORM_HAS_ROM_DRIVE
 
-// Reserve up to 384 kB for firmware.
-#define ROMDRIVE_OFFSET (384 * 1024)
+// Reserve up to 352 kB for firmware.
+#define ROMDRIVE_OFFSET (352 * 1024)
 
 uint32_t azplatform_get_romdrive_maxsize()
 {

--- a/lib/ZuluSCSI_platform_RP2040/rp2040.ld
+++ b/lib/ZuluSCSI_platform_RP2040/rp2040.ld
@@ -1,6 +1,6 @@
 MEMORY
 {
-    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 384k
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 352k
     RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 240k  /* Leave space for pico-debug */
     SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -103,8 +103,8 @@ bool scsiDiskProgramRomDrive(const char *filename, int scsi_id, int blocksize, S
     uint32_t maxsize = azplatform_get_romdrive_maxsize() - AZPLATFORM_ROMDRIVE_PAGE_SIZE;
 
     azlog("---- SCSI ID: ", scsi_id, " blocksize ", blocksize, " type ", (int)type);
-    azlog("---- ROM drive maximum size is ", (int)azplatform_get_romdrive_maxsize(),
-          " bytes, image file is ", (int)file.size(), " bytes");
+    azlog("---- ROM drive maximum size is ", (int)maxsize,
+          " bytes, image file is ", (int)filesize, " bytes");
     
     if (filesize > maxsize)
     {


### PR DESCRIPTION
Corrected the max rom size reported in the log file. Decreased max program size by 32KB to increase max ROM size.