### PR TITLE
Add ability to disable ROM drive with zuluscsi.ini file

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -178,11 +178,26 @@ bool scsiDiskActivateRomDrive()
         return false;
     }
 
+    if (ini_getbool("SCSI", "DisableROM", 0, CONFIGFILE))
+    {
+        azlog("---- ROM disabled in ini file, not enabling");
+        return false;
+    }
+
+    long rom_scsi_id = ini_getl("SCSI", "ROMSetSCSIID", -1, CONFIGFILE);
+    if (rom_scsi_id >= 0 && rom_scsi_id <= 7)
+    {
+        hdr.scsi_id = rom_scsi_id;
+        azlog("---- ROM drive SCSI id overriden in ini file, changed to ", (int)hdr.scsi_id);
+    }
+
     if (s2s_getConfigById(hdr.scsi_id))
     {
         azlog("---- ROM drive SCSI id ", (int)hdr.scsi_id, " is already in use, not enabling");
         return false;
     }
+
+
 
     azlog("---- Activating ROM drive, SCSI id ", (int)hdr.scsi_id, " size ", (int)(hdr.imagesize / 1024), " kB");
     bool status = scsiDiskOpenHDDImage(hdr.scsi_id, "ROM:", hdr.scsi_id, 0, hdr.blocksize, hdr.drivetype);

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -178,13 +178,13 @@ bool scsiDiskActivateRomDrive()
         return false;
     }
 
-    if (ini_getbool("SCSI", "DisableROM", 0, CONFIGFILE))
+    if (ini_getbool("SCSI", "DisableROMDrive", 0, CONFIGFILE))
     {
-        azlog("---- ROM disabled in ini file, not enabling");
+        azlog("---- ROM drive disabled in ini file, not enabling");
         return false;
     }
 
-    long rom_scsi_id = ini_getl("SCSI", "ROMSetSCSIID", -1, CONFIGFILE);
+    long rom_scsi_id = ini_getl("SCSI", "ROMDriveSCSIID", -1, CONFIGFILE);
     if (rom_scsi_id >= 0 && rom_scsi_id <= 7)
     {
         hdr.scsi_id = rom_scsi_id;

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -14,6 +14,10 @@ EnableSelLatch = 0 # For Philips P2000C and other devices that release SEL signa
 MapLunsToIDs = 0 # For Philips P2000C simulate multiple LUNs
 MaxSyncSpeed = 10 # Set to 5 or 10 to enable synchronous SCSI mode, 0 to disable
 
+# ROM settings
+#DisableROM = 1 # Disable the ROM if it has been loaded to Flash
+#ROMSetSCSIID = 7 # Override ROM's SCSI ID, set to -1 or do not include to use ROM's orignal ID
+
 # Settings that can be specified either per-device or for all devices.
 #Vendor = "QUANTUM"
 #Product = "FIREBALL1"

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -15,8 +15,8 @@ MapLunsToIDs = 0 # For Philips P2000C simulate multiple LUNs
 MaxSyncSpeed = 10 # Set to 5 or 10 to enable synchronous SCSI mode, 0 to disable
 
 # ROM settings
-#DisableROM = 1 # Disable the ROM if it has been loaded to Flash
-#ROMSetSCSIID = 7 # Override ROM's SCSI ID, set to -1 or do not include to use ROM's orignal ID
+#DisableROMDrive = 1 # Disable the ROM drive if it has been loaded to flash
+#ROMDriveSCSIID = 7 # Override ROM drive's SCSI ID
 
 # Settings that can be specified either per-device or for all devices.
 #Vendor = "QUANTUM"


### PR DESCRIPTION
Added the ability to disable the ROM drive after it has been written to flash.

Added the ability to change the SCSI ID of the ROM drive from the ini file.