### PR TITLE
RP2040: Add .ini option to enable/disable parity check.

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
@@ -21,6 +21,7 @@ extern const char *g_azplatform_name;
 #define PLATFORM_OPTIMAL_LAST_SD_WRITE_SIZE 8192
 #define SD_USE_SDIO 1
 #define PLATFORM_HAS_INITIATOR_MODE 1
+#define PLATFORM_HAS_PARITY_CHECK 1
 
 // NOTE: The driver supports synchronous speeds higher than 10MB/s, but this
 // has not been tested due to lack of fast enough SCSI adapter.

--- a/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
@@ -354,17 +354,21 @@ extern "C" uint8_t scsiReadByte(void)
 extern "C" void scsiRead(uint8_t* data, uint32_t count, int* parityError)
 {
     *parityError = 0;
+    if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY)) { parityError = NULL; }
+
     scsiStartRead(data, count, parityError);
     scsiFinishRead(data, count, parityError);
 }
 
 extern "C" void scsiStartRead(uint8_t* data, uint32_t count, int *parityError)
 {
+    if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY)) { parityError = NULL; }
     scsi_accel_rp2040_startRead(data, count, parityError, &scsiDev.resetFlag);
 }
 
 extern "C" void scsiFinishRead(uint8_t* data, uint32_t count, int *parityError)
 {
+    if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY)) { parityError = NULL; }
     scsi_accel_rp2040_finishRead(data, count, parityError, &scsiDev.resetFlag);
     scsiLogDataOut(data, count);
 }

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -684,7 +684,7 @@ void scsi_accel_rp2040_finishRead(const uint8_t *data, uint32_t count, int *pari
     }
     
     // Check if any parity errors have been detected during the transfer so far
-    if (SCSI_DMA_PIO->irq & 1)
+    if (parityError != NULL && (SCSI_DMA_PIO->irq & 1))
     {
         azdbg("scsi_accel_rp2040_finishRead(", bytearray(data, count), ") detected parity error");
         *parityError = true;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -978,6 +978,18 @@ void s2s_configInit(S2S_BoardCfg* config)
         azlog("-- MapLunsToIDs is on");
         config->flags |= S2S_CFG_MAP_LUNS_TO_IDS;
     }
+
+#ifdef PLATFORM_HAS_PARITY_CHECK
+    if (ini_getbool("SCSI", "EnableParity", true, CONFIGFILE))
+    {
+        azlog("-- EnableParity is on");
+        config->flags |= S2S_CFG_ENABLE_PARITY;
+    }
+    else
+    {
+        azlog("-- EnableParity is off");
+    }
+#endif
 }
 
 extern "C"

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -12,6 +12,7 @@ Quirks = 0   # 0: Standard, 1: Apple, 2: OMTI, 4: Xebec, 8: VMS
 EnableUnitAttention = 0 # Post UNIT_ATTENTION status on power-on or SD card hotplug
 EnableSCSI2 = 1 # Enable faster speeds of SCSI2
 EnableSelLatch = 0 # For Philips P2000C and other devices that release SEL signal before BSY
+EnableParity = 1 # Enable parity checks on platforms that support it (RP2040)
 MapLunsToIDs = 0 # For Philips P2000C simulate multiple LUNs
 MaxSyncSpeed = 10 # Set to 5 or 10 to enable synchronous SCSI mode, 0 to disable
 


### PR DESCRIPTION
Parity bit will always be transmitted to the host. RP2040 platform can optionally check received parity. Some hosts do not implement parity, so this option allows to disable the check:

    [SCSI]
    EnableParity = 0

The log file will indicate either `-- EnableParity is on` (default) or `-- EnableParity is off` on platforms that support the check.

**Note:** I haven't yet tested this on real hardware myself. Please download test build from here and check before merging:
https://github.com/ZuluSCSI/ZuluSCSI-firmware/actions/runs/4240160312
