### PR TITLE
Report proper termination on ZuluSCSI mini v1.0

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -203,6 +203,9 @@ void azplatform_init()
 
 void azplatform_late_init()
 {
+#ifdef ZULUSCSI_V1_0_mini
+        azlog("DIPSW3 is ON: Enabling SCSI termination");
+#else
     if (gpio_input_bit_get(DIP_PORT, DIPSW3_PIN))
     {
         azlog("DIPSW3 is ON: Enabling SCSI termination");
@@ -212,6 +215,7 @@ void azplatform_late_init()
     {
         azlog("DIPSW3 is OFF: SCSI termination disabled");
     }
+#endif // ZULUSCSI_V1_0_mini
 
     if (gpio_input_bit_get(DIP_PORT, DIPSW2_PIN))
     {

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -15,7 +15,11 @@ extern "C" {
 extern const char *g_azplatform_name;
 
 #if defined(ZULUSCSI_V1_0)
-#   define PLATFORM_NAME "ZuluSCSI v1.0"
+#   if defined(ZULUSCSI_V1_0_mini)
+#       define PLATFORM_NAME "ZuluSCSI mini v1.0"
+#   else
+#       define PLATFORM_NAME "ZuluSCSI v1.0"
+#   endif
 #   define PLATFORM_REVISION "1.0"
 #   define PLATFORM_MAX_SCSI_SPEED S2S_CFG_SPEED_ASYNC_50
 #   include "ZuluSCSI_v1_0_gpio.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,7 @@
 ; PlatformIO Project Configuration File https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = ZuluSCSIv1_0, ZuluSCSIv1_1, ZuluSCSI_RP2040
+default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1, ZuluSCSI_RP2040
 
 ; Example platform to serve as a base for porting efforts
 [env:template]
@@ -49,6 +49,18 @@ build_flags =
      -DSD_CHIP_SELECT_MODE=2
      -DENABLE_DEDICATED_SPI=1
      -DZULUSCSI_V1_0
+
+; ZuluSCSI V1.0 mini hardware platform with GD32F205 CPU.
+[env:ZuluSCSIv1_0_mini]
+extends = env:ZuluSCSIv1_0
+build_flags = 
+     -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
+     -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
+     -DSPI_DRIVER_SELECT=3
+     -DSD_CHIP_SELECT_MODE=2
+     -DENABLE_DEDICATED_SPI=1
+     -DZULUSCSI_V1_0
+     -DZULUSCSI_V1_0_mini
 
 ; ZuluSCSI V1.1 hardware platform, similar to V1.0 but with improved performance.
 [env:ZuluSCSIv1_1]

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -6,7 +6,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "1.1.4"
+#define FW_VER_NUM      "1.1.5"
 #define FW_VER_SUFFIX   "release"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 


### PR DESCRIPTION
Mask a hardware error on some rev2022b boards that are reporting the incorrect termination status.