### PR TITLE
Update workflow action version to v3

### DIFF
--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ZuluSCSI
           fetch-depth: "0"
@@ -31,7 +31,7 @@ jobs:
           utils/rename_binaries.sh
 
       - name: Upload binaries into build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ZuluSCSI/distrib/*
           name: ZuluSCSI binaries


### PR DESCRIPTION
This is to get rid of depreciated messages when auto building assets.