### PR TITLE
Fix reporting time of firmware version

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -203,6 +203,9 @@ void azplatform_init()
 
 void azplatform_late_init()
 {
+    azlog("Platform: ", g_azplatform_name);
+    azlog("FW Version: ", g_azlog_firmwareversion);
+    
     if (gpio_input_bit_get(DIP_PORT, DIPSW3_PIN))
     {
         azlog("DIPSW3 is ON: Enabling SCSI termination");

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -475,12 +475,6 @@ static void reinitSCSI()
 
 extern "C" void zuluscsi_setup(void)
 {
-// V2.0, the RP2040 must log FW Version in azplatform_init to avoid hanging  
-#ifndef ZULUSCSI_V2_0  
-  azlog("Platform: ", g_azplatform_name);
-  azlog("FW Version: ", g_azlog_firmwareversion);
-#endif
-
   azplatform_init();
   azplatform_late_init();
 


### PR DESCRIPTION
Move firmware version logging to platform code after millisecond clock is reset.