### PR TITLE
Add the ability to disable the status LED

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -239,6 +239,12 @@ void azplatform_late_init()
     greenpak_load_firmware();
 }
 
+void azplatform_disable_led(void)
+{   
+    gpio_init(LED_PORT, GPIO_MODE_IPU, 0, LED_PINS);
+    azlog("Disabling status LED");
+}
+
 /*****************************************/
 /* Crash handlers                        */
 /*****************************************/

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -65,6 +65,9 @@ void azplatform_init();
 // Initialization for main application, not used for bootloader
 void azplatform_late_init();
 
+// Disable the status LED
+void azplatform_disable_led(void);
+
 // Setup soft watchdog
 void azplatform_reset_watchdog();
 

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -231,6 +231,13 @@ bool azplatform_is_initiator_mode_enabled()
     return g_scsi_initiator;
 }
 
+void azplatform_disable_led(void)
+{   
+    //        pin      function       pup   pdown  out    state fast
+    gpio_conf(LED_PIN, GPIO_FUNC_SIO, false,false, false, false, false);
+    azlog("Disabling status LED");
+}
+
 /*****************************************/
 /* Crash handlers                        */
 /*****************************************/

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
@@ -54,6 +54,9 @@ void azplatform_init();
 // Initialization for main application, not used for bootloader
 void azplatform_late_init();
 
+// Disable the status LED
+void azplatform_disable_led(void);
+
 // Query whether initiator mode is enabled on targets with PLATFORM_HAS_INITIATOR_MODE
 bool azplatform_is_initiator_mode_enabled();
 

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
@@ -27,6 +27,14 @@ void azplatform_late_init()
      */
 }
 
+void azplatform_disable_led(void)
+{
+    /* This function disables the LED on the ZuluSCSI board
+    *  Generally by switching the pin from output to input.
+    */
+}
+
+
 /*****************************************/
 /* Debug logging and watchdor            */
 /*****************************************/

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
@@ -46,6 +46,9 @@ void azplatform_init();
 // Initialization for main application, not used for bootloader
 void azplatform_late_init();
 
+// Disable the status LED
+void azplatform_disable_led(void);
+
 // Setup soft watchdog if supported
 void azplatform_reset_watchdog();
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -519,6 +519,10 @@ extern "C" void zuluscsi_setup(void)
   if (g_sdcard_present)
   {
     init_logfile();
+    if (ini_getbool("SCSI", "DisableStatusLED", false, CONFIGFILE))
+    {
+      azplatform_disable_led();
+    }
   }
 }
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -5,6 +5,7 @@ SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 =
 PhyMode = 0   # 0: Best available  1: PIO  2: DMA_TIMER  3: GREENPAK_PIO   4: GREENPAK_DMA
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9
+#DisableStatusLED 1 # 0: Use status LED, 1: Disable status LED
 
 # Settings that can be needed for compatibility with some hosts
 Quirks = 0   # 0: Standard, 1: Apple, 2: OMTI, 4: Xebec, 8: VMS


### PR DESCRIPTION
The LED is only disabled after the SD card is read.

That means it will blink on boot and blink until it finds an SD card that is readable with a the zuluscsi.ini file and the `DisableStatusLED = 1` under `[SCSI]` is set. After which it will never blink again until the board is power cycled.