### PR TITLE
Reinsert CD-ROM image when receiving Inquiry command

### DIFF
--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -30,6 +30,7 @@ MaxSyncSpeed = 10 # Set to 5 or 10 to enable synchronous SCSI mode, 0 to disable
 #HeadsPerCylinder = 255
 #RightAlignStrings = 0 # Right-align SCSI vendor / product strings, defaults on if Quirks = 1
 #PrefetchBytes = 8192 # Maximum number of bytes to prefetch after a read request, 0 to disable
+#ReinsertCDOnInquiry = 1 # Reinsert any ejected CD-ROM image on Inquiry command
 
 # Settings can be overridden for individual devices.
 [SCSI2]


### PR DESCRIPTION
Some hosts do not issue bus reset on reboot, so this makes sure that any ejected CD-ROMs are automatically reinserted on first inquiry command.

This feature is enabled by default. It can be disabled in zuluscsi.ini by setting ReinsertCDOnInquiry = 0