### PR TITLE
RP2040: Reduce delay between phase signal changes (#128)

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
@@ -205,9 +205,20 @@ extern "C" uint32_t scsiEnterPhaseImmediate(int phase)
         }
         else
         {
-            SCSI_OUT(MSG, phase & __scsiphase_msg);
-            SCSI_OUT(CD,  phase & __scsiphase_cd);
-            SCSI_OUT(IO,  phase & __scsiphase_io);
+            // The phase control signals should be changed close to simultaneously.
+            // The SCSI spec allows 400 ns for this, but some hosts do not seem to be that
+            // tolerant. The Cortex-M0 is also quite slow in bit twiddling.
+            //
+            // To avoid unnecessary delays, precalculate an XOR mask and then apply it
+            // simultaneously to all three signals.
+            uint32_t gpio_new = 0;
+            if (!(phase & __scsiphase_msg)) { gpio_new |= (1 << SCSI_OUT_MSG); }
+            if (!(phase & __scsiphase_cd)) { gpio_new |= (1 << SCSI_OUT_CD); }
+            if (!(phase & __scsiphase_io)) { gpio_new |= (1 << SCSI_OUT_IO); }
+
+            uint32_t mask = (1 << SCSI_OUT_MSG) | (1 << SCSI_OUT_CD) | (1 << SCSI_OUT_IO);
+            uint32_t gpio_xor = (sio_hw->gpio_out ^ gpio_new) & mask;
+            sio_hw->gpio_togl = gpio_xor;
             SCSI_ENABLE_CONTROL_OUT();
 
             int delayNs = 400; // Bus settle delay


### PR DESCRIPTION
It seems that some hosts like PC-9821 have low tolerance for delay between the different phase signals toggling. The Cortex-M0 processor slow bit twiddling instructions caused around 100 ns delay before this change. The signals are now toggled simultaneously.

While #128 is not yet fully fixed, this seems to at least improve things and is closer to "ideal" operation.