### PR TITLE
Reduce differences with BlueSCSI fork

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-extern const char *g_azplatform_name;
+extern const char *g_platform_name;
 
 #if defined(ZULUSCSI_V1_0)
 #   if defined(ZULUSCSI_V1_0_mini)
@@ -34,7 +34,7 @@ extern const char *g_azplatform_name;
 #endif
 
 // Debug logging functions
-void azplatform_log(const char *s);
+void platform_log(const char *s);
 
 // Minimal millis() implementation as GD32F205 does not
 // have an Arduino core yet.
@@ -60,25 +60,25 @@ static inline void delay_100ns()
 }
 
 // Initialize SPI and GPIO configuration
-void azplatform_init();
+void platform_init();
 
 // Initialization for main application, not used for bootloader
-void azplatform_late_init();
+void platform_late_init();
 
 // Disable the status LED
-void azplatform_disable_led(void);
+void platform_disable_led(void);
 
 // Setup soft watchdog
-void azplatform_reset_watchdog();
+void platform_reset_watchdog();
 
 // Reinitialize SD card connection and save log from interrupt context.
 // This can be used in crash handlers.
-void azplatform_emergency_log_save();
+void platform_emergency_log_save();
 
 // Set callback that will be called during data transfer to/from SD card.
 // This can be used to implement simultaneous transfer to SCSI bus.
 typedef void (*sd_callback_t)(uint32_t bytes_complete);
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 // This function is called by scsiPhy.cpp.
 // It resets the systick counter to give 1 millisecond of uninterrupted transfer time.
@@ -86,16 +86,16 @@ void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 void SysTick_Handle_PreEmptively();
 
 // Reprogram firmware in main program area.
-#define AZPLATFORM_BOOTLOADER_SIZE 32768
-#define AZPLATFORM_FLASH_TOTAL_SIZE (256 * 1024)
-#define AZPLATFORM_FLASH_PAGE_SIZE 2048
-bool azplatform_rewrite_flash_page(uint32_t offset, uint8_t buffer[AZPLATFORM_FLASH_PAGE_SIZE]);
-void azplatform_boot_to_main_firmware();
+#define PLATFORM_BOOTLOADER_SIZE 32768
+#define PLATFORM_FLASH_TOTAL_SIZE (256 * 1024)
+#define PLATFORM_FLASH_PAGE_SIZE 2048
+bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE]);
+void platform_boot_to_main_firmware();
 
 // Configuration customizations based on DIP switch settings
 // When DIPSW1 is on, Apple quirks are enabled by default.
-void azplatform_config_hook(S2S_TargetCfg *config);
-#define AZPLATFORM_CONFIG_HOOK(cfg) azplatform_config_hook(cfg)
+void platform_config_hook(S2S_TargetCfg *config);
+#define PLATFORM_CONFIG_HOOK(cfg) platform_config_hook(cfg)
 
 // Write a single SCSI pin.
 // Example use: SCSI_OUT(ATN, 1) sets SCSI_ATN to low (active) state.

--- a/lib/ZuluSCSI_platform_GD32F205/greenpak.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/greenpak.cpp
@@ -155,22 +155,22 @@ bool greenpak_load_firmware()
 
     if (!greenpak_read(0, &dummy, 1))
     {
-        azlog("Optional GreenPAK not detected");
+        logmsg("Optional GreenPAK not detected");
         return false;
     }
     else
     {
-        azlog("Optional GreenPAK detected, loading firmware");
+        logmsg("Optional GreenPAK detected, loading firmware");
     }
 
     if (!greenpak_write(0, g_greenpak_fw, sizeof(g_greenpak_fw)))
     {
-        azlog("GreenPAK firmware loading failed");
+        logmsg("GreenPAK firmware loading failed");
         return false;
     }
     else
     {
-        azlog("GreenPAK firmware successfully loaded");
+        logmsg("GreenPAK firmware successfully loaded");
         LED_ON();
         delay(10);
         LED_OFF();

--- a/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
@@ -117,7 +117,7 @@ static void scsi_rst_assert_interrupt()
 
     if (rst1 && rst2)
     {
-        azdbg("BUS RESET");
+        dbgmsg("BUS RESET");
         scsiDev.resetFlag = 1;
     }
 }
@@ -164,7 +164,7 @@ static void selectPhyMode()
 
     if (g_scsi_phy_mode != oldmode)
     {
-        azlog("SCSI PHY operating mode: ", g_scsi_phy_mode_names[g_scsi_phy_mode]);
+        logmsg("SCSI PHY operating mode: ", g_scsi_phy_mode_names[g_scsi_phy_mode]);
     }
 }
 
@@ -353,7 +353,7 @@ extern "C" void scsiStartWrite(const uint8_t* data, uint32_t count)
     }
     else
     {
-        azlog("Unknown SCSI PHY mode: ", (int)g_scsi_phy_mode);
+        logmsg("Unknown SCSI PHY mode: ", (int)g_scsi_phy_mode);
     }
 }
 

--- a/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
@@ -273,7 +273,7 @@ static void check_dma_next_buffer()
 // Convert new data from application buffer to DMA buffer
 extern "C" void SCSI_TIMER_DMACHA_IRQ()
 {
-    // azdbg("DMA irq A, counts: ", DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHA), " ",
+    // dbgmsg("DMA irq A, counts: ", DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHA), " ",
     //             DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHB), " ",
     //             TIMER_CNT(SCSI_TIMER));
 
@@ -284,7 +284,7 @@ extern "C" void SCSI_TIMER_DMACHA_IRQ()
     {
         if (intf & full_flag)
         {
-            azlog("ERROR: SCSI DMA overrun: ", intf,
+            logmsg("ERROR: SCSI DMA overrun: ", intf,
                " bytes_app: ", g_scsi_dma.bytes_app,
                " bytes_dma: ", g_scsi_dma.bytes_dma,
                " dma_idx: ", g_scsi_dma.dma_idx,
@@ -311,7 +311,7 @@ extern "C" void SCSI_TIMER_DMACHA_IRQ()
 // Check if enough data is available to continue DMA transfer
 extern "C" void SCSI_TIMER_DMACHB_IRQ()
 {
-    // azdbg("DMA irq B, counts: ", DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHA), " ",
+    // dbgmsg("DMA irq B, counts: ", DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHA), " ",
     //             DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHB), " ",
     //             TIMER_CNT(SCSI_TIMER));
     uint32_t intf = DMA_INTF(SCSI_TIMER_DMA);
@@ -394,7 +394,7 @@ void scsi_accel_dma_startWrite(const uint8_t* data, uint32_t count, volatile int
         }
     }
 
-    // azdbg("Starting DMA write of ", (int)count, " bytes");
+    // dbgmsg("Starting DMA write of ", (int)count, " bytes");
     scsi_dma_gpio_config(true);
     g_scsi_dma_state = SCSIDMA_WRITE;
     g_scsi_dma.app_buf = (uint8_t*)data;
@@ -452,7 +452,7 @@ void scsi_accel_dma_finishWrite(volatile int *resetFlag)
     {
         if ((uint32_t)(millis() - start) > 5000)
         {
-            azlog("scsi_accel_dma_finishWrite() timeout, DMA counts ",
+            logmsg("scsi_accel_dma_finishWrite() timeout, DMA counts ",
                 DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHA), " ",
                 DMA_CHCNT(SCSI_TIMER_DMA, SCSI_TIMER_DMACHB), " ",
                 TIMER_CNT(SCSI_TIMER));

--- a/lib/ZuluSCSI_platform_GD32F205/scsi_accel_sync.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsi_accel_sync.cpp
@@ -135,7 +135,7 @@ void scsi_accel_sync_recv(uint8_t *data, uint32_t count, int* parityError, volat
             {
                 // We are in a pinch here: without ACK pulses coming, the EXMC and DMA peripherals
                 // are locked up. The only way out is a whole system reset.
-                azlog("SCSI Synchronous read timeout: resetting system");
+                logmsg("SCSI Synchronous read timeout: resetting system");
                 NVIC_SystemReset();
             }
         }
@@ -450,7 +450,7 @@ void scsi_accel_sync_send(const uint8_t* data, uint32_t count, volatile int *res
     }
     else
     {
-        azdbg("No optimized routine for syncOffset=", syncOffset, " syndPeriod=", syncPeriod, ", using fallback");
+        dbgmsg("No optimized routine for syncOffset=", syncOffset, " syndPeriod=", syncPeriod, ", using fallback");
         while (count-- > 0)
         {
             while (TIMER_CNT(SCSI_SYNC_TIMER) > count + syncOffset && !*resetFlag);
@@ -468,7 +468,7 @@ void scsi_accel_sync_send(const uint8_t* data, uint32_t count, volatile int *res
 
     if (*resetFlag)
     {
-        azdbg("Bus reset during sync transfer, total ", (int)count,
+        dbgmsg("Bus reset during sync transfer, total ", (int)count,
               " bytes, remaining ACK count ", (int)TIMER_CNT(SCSI_SYNC_TIMER));
     }
 

--- a/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
@@ -23,7 +23,7 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    azlog("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
     return false;
 }
 
@@ -37,7 +37,7 @@ bool SdioCard::begin(SdioConfig sdioConfig)
     if (g_sdio_error != SD_OK)
     {
         // Don't spam the log when main program polls for card insertion.
-        azdbg("sd_init() failed: ", (int)g_sdio_error);
+        dbgmsg("sd_init() failed: ", (int)g_sdio_error);
         return false;
     }
 
@@ -98,19 +98,19 @@ bool SdioCard::readOCR(uint32_t* ocr)
 
 bool SdioCard::readData(uint8_t* dst)
 {
-    azlog("SdioCard::readData() called but not implemented!");
+    logmsg("SdioCard::readData() called but not implemented!");
     return false;
 }
 
 bool SdioCard::readStart(uint32_t sector)
 {
-    azlog("SdioCard::readStart() called but not implemented!");
+    logmsg("SdioCard::readStart() called but not implemented!");
     return false;
 }
 
 bool SdioCard::readStop()
 {
-    azlog("SdioCard::readStop() called but not implemented!");
+    logmsg("SdioCard::readStop() called but not implemented!");
     return false;
 }
 
@@ -147,7 +147,7 @@ bool SdioCard::stopTransmission(bool blocking)
         }
         if (isBusy())
         {
-            azlog("SdioCard::stopTransmission() timeout");
+            logmsg("SdioCard::stopTransmission() timeout");
             return false;
         }
         else
@@ -178,19 +178,19 @@ uint8_t SdioCard::type() const
 
 bool SdioCard::writeData(const uint8_t* src)
 {
-    azlog("SdioCard::writeData() called but not implemented!");
+    logmsg("SdioCard::writeData() called but not implemented!");
     return false;
 }
 
 bool SdioCard::writeStart(uint32_t sector)
 {
-    azlog("SdioCard::writeStart() called but not implemented!");
+    logmsg("SdioCard::writeStart() called but not implemented!");
     return false;
 }
 
 bool SdioCard::writeStop()
 {
-    azlog("SdioCard::writeStop() called but not implemented!");
+    logmsg("SdioCard::writeStop() called but not implemented!");
     return false;
 }
 
@@ -200,12 +200,12 @@ bool SdioCard::erase(uint32_t firstSector, uint32_t lastSector)
 }
 
 bool SdioCard::cardCMD6(uint32_t arg, uint8_t* status) {
-    azlog("SdioCard::cardCMD6() not implemented");
+    logmsg("SdioCard::cardCMD6() not implemented");
     return false;
 }
 
 bool SdioCard::readSCR(scr_t* scr) {
-    azlog("SdioCard::readSCR() not implemented");
+    logmsg("SdioCard::readSCR() not implemented");
     return false;
 }
 
@@ -216,7 +216,7 @@ static const uint8_t *m_stream_buffer;
 static uint32_t m_stream_count;
 static uint32_t m_stream_count_start;
 
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
 {
     m_stream_callback = func;
     m_stream_buffer = buffer;
@@ -245,7 +245,7 @@ static sdio_callback_t get_stream_callback(const uint8_t *buf, uint32_t count, c
         }
         else
         {
-            azdbg("SD card ", accesstype, "(", (int)sector,
+            dbgmsg("SD card ", accesstype, "(", (int)sector,
                   ") slow transfer, buffer", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
             return NULL;
         }
@@ -282,7 +282,7 @@ bool SdioCard::readSectors(uint32_t sector, uint8_t* dst, size_t n)
         {
             if (!readSector(sector + i, dst + i * 512))
             {
-                azlog("End of drive read failed at ", sector, " + ", i);
+                logmsg("End of drive read failed at ", sector, " + ", i);
                 return false;
             }
         }

--- a/lib/ZuluSCSI_platform_GD32F205/sd_card_spi.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/sd_card_spi.cpp
@@ -121,7 +121,7 @@ public:
         }
         else if (m_stream_callback)
         {
-            azdbg("Stream buffer mismatch: ", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
+            dbgmsg("Stream buffer mismatch: ", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
         }
 
         // Use DMA to stream dummy TX data and store RX data
@@ -143,7 +143,7 @@ public:
         {
             if (millis() - start > 500)
             {
-                azlog("ERROR: SPI DMA receive of ", (int)count, " bytes timeouted");
+                logmsg("ERROR: SPI DMA receive of ", (int)count, " bytes timeouted");
                 return 1;
             }
 
@@ -156,7 +156,7 @@ public:
 
         if (DMA_INTF(DMA0) & DMA_FLAG_ADD(DMA_FLAG_ERR, SD_SPI_RX_DMA_CHANNEL))
         {
-            azlog("ERROR: SPI DMA receive set DMA_FLAG_ERR");
+            logmsg("ERROR: SPI DMA receive set DMA_FLAG_ERR");
         }
 
         SPI_CTL1(SD_SPI) &= ~(SPI_CTL1_DMAREN | SPI_CTL1_DMATEN);
@@ -181,7 +181,7 @@ public:
         }
         else if (m_stream_callback)
         {
-            azdbg("Stream buffer mismatch: ", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
+            dbgmsg("Stream buffer mismatch: ", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
         }
 
         // Use DMA to stream TX data
@@ -198,7 +198,7 @@ public:
         {
             if (millis() - start > 500)
             {
-                azlog("ERROR: SPI DMA transmit of ", (int)count, " bytes timeouted");
+                logmsg("ERROR: SPI DMA transmit of ", (int)count, " bytes timeouted");
                 return;
             }
 
@@ -211,7 +211,7 @@ public:
 
         if (DMA_INTF(DMA0) & DMA_FLAG_ADD(DMA_FLAG_ERR, SD_SPI_TX_DMA_CHANNEL))
         {
-            azlog("ERROR: SPI DMA transmit set DMA_FLAG_ERR");
+            logmsg("ERROR: SPI DMA transmit set DMA_FLAG_ERR");
         }
 
         wait_idle();
@@ -258,7 +258,7 @@ void sdCsWrite(SdCsPin_t pin, bool level)
 GD32SPIDriver g_sd_spi_port;
 SdSpiConfig g_sd_spi_config(0, DEDICATED_SPI, SD_SCK_MHZ(30), &g_sd_spi_port);
 
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
 {
     g_sd_spi_port.set_sd_callback(func, buffer);    
 }

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /* These are used in debug output and default SCSI strings */
-extern const char *g_azplatform_name;
+extern const char *g_platform_name;
 #define PLATFORM_NAME "ZuluSCSI RP2040"
 #define PLATFORM_REVISION "2.0"
 #define PLATFORM_MAX_SCSI_SPEED S2S_CFG_SPEED_SYNC_10
@@ -29,8 +29,8 @@ extern const char *g_azplatform_name;
 
 // Debug logging function, can be used to print to e.g. serial port.
 // May get called from interrupt handlers.
-void azplatform_log(const char *s);
-void azplatform_emergency_log_save();
+void platform_log(const char *s);
+void platform_emergency_log_save();
 
 // Timing and delay functions.
 // Arduino platform already provides these
@@ -50,46 +50,46 @@ static inline void delay_100ns()
 }
 
 // Initialize SD card and GPIO configuration
-void azplatform_init();
+void platform_init();
 
 // Initialization for main application, not used for bootloader
-void azplatform_late_init();
+void platform_late_init();
 
 // Disable the status LED
-void azplatform_disable_led(void);
+void platform_disable_led(void);
 
 // Query whether initiator mode is enabled on targets with PLATFORM_HAS_INITIATOR_MODE
-bool azplatform_is_initiator_mode_enabled();
+bool platform_is_initiator_mode_enabled();
 
 // Setup soft watchdog if supported
-void azplatform_reset_watchdog();
+void platform_reset_watchdog();
 
 // Set callback that will be called during data transfer to/from SD card.
 // This can be used to implement simultaneous transfer to SCSI bus.
 typedef void (*sd_callback_t)(uint32_t bytes_complete);
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 // Reprogram firmware in main program area.
 #ifndef RP2040_DISABLE_BOOTLOADER
-#define AZPLATFORM_BOOTLOADER_SIZE (128 * 1024)
-#define AZPLATFORM_FLASH_TOTAL_SIZE (1024 * 1024)
-#define AZPLATFORM_FLASH_PAGE_SIZE 4096
-bool azplatform_rewrite_flash_page(uint32_t offset, uint8_t buffer[AZPLATFORM_FLASH_PAGE_SIZE]);
-void azplatform_boot_to_main_firmware();
+#define PLATFORM_BOOTLOADER_SIZE (128 * 1024)
+#define PLATFORM_FLASH_TOTAL_SIZE (1024 * 1024)
+#define PLATFORM_FLASH_PAGE_SIZE 4096
+bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE]);
+void platform_boot_to_main_firmware();
 #endif
 
 // ROM drive in the unused external flash area
 #ifndef RP2040_DISABLE_ROMDRIVE
 #define PLATFORM_HAS_ROM_DRIVE 1
 // Check maximum available space for ROM drive in bytes
-uint32_t azplatform_get_romdrive_maxsize();
+uint32_t platform_get_romdrive_maxsize();
 
 // Read ROM drive area
-bool azplatform_read_romdrive(uint8_t *dest, uint32_t start, uint32_t count);
+bool platform_read_romdrive(uint8_t *dest, uint32_t start, uint32_t count);
 
 // Reprogram ROM drive area
-#define AZPLATFORM_ROMDRIVE_PAGE_SIZE 4096
-bool azplatform_write_romdrive(const uint8_t *data, uint32_t start, uint32_t count);
+#define PLATFORM_ROMDRIVE_PAGE_SIZE 4096
+bool platform_write_romdrive(const uint8_t *data, uint32_t start, uint32_t count);
 #endif
 
 // Parity lookup tables for write and read from SCSI bus.

--- a/lib/ZuluSCSI_platform_RP2040/rp2040_sdio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/rp2040_sdio.cpp
@@ -134,7 +134,7 @@ uint64_t sdio_crc16_4bit_checksum(uint32_t *data, uint32_t num_words)
 
 static void sdio_send_command(uint8_t command, uint32_t arg, uint8_t response_bits)
 {
-    // azdbg("SDIO Command: ", (int)command, " arg ", arg);
+    // dbgmsg("SDIO Command: ", (int)command, " arg ", arg);
 
     // Format the arguments in the way expected by the PIO code.
     uint32_t word0 =
@@ -183,7 +183,7 @@ sdio_status_t rp2040_sdio_command_R1(uint8_t command, uint32_t arg, uint32_t *re
         {
             if (command != 8) // Don't log for missing SD card
             {
-                azdbg("Timeout waiting for response in rp2040_sdio_command_R1(", (int)command, "), ",
+                dbgmsg("Timeout waiting for response in rp2040_sdio_command_R1(", (int)command, "), ",
                     "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)g_sdio.pio_cmd_clk_offset,
                     " RXF: ", (int)pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM),
                     " TXF: ", (int)pio_sm_get_tx_fifo_level(SDIO_PIO, SDIO_CMD_SM));
@@ -201,7 +201,7 @@ sdio_status_t rp2040_sdio_command_R1(uint8_t command, uint32_t arg, uint32_t *re
         // Read out response packet
         uint32_t resp0 = pio_sm_get(SDIO_PIO, SDIO_CMD_SM);
         uint32_t resp1 = pio_sm_get(SDIO_PIO, SDIO_CMD_SM);
-        // azdbg("SDIO R1 response: ", resp0, " ", resp1);
+        // dbgmsg("SDIO R1 response: ", resp0, " ", resp1);
 
         // Calculate response checksum
         uint8_t crc = 0;
@@ -214,14 +214,14 @@ sdio_status_t rp2040_sdio_command_R1(uint8_t command, uint32_t arg, uint32_t *re
         uint8_t actual_crc = ((resp1 >> 0) & 0xFE);
         if (crc != actual_crc)
         {
-            azdbg("rp2040_sdio_command_R1(", (int)command, "): CRC error, calculated ", crc, " packet has ", actual_crc);
+            dbgmsg("rp2040_sdio_command_R1(", (int)command, "): CRC error, calculated ", crc, " packet has ", actual_crc);
             return SDIO_ERR_RESPONSE_CRC;
         }
 
         uint8_t response_cmd = ((resp0 >> 24) & 0xFF);
         if (response_cmd != command && command != 41)
         {
-            azdbg("rp2040_sdio_command_R1(", (int)command, "): received reply for ", (int)response_cmd);
+            dbgmsg("rp2040_sdio_command_R1(", (int)command, "): received reply for ", (int)response_cmd);
             return SDIO_ERR_RESPONSE_CODE;
         }
 
@@ -255,7 +255,7 @@ sdio_status_t rp2040_sdio_command_R2(uint8_t command, uint32_t arg, uint8_t resp
     {
         if ((uint32_t)(millis() - start) > 2)
         {
-            azdbg("Timeout waiting for response in rp2040_sdio_command_R2(", (int)command, "), ",
+            dbgmsg("Timeout waiting for response in rp2040_sdio_command_R2(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)g_sdio.pio_cmd_clk_offset,
                   " RXF: ", (int)pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM),
                   " TXF: ", (int)pio_sm_get_tx_fifo_level(SDIO_PIO, SDIO_CMD_SM));
@@ -298,14 +298,14 @@ sdio_status_t rp2040_sdio_command_R2(uint8_t command, uint32_t arg, uint8_t resp
     uint8_t actual_crc = response[15] & 0xFE;
     if (crc != actual_crc)
     {
-        azdbg("rp2040_sdio_command_R2(", (int)command, "): CRC error, calculated ", crc, " packet has ", actual_crc);
+        dbgmsg("rp2040_sdio_command_R2(", (int)command, "): CRC error, calculated ", crc, " packet has ", actual_crc);
         return SDIO_ERR_RESPONSE_CRC;
     }
 
     uint8_t response_cmd = ((response_buf[0] >> 24) & 0xFF);
     if (response_cmd != 0x3F)
     {
-        azdbg("rp2040_sdio_command_R2(", (int)command, "): Expected reply code 0x3F");
+        dbgmsg("rp2040_sdio_command_R2(", (int)command, "): Expected reply code 0x3F");
         return SDIO_ERR_RESPONSE_CODE;
     }
 
@@ -323,7 +323,7 @@ sdio_status_t rp2040_sdio_command_R3(uint8_t command, uint32_t arg, uint32_t *re
     {
         if ((uint32_t)(millis() - start) > 2)
         {
-            azdbg("Timeout waiting for response in rp2040_sdio_command_R3(", (int)command, "), ",
+            dbgmsg("Timeout waiting for response in rp2040_sdio_command_R3(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)g_sdio.pio_cmd_clk_offset,
                   " RXF: ", (int)pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM),
                   " TXF: ", (int)pio_sm_get_tx_fifo_level(SDIO_PIO, SDIO_CMD_SM));
@@ -339,7 +339,7 @@ sdio_status_t rp2040_sdio_command_R3(uint8_t command, uint32_t arg, uint32_t *re
     uint32_t resp0 = pio_sm_get(SDIO_PIO, SDIO_CMD_SM);
     uint32_t resp1 = pio_sm_get(SDIO_PIO, SDIO_CMD_SM);
     *response = ((resp0 & 0xFFFFFF) << 8) | ((resp1 >> 8) & 0xFF);
-    // azdbg("SDIO R3 response: ", resp0, " ", resp1);
+    // dbgmsg("SDIO R3 response: ", resp0, " ", resp1);
 
     return SDIO_OK;
 }
@@ -432,7 +432,7 @@ static void sdio_verify_rx_checksums(uint32_t maxcount)
             g_sdio.checksum_errors++;
             if (g_sdio.checksum_errors == 1)
             {
-                azlog("SDIO checksum error in reception: block ", blockidx,
+                logmsg("SDIO checksum error in reception: block ", blockidx,
                       " calculated ", checksum, " expected ", expected);
             }
         }
@@ -482,7 +482,7 @@ sdio_status_t rp2040_sdio_rx_poll(uint32_t *bytes_complete)
     }
     else if ((uint32_t)(millis() - g_sdio.transfer_start_time) > 1000)
     {
-        azdbg("rp2040_sdio_rx_poll() timeout, "
+        dbgmsg("rp2040_sdio_rx_poll() timeout, "
             "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_DATA_SM) - (int)g_sdio.pio_data_rx_offset,
             " RXF: ", (int)pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_DATA_SM),
             " TXF: ", (int)pio_sm_get_tx_fifo_level(SDIO_PIO, SDIO_DATA_SM),
@@ -604,17 +604,17 @@ sdio_status_t check_sdio_write_response(uint32_t card_response)
     }
     else if (wr_status == 5)
     {
-        azlog("SDIO card reports write CRC error, status ", card_response);
+        logmsg("SDIO card reports write CRC error, status ", card_response);
         return SDIO_ERR_WRITE_CRC;    
     }
     else if (wr_status == 6)
     {
-        azlog("SDIO card reports write failure, status ", card_response);
+        logmsg("SDIO card reports write failure, status ", card_response);
         return SDIO_ERR_WRITE_FAIL;    
     }
     else
     {
-        azlog("SDIO card reports unknown write status ", card_response);
+        logmsg("SDIO card reports unknown write status ", card_response);
         return SDIO_ERR_WRITE_FAIL;    
     }
 }
@@ -704,7 +704,7 @@ sdio_status_t rp2040_sdio_tx_poll(uint32_t *bytes_complete)
     }
     else if ((uint32_t)(millis() - g_sdio.transfer_start_time) > 1000)
     {
-        azdbg("rp2040_sdio_tx_poll() timeout, "
+        dbgmsg("rp2040_sdio_tx_poll() timeout, "
             "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_DATA_SM) - (int)g_sdio.pio_data_tx_offset,
             " RXF: ", (int)pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_DATA_SM),
             " TXF: ", (int)pio_sm_get_tx_fifo_level(SDIO_PIO, SDIO_DATA_SM),

--- a/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
@@ -44,7 +44,7 @@ bool scsiHostPhySelect(int target_id)
 
         if (SCSI_IN_DATA() != 0)
         {
-            azdbg("scsiHostPhySelect: bus is busy");
+            dbgmsg("scsiHostPhySelect: bus is busy");
             scsiLogInitiatorPhaseChange(BUS_FREE);
             SCSI_RELEASE_OUTPUTS();
             return false;
@@ -53,7 +53,7 @@ bool scsiHostPhySelect(int target_id)
 
     // Selection phase
     scsiLogInitiatorPhaseChange(SELECTION);
-    azdbg("------ SELECTING ", target_id);
+    dbgmsg("------ SELECTING ", target_id);
     SCSI_OUT(SEL, 1);
     delayMicroseconds(5);
     SCSI_OUT_DATA(1 << target_id);
@@ -179,7 +179,7 @@ static inline uint8_t scsiHostReadOneByte(int* parityError)
 
     if (parityError && r != (g_scsi_parity_lookup[r & 0xFF] ^ SCSI_IO_DATA_MASK))
     {
-        azlog("Parity error in scsiReadOneByte(): ", (uint32_t)r);
+        logmsg("Parity error in scsiReadOneByte(): ", (uint32_t)r);
         *parityError = 1;
     }
 
@@ -200,7 +200,7 @@ uint32_t scsiHostWrite(const uint8_t *data, uint32_t count)
             if (g_scsiHostPhyReset || SCSI_IN(IO) || SCSI_IN(CD) != cd_start || SCSI_IN(MSG) != msg_start)
             {
                 // Target switched out of DATA_OUT mode
-                azlog("scsiHostWrite: sent ", (int)i, " bytes, expected ", (int)count);
+                logmsg("scsiHostWrite: sent ", (int)i, " bytes, expected ", (int)count);
                 return i;
             }
         }
@@ -251,7 +251,7 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count)
     {
         if (count < fullcount)
         {
-            azlog("scsiHostRead: received ", (int)count, " bytes, expected ", (int)fullcount);
+            logmsg("scsiHostRead: received ", (int)count, " bytes, expected ", (int)fullcount);
         }
 
         return count;

--- a/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiPhy.cpp
@@ -107,7 +107,7 @@ static void scsi_rst_assert_interrupt()
 
     if (rst1 && rst2)
     {
-        azdbg("BUS RESET");
+        dbgmsg("BUS RESET");
         scsiDev.resetFlag = 1;
     }
 }
@@ -337,7 +337,7 @@ static inline uint8_t scsiReadOneByte(int* parityError)
 
     if (parityError && r != (g_scsi_parity_lookup[r & 0xFF] ^ SCSI_IO_DATA_MASK))
     {
-        azlog("Parity error in scsiReadOneByte(): ", (uint32_t)r);
+        logmsg("Parity error in scsiReadOneByte(): ", (uint32_t)r);
         *parityError = 1;
     }
 

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_host.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_host.cpp
@@ -110,7 +110,7 @@ uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, vo
     uint8_t byte1 = ~(paritycheck >> 16);
     if (paritycheck != ((g_scsi_parity_lookup[byte1] << 16) | g_scsi_parity_lookup[byte0]))
     {
-        azlog("Parity error in scsi_accel_host_read(): ", paritycheck);
+        logmsg("Parity error in scsi_accel_host_read(): ", paritycheck);
         *parityError = 1;
     }
 

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -345,7 +345,7 @@ static void scsi_accel_rp2040_stopWrite(volatile int *resetFlag)
     {
         if ((uint32_t)(millis() - start) > 5000)
         {
-            azlog("scsi_accel_rp2040_stopWrite() timeout, FIFO levels ",
+            logmsg("scsi_accel_rp2040_stopWrite() timeout, FIFO levels ",
                 (int)pio_sm_get_tx_fifo_level(SCSI_DMA_PIO, SCSI_DATA_SM), " ",
                 (int)pio_sm_get_rx_fifo_level(SCSI_DMA_PIO, SCSI_DATA_SM), " PC ",
                 (int)pio_sm_get_pc(SCSI_DMA_PIO, SCSI_DATA_SM));
@@ -374,7 +374,7 @@ void scsi_accel_rp2040_finishWrite(volatile int *resetFlag)
     {
         if ((uint32_t)(millis() - start) > 5000)
         {
-            azlog("scsi_accel_rp2040_finishWrite() timeout,"
+            logmsg("scsi_accel_rp2040_finishWrite() timeout,"
              " state: ", (int)g_scsi_dma_state, " ", (int)g_scsi_dma.dma_bytes, "/", (int)g_scsi_dma.app_bytes, ", ", (int)g_scsi_dma.next_app_bytes,
              " PIO PC: ", (int)pio_sm_get_pc(SCSI_DMA_PIO, SCSI_DATA_SM), " ", (int)pio_sm_get_pc(SCSI_DMA_PIO, SCSI_SYNC_SM),
              " PIO FIFO: ", (int)pio_sm_get_tx_fifo_level(SCSI_DMA_PIO, SCSI_DATA_SM), " ", (int)pio_sm_get_tx_fifo_level(SCSI_DMA_PIO, SCSI_SYNC_SM),
@@ -666,7 +666,7 @@ void scsi_accel_rp2040_finishRead(const uint8_t *data, uint32_t count, int *pari
     {
         if ((uint32_t)(millis() - start) > 5000)
         {
-            azlog("scsi_accel_rp2040_finishRead timeout,"
+            logmsg("scsi_accel_rp2040_finishRead timeout,"
              " state: ", (int)g_scsi_dma_state, " ", (int)g_scsi_dma.dma_bytes, "/", (int)g_scsi_dma.app_bytes, ", ", (int)g_scsi_dma.next_app_bytes,
              " PIO PC: ", (int)pio_sm_get_pc(SCSI_DMA_PIO, SCSI_DATA_SM), " ", (int)pio_sm_get_pc(SCSI_DMA_PIO, SCSI_SYNC_SM),
              " PIO FIFO: ", (int)pio_sm_get_rx_fifo_level(SCSI_DMA_PIO, SCSI_DATA_SM), " ", (int)pio_sm_get_tx_fifo_level(SCSI_DMA_PIO, SCSI_DATA_SM),
@@ -686,7 +686,7 @@ void scsi_accel_rp2040_finishRead(const uint8_t *data, uint32_t count, int *pari
     // Check if any parity errors have been detected during the transfer so far
     if (parityError != NULL && (SCSI_DMA_PIO->irq & 1))
     {
-        azdbg("scsi_accel_rp2040_finishRead(", bytearray(data, count), ") detected parity error");
+        dbgmsg("scsi_accel_rp2040_finishRead(", bytearray(data, count), ") detected parity error");
         *parityError = true;
     }
 }

--- a/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -23,7 +23,7 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    azlog("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
     return false;
 }
 
@@ -33,7 +33,7 @@ static const uint8_t *m_stream_buffer;
 static uint32_t m_stream_count;
 static uint32_t m_stream_count_start;
 
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
 {
     m_stream_callback = func;
     m_stream_buffer = buffer;
@@ -54,7 +54,7 @@ static sd_callback_t get_stream_callback(const uint8_t *buf, uint32_t count, con
         }
         else
         {
-            azdbg("SD card ", accesstype, "(", (int)sector,
+            dbgmsg("SD card ", accesstype, "(", (int)sector,
                   ") slow transfer, buffer", (uint32_t)buf, " vs. ", (uint32_t)(m_stream_buffer + m_stream_count));
             return NULL;
         }
@@ -87,7 +87,7 @@ bool SdioCard::begin(SdioConfig sdioConfig)
 
     if (reply != 0x1AA || status != SDIO_OK)
     {
-        // azdbg("SDIO not responding to CMD8 SEND_IF_COND, status ", (int)status, " reply ", reply);
+        // dbgmsg("SDIO not responding to CMD8 SEND_IF_COND, status ", (int)status, " reply ", reply);
         return false;
     }
 
@@ -103,7 +103,7 @@ bool SdioCard::begin(SdioConfig sdioConfig)
 
         if ((uint32_t)(millis() - start) > 1000)
         {
-            azlog("SDIO card initialization timeout");
+            logmsg("SDIO card initialization timeout");
             return false;
         }
     } while (!(g_sdio_ocr & (1 << 31)));
@@ -111,21 +111,21 @@ bool SdioCard::begin(SdioConfig sdioConfig)
     // Get CID
     if (!checkReturnOk(rp2040_sdio_command_R2(CMD2, 0, (uint8_t*)&g_sdio_cid)))
     {
-        azdbg("SDIO failed to read CID");
+        dbgmsg("SDIO failed to read CID");
         return false;
     }
 
     // Get relative card address
     if (!checkReturnOk(rp2040_sdio_command_R1(CMD3, 0, &g_sdio_rca)))
     {
-        azdbg("SDIO failed to get RCA");
+        dbgmsg("SDIO failed to get RCA");
         return false;
     }
 
     // Get CSD
     if (!checkReturnOk(rp2040_sdio_command_R2(CMD9, g_sdio_rca, (uint8_t*)&g_sdio_csd)))
     {
-        azdbg("SDIO failed to read CSD");
+        dbgmsg("SDIO failed to read CSD");
         return false;
     }
 
@@ -134,7 +134,7 @@ bool SdioCard::begin(SdioConfig sdioConfig)
     // Select card
     if (!checkReturnOk(rp2040_sdio_command_R1(CMD7, g_sdio_rca, &reply)))
     {
-        azdbg("SDIO failed to select card");
+        dbgmsg("SDIO failed to select card");
         return false;
     }
 
@@ -142,7 +142,7 @@ bool SdioCard::begin(SdioConfig sdioConfig)
     if (!checkReturnOk(rp2040_sdio_command_R1(CMD55, g_sdio_rca, &reply)) ||
         !checkReturnOk(rp2040_sdio_command_R1(ACMD6, 2, &reply)))
     {
-        azdbg("SDIO failed to set bus width");
+        dbgmsg("SDIO failed to set bus width");
         return false;
     }
 
@@ -198,19 +198,19 @@ bool SdioCard::readOCR(uint32_t* ocr)
 
 bool SdioCard::readData(uint8_t* dst)
 {
-    azlog("SdioCard::readData() called but not implemented!");
+    logmsg("SdioCard::readData() called but not implemented!");
     return false;
 }
 
 bool SdioCard::readStart(uint32_t sector)
 {
-    azlog("SdioCard::readStart() called but not implemented!");
+    logmsg("SdioCard::readStart() called but not implemented!");
     return false;
 }
 
 bool SdioCard::readStop()
 {
-    azlog("SdioCard::readStop() called but not implemented!");
+    logmsg("SdioCard::readStop() called but not implemented!");
     return false;
 }
 
@@ -252,7 +252,7 @@ bool SdioCard::stopTransmission(bool blocking)
         }
         if (isBusy())
         {
-            azlog("SdioCard::stopTransmission() timeout");
+            logmsg("SdioCard::stopTransmission() timeout");
             return false;
         }
         else
@@ -277,35 +277,35 @@ uint8_t SdioCard::type() const
 
 bool SdioCard::writeData(const uint8_t* src)
 {
-    azlog("SdioCard::writeData() called but not implemented!");
+    logmsg("SdioCard::writeData() called but not implemented!");
     return false;
 }
 
 bool SdioCard::writeStart(uint32_t sector)
 {
-    azlog("SdioCard::writeStart() called but not implemented!");
+    logmsg("SdioCard::writeStart() called but not implemented!");
     return false;
 }
 
 bool SdioCard::writeStop()
 {
-    azlog("SdioCard::writeStop() called but not implemented!");
+    logmsg("SdioCard::writeStop() called but not implemented!");
     return false;
 }
 
 bool SdioCard::erase(uint32_t firstSector, uint32_t lastSector)
 {
-    azlog("SdioCard::erase() not implemented");
+    logmsg("SdioCard::erase() not implemented");
     return false;
 }
 
 bool SdioCard::cardCMD6(uint32_t arg, uint8_t* status) {
-    azlog("SdioCard::cardCMD6() not implemented");
+    logmsg("SdioCard::cardCMD6() not implemented");
     return false;
 }
 
 bool SdioCard::readSCR(scr_t* scr) {
-    azlog("SdioCard::readSCR() not implemented");
+    logmsg("SdioCard::readSCR() not implemented");
     return false;
 }
 
@@ -343,7 +343,7 @@ bool SdioCard::writeSector(uint32_t sector, const uint8_t* src)
 
     if (g_sdio_error != SDIO_OK)
     {
-        azlog("SdioCard::writeSector(", sector, ") failed: ", (int)g_sdio_error);
+        logmsg("SdioCard::writeSector(", sector, ") failed: ", (int)g_sdio_error);
     }
 
     return g_sdio_error == SDIO_OK;
@@ -388,7 +388,7 @@ bool SdioCard::writeSectors(uint32_t sector, const uint8_t* src, size_t n)
 
     if (g_sdio_error != SDIO_OK)
     {
-        azlog("SdioCard::writeSectors(", sector, ",...,", (int)n, ") failed: ", (int)g_sdio_error);
+        logmsg("SdioCard::writeSectors(", sector, ",...,", (int)n, ") failed: ", (int)g_sdio_error);
         stopTransmission(true);
         return false;
     }
@@ -429,7 +429,7 @@ bool SdioCard::readSector(uint32_t sector, uint8_t* dst)
 
     if (g_sdio_error != SDIO_OK)
     {
-        azlog("SdioCard::readSector(", sector, ") failed: ", (int)g_sdio_error);
+        logmsg("SdioCard::readSector(", sector, ") failed: ", (int)g_sdio_error);
     }
 
     if (dst != real_dst)
@@ -477,7 +477,7 @@ bool SdioCard::readSectors(uint32_t sector, uint8_t* dst, size_t n)
 
     if (g_sdio_error != SDIO_OK)
     {
-        azlog("SdioCard::readSectors(", sector, ",...,", (int)n, ") failed: ", (int)g_sdio_error);
+        logmsg("SdioCard::readSectors(", sector, ",...,", (int)n, ") failed: ", (int)g_sdio_error);
         stopTransmission(true);
         return false;
     }

--- a/lib/ZuluSCSI_platform_RP2040/sd_card_spi.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/sd_card_spi.cpp
@@ -75,7 +75,7 @@ void sdCsWrite(SdCsPin_t pin, bool level)
 RP2040SPIDriver g_sd_spi_port;
 SdSpiConfig g_sd_spi_config(0, DEDICATED_SPI, SD_SCK_MHZ(25), &g_sd_spi_port);
 
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
 {
 }
 

--- a/lib/ZuluSCSI_platform_template/README.md
+++ b/lib/ZuluSCSI_platform_template/README.md
@@ -50,7 +50,7 @@ To implement this, one or both of them must be able to execute transfers in back
 On most platforms this is possible for SD card access.
 The SCSI handshake mechanism is harder to implement using DMA.
 
-To implement parallelism with SD card DMA, implement `azplatform_set_sd_callback(func, buffer)`.
+To implement parallelism with SD card DMA, implement `platform_set_sd_callback(func, buffer)`.
 It sets a callback function which should be called by the SD card driver to report how many bytes have
 been transferred to/from `buffer` so far. The SD card driver should call this function in a loop while
 it is waiting for SD card transfer to finish. The code in `ZuluSCSI_disk.cpp` will implement the callback

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
@@ -7,27 +7,27 @@
 
 extern "C" {
 
-const char *g_azplatform_name = PLATFORM_NAME;
+const char *g_platform_name = PLATFORM_NAME;
 
 /***************/
 /* GPIO init   */
 /***************/
 
-void azplatform_init()
+void platform_init()
 {
     /* Initialize SCSI and SD card pins to required modes.
      * SCSI pins should be inactive / input at this point.
      */
 }
 
-void azplatform_late_init()
+void platform_late_init()
 {
     /* This function can usually be left empty.
      * It can be used for initialization code that should not run in bootloader.
      */
 }
 
-void azplatform_disable_led(void)
+void platform_disable_led(void)
 {
     /* This function disables the LED on the ZuluSCSI board
     *  Generally by switching the pin from output to input.
@@ -42,13 +42,13 @@ void azplatform_disable_led(void)
 // This function is called for every log message.
 // It can e.g. write the log to serial port in real time.
 // It can also be left empty to use only the debug log file on SD card.
-void azplatform_log(const char *s)
+void platform_log(const char *s)
 {
 }
 
 // This function can be used to periodically reset watchdog timer for crash handling.
 // It can also be left empty if the platform does not use a watchdog timer.
-void azplatform_reset_watchdog()
+void platform_reset_watchdog()
 {
 }
 
@@ -105,7 +105,7 @@ const uint32_t g_scsi_out_byte_to_bop[256] =
  */
 SdSpiConfig g_sd_spi_config(0, DEDICATED_SPI, SD_SCK_MHZ(25));
 
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
 {
     /* This function can be left empty.
      * If the platform supports DMA for SD card transfers, this function

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
@@ -15,13 +15,13 @@ extern "C" {
 #endif
 
 /* These are used in debug output and default SCSI strings */
-extern const char *g_azplatform_name;
+extern const char *g_platform_name;
 #define PLATFORM_NAME "Example"
 #define PLATFORM_REVISION "1.0"
 
 // Debug logging function, can be used to print to e.g. serial port.
 // May get called from interrupt handlers.
-void azplatform_log(const char *s);
+void platform_log(const char *s);
 
 // Timing and delay functions.
 // Arduino platform already provides these
@@ -41,21 +41,21 @@ static inline void delay_100ns()
 }
 
 // Initialize SD card and GPIO configuration
-void azplatform_init();
+void platform_init();
 
 // Initialization for main application, not used for bootloader
-void azplatform_late_init();
+void platform_late_init();
 
 // Disable the status LED
-void azplatform_disable_led(void);
+void platform_disable_led(void);
 
 // Setup soft watchdog if supported
-void azplatform_reset_watchdog();
+void platform_reset_watchdog();
 
 // Set callback that will be called during data transfer to/from SD card.
 // This can be used to implement simultaneous transfer to SCSI bus.
 typedef void (*sd_callback_t)(uint32_t bytes_complete);
-void azplatform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
+void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 // Below are GPIO access definitions that are used from scsiPhy.cpp.
 // The definitions shown will work for STM32 style devices, other platforms

--- a/lib/ZuluSCSI_platform_template/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_template/scsiPhy.cpp
@@ -93,7 +93,7 @@ static void scsi_rst_assert_interrupt()
 
     if (rst1 && rst2)
     {
-        azdbg("BUS RESET");
+        dbgmsg("BUS RESET");
         scsiDev.resetFlag = 1;
     }
 }

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -317,9 +317,17 @@ bool findHDDImages()
         strcat(fullname, name);
 
         // Check whether this SCSI ID has been configured yet
-        if (s2s_getConfigById(id))
+        const S2S_TargetCfg* cfg = s2s_getConfigById(id);
+        if (cfg)
         {
           azlog("-- Ignoring ", fullname, ", SCSI ID ", id, " is already in use!");
+          continue;
+        }
+
+        // Apple computers reserve ID 7, so warn the user this configuration wont work
+        if(id == 7 && cfg->quirks == S2S_CFG_QUIRKS_APPLE )
+        {
+          azlog("-- Ignoring ", fullname, ", SCSI ID ", id, " Quirks set to Apple so can not use SCSI ID 7!");
           continue;
         }
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -214,6 +214,12 @@ bool findHDDImages()
       bool is_re = (tolower(name[0]) == 'r' && tolower(name[1]) == 'e');
       bool is_tp = (tolower(name[0]) == 't' && tolower(name[1]) == 'p');
 
+      if(strcasecmp(name, "CLEAR_ROM") == 0)
+      {
+        scsiDiskClearRomDrive();
+        continue;
+      }
+
       if (is_hd || is_cd || is_fd || is_mo || is_re || is_tp)
       {
         // Check file extension

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -493,8 +493,6 @@ extern "C" void zuluscsi_setup(void)
   {
     azlog("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
            " sdErrorData: ", (int)SD.sdErrorData());
-    
-    blinkStatus(BLINK_ERROR_NO_SD_CARD);
 
     if (scsiDiskCheckRomDrive())
     {

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -95,15 +95,15 @@ void save_logfile(bool always = false)
   static uint32_t prev_log_pos = 0;
   static uint32_t prev_log_len = 0;
   static uint32_t prev_log_save = 0;
-  uint32_t loglen = azlog_get_buffer_len();
+  uint32_t loglen = log_get_buffer_len();
 
   if (loglen != prev_log_len && g_sdcard_present)
   {
     // When debug is off, save log at most every LOG_SAVE_INTERVAL_MS
     // When debug is on, save after every SCSI command.
-    if (always || g_azlog_debug || (LOG_SAVE_INTERVAL_MS > 0 && (uint32_t)(millis() - prev_log_save) > LOG_SAVE_INTERVAL_MS))
+    if (always || g_log_debug || (LOG_SAVE_INTERVAL_MS > 0 && (uint32_t)(millis() - prev_log_save) > LOG_SAVE_INTERVAL_MS))
     {
-      g_logfile.write(azlog_get_buffer(&prev_log_pos));
+      g_logfile.write(log_get_buffer(&prev_log_pos));
       g_logfile.flush();
       
       prev_log_len = loglen;
@@ -121,7 +121,7 @@ void init_logfile()
   g_logfile = SD.open(LOGFILE, flags);
   if (!g_logfile.isOpen())
   {
-    azlog("Failed to open log file: ", SD.sdErrorCode());
+    logmsg("Failed to open log file: ", SD.sdErrorCode());
   }
   save_logfile(true);
 
@@ -131,19 +131,19 @@ void init_logfile()
 void print_sd_info()
 {
   uint64_t size = (uint64_t)SD.vol()->clusterCount() * SD.vol()->bytesPerCluster();
-  azlog("SD card detected, FAT", (int)SD.vol()->fatType(),
+  logmsg("SD card detected, FAT", (int)SD.vol()->fatType(),
           " volume size: ", (int)(size / 1024 / 1024), " MB");
   
   cid_t sd_cid;
 
   if(SD.card()->readCID(&sd_cid))
   {
-    azlog("SD MID: ", (uint8_t)sd_cid.mid, ", OID: ", (uint8_t)sd_cid.oid[0], " ", (uint8_t)sd_cid.oid[1]);
+    logmsg("SD MID: ", (uint8_t)sd_cid.mid, ", OID: ", (uint8_t)sd_cid.oid[0], " ", (uint8_t)sd_cid.oid[1]);
     
     char sdname[6] = {sd_cid.pnm[0], sd_cid.pnm[1], sd_cid.pnm[2], sd_cid.pnm[3], sd_cid.pnm[4], 0};
-    azlog("SD Name: ", sdname);
-    azlog("SD Date: ", (int)sd_cid.mdtMonth(), "/", sd_cid.mdtYear());
-    azlog("SD Serial: ", sd_cid.psn());
+    logmsg("SD Name: ", sdname);
+    logmsg("SD Date: ", (int)sd_cid.mdtMonth(), "/", sd_cid.mdtYear());
+    logmsg("SD Serial: ", sd_cid.psn());
   }
 }
 
@@ -158,13 +158,13 @@ bool findHDDImages()
   ini_gets("SCSI", "Dir", "/", imgdir, sizeof(imgdir), CONFIGFILE);
   int dirindex = 0;
 
-  azlog("Finding HDD images in directory ", imgdir, ":");
+  logmsg("Finding HDD images in directory ", imgdir, ":");
 
   SdFile root;
   root.open(imgdir);
   if (!root.isOpen())
   {
-    azlog("Could not open directory: ", imgdir);
+    logmsg("Could not open directory: ", imgdir);
   }
 
   SdFile file;
@@ -189,11 +189,11 @@ bool findHDDImages()
 
       if (imgdir[0] != '\0')
       {
-        azlog("Finding HDD images in additional directory Dir", (int)dirindex, " = \"", imgdir, "\":");
+        logmsg("Finding HDD images in additional directory Dir", (int)dirindex, " = \"", imgdir, "\":");
         root.open(imgdir);
         if (!root.isOpen())
         {
-          azlog("-- Could not open directory: ", imgdir);
+          logmsg("-- Could not open directory: ", imgdir);
         }
         continue;
       }
@@ -247,7 +247,7 @@ bool findHDDImages()
 
         if (is_compressed)
         {
-          azlog("-- Ignoring compressed file ", name);
+          logmsg("-- Ignoring compressed file ", name);
           continue;
         }
 
@@ -320,14 +320,14 @@ bool findHDDImages()
         const S2S_TargetCfg* cfg = s2s_getConfigById(id);
         if (cfg)
         {
-          azlog("-- Ignoring ", fullname, ", SCSI ID ", id, " is already in use!");
+          logmsg("-- Ignoring ", fullname, ", SCSI ID ", id, " is already in use!");
           continue;
         }
 
         // Apple computers reserve ID 7, so warn the user this configuration wont work
         if(id == 7 && cfg->quirks == S2S_CFG_QUIRKS_APPLE )
         {
-          azlog("-- Ignoring ", fullname, ", SCSI ID ", id, " Quirks set to Apple so can not use SCSI ID 7!");
+          logmsg("-- Ignoring ", fullname, ", SCSI ID ", id, " Quirks set to Apple so can not use SCSI ID 7!");
           continue;
         }
 
@@ -343,7 +343,7 @@ bool findHDDImages()
         // Open the image file
         if (id < NUM_SCSIID && is_romdrive)
         {
-          azlog("-- Loading ROM drive from ", fullname, " for id:", id);
+          logmsg("-- Loading ROM drive from ", fullname, " for id:", id);
           imageReady = scsiDiskProgramRomDrive(fullname, id, blk, type);
           
           if (imageReady)
@@ -352,7 +352,7 @@ bool findHDDImages()
           }
         }
         else if(id < NUM_SCSIID && lun < NUM_SCSILUN) {
-          azlog("-- Opening ", fullname, " for id:", id, " lun:", lun);
+          logmsg("-- Opening ", fullname, " for id:", id, " lun:", lun);
 
           imageReady = scsiDiskOpenHDDImage(id, fullname, id, lun, blk, type);
           if(imageReady)
@@ -361,17 +361,17 @@ bool findHDDImages()
           }
           else
           {
-            azlog("---- Failed to load image");
+            logmsg("---- Failed to load image");
           }
         } else {
-          azlog("-- Invalid lun or id for image ", fullname);
+          logmsg("-- Invalid lun or id for image ", fullname);
         }
       }
     }
   }
 
   if(usedDefaultId > 0) {
-    azlog("Some images did not specify a SCSI ID. Last file will be used at ID ", usedDefaultId);
+    logmsg("Some images did not specify a SCSI ID. Last file will be used at ID ", usedDefaultId);
   }
   root.close();
 
@@ -385,7 +385,7 @@ bool findHDDImages()
     if (cfg && (cfg->scsiId & S2S_CFG_TARGET_ENABLED))
     {
       int capacity_kB = ((uint64_t)cfg->scsiSectors * cfg->bytesPerSector) / 1024;
-      azlog("SCSI ID:", (int)(cfg->scsiId & 7),
+      logmsg("SCSI ID:", (int)(cfg->scsiId & 7),
             " BlockSize:", (int)cfg->bytesPerSector,
             " Type:", (int)cfg->deviceType,
             " Quirks:", (int)cfg->quirks,
@@ -436,11 +436,11 @@ static void reinitSCSI()
 {
   if (ini_getbool("SCSI", "Debug", 0, CONFIGFILE))
   {
-    g_azlog_debug = true;
+    g_log_debug = true;
   }
 
 #ifdef PLATFORM_HAS_INITIATOR_MODE
-  if (azplatform_is_initiator_mode_enabled())
+  if (platform_is_initiator_mode_enabled())
   {
     // Initialize scsiDev to zero values even though it is not used
     scsiInit();
@@ -467,11 +467,11 @@ static void reinitSCSI()
   else
   {
 #if RAW_FALLBACK_ENABLE
-    azlog("No images found, enabling RAW fallback partition");
+    logmsg("No images found, enabling RAW fallback partition");
     scsiDiskOpenHDDImage(RAW_FALLBACK_SCSI_ID, "RAW:0:0xFFFFFFFF", RAW_FALLBACK_SCSI_ID, 0,
                          RAW_FALLBACK_BLOCKSIZE);
 #else
-    azlog("No valid image files found!");
+    logmsg("No valid image files found!");
 #endif
     blinkStatus(BLINK_ERROR_NO_IMAGES);
   }
@@ -484,14 +484,14 @@ static void reinitSCSI()
 
 extern "C" void zuluscsi_setup(void)
 {
-  azplatform_init();
-  azplatform_late_init();
+  platform_init();
+  platform_late_init();
 
   g_sdcard_present = mountSDCard();
 
   if(!g_sdcard_present)
   {
-    azlog("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
+    logmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
            " sdErrorData: ", (int)SD.sdErrorData());
 
     if (scsiDiskCheckRomDrive())
@@ -499,7 +499,7 @@ extern "C" void zuluscsi_setup(void)
       reinitSCSI();
       if (g_romdrive_active)
       {
-        azlog("Enabled ROM drive without SD card");
+        logmsg("Enabled ROM drive without SD card");
         return;
       }
     }
@@ -508,17 +508,17 @@ extern "C" void zuluscsi_setup(void)
     {
       blinkStatus(BLINK_ERROR_NO_SD_CARD);
       delay(1000);
-      azplatform_reset_watchdog();
+      platform_reset_watchdog();
       g_sdcard_present = mountSDCard();
     } while (!g_sdcard_present);
-    azlog("SD card init succeeded after retry");
+    logmsg("SD card init succeeded after retry");
   }
 
   if (g_sdcard_present)
   {
     if (SD.clusterCount() == 0)
     {
-      azlog("SD card without filesystem!");
+      logmsg("SD card without filesystem!");
     }
 
     print_sd_info();
@@ -526,14 +526,14 @@ extern "C" void zuluscsi_setup(void)
     reinitSCSI();
   }
 
-  azlog("Initialization complete!");
+  logmsg("Initialization complete!");
 
   if (g_sdcard_present)
   {
     init_logfile();
     if (ini_getbool("SCSI", "DisableStatusLED", false, CONFIGFILE))
     {
-      azplatform_disable_led();
+      platform_disable_led();
     }
   }
 }
@@ -542,10 +542,10 @@ extern "C" void zuluscsi_main_loop(void)
 {
   static uint32_t sd_card_check_time = 0;
 
-  azplatform_reset_watchdog();
+  platform_reset_watchdog();
   
 #ifdef PLATFORM_HAS_INITIATOR_MODE
-  if (azplatform_is_initiator_mode_enabled())
+  if (platform_is_initiator_mode_enabled())
   {
     scsiInitiatorMainLoop();
     save_logfile();
@@ -577,7 +577,7 @@ extern "C" void zuluscsi_main_loop(void)
         if (!SD.card()->readOCR(&ocr))
         {
           g_sdcard_present = false;
-          azlog("SD card removed, trying to reinit");
+          logmsg("SD card removed, trying to reinit");
         }
       }
     }
@@ -592,7 +592,7 @@ extern "C" void zuluscsi_main_loop(void)
 
       if (g_sdcard_present)
       {
-        azlog("SD card reinit succeeded");
+        logmsg("SD card reinit succeeded");
         print_sd_info();
 
         reinitSCSI();
@@ -602,7 +602,7 @@ extern "C" void zuluscsi_main_loop(void)
       {
         blinkStatus(BLINK_ERROR_NO_SD_CARD);
         delay(1000);
-        azplatform_reset_watchdog();
+        platform_reset_watchdog();
       }
     } while (!g_sdcard_present && !g_romdrive_active);
   }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -365,10 +365,9 @@ public:
                 if (end != begin + sectorcount)
                 {
                     uint32_t allocsize = end - begin + 1;
-                    azlog("---- NOTE: File ", filename, " has FAT allocated size of ", (int)allocsize, " sectors and file size of ", (int)sectorcount, " sectors");
-                    azlog("---- Due to issue #80 in ZuluSCSI version 1.0.8 and 1.0.9 the allocated size was mistakenly reported to SCSI controller.");
-                    azlog("---- If the drive was formatted using those versions, you may have problems accessing it with newer firmware.");
-                    azlog("---- The old behavior can be restored with setting  [SCSI] UseFATAllocSize = 1 in " CONFIGFILE);
+                    // Due to issue #80 in ZuluSCSI version 1.0.8 and 1.0.9 the allocated size was mistakenly reported to SCSI controller.
+                    // If the drive was formatted using those versions, you may have problems accessing it with newer firmware.
+                    // The old behavior can be restored with setting  [SCSI] UseFATAllocSize = 1 in config file.
 
                     if (ini_getbool("SCSI", "UseFATAllocSize", 0, CONFIGFILE))
                     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -769,7 +769,7 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int
         }
         else if (img.file.contiguousRange(&sector_begin, &sector_end))
         {
-            azlog("---- Image file is contiguous, SD card sectors ", (int)sector_begin, " to ", (int)sector_end);
+            azdbg("---- Image file is contiguous, SD card sectors ", (int)sector_begin, " to ", (int)sector_end);
         }
         else
         {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -116,6 +116,26 @@ static bool check_romdrive(romdrive_hdr_t *hdr)
     return true;
 }
 
+// Clear the drive metadata header
+bool scsiDiskClearRomDrive()
+{
+#ifndef PLATFORM_HAS_ROM_DRIVE
+    azlog("---- Platform does not support ROM drive");
+    return false;
+#else
+    romdrive_hdr_t hdr = {0x0};
+
+    if (!azplatform_write_romdrive((const uint8_t*)&hdr, 0, AZPLATFORM_ROMDRIVE_PAGE_SIZE))
+    {
+        azlog("-- Failed to clear ROM drive");
+        return false;
+    }
+    azlog("-- Cleared ROM drive");
+    SD.remove("CLEAR_ROM");
+    return true;
+#endif
+}
+
 // Load an image file to romdrive
 bool scsiDiskProgramRomDrive(const char *filename, int scsi_id, int blocksize, S2S_CFG_TYPE type)
 {

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -17,6 +17,8 @@ void scsiDiskResetImages();
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED);
 void scsiDiskLoadConfig(int target_idx);
 
+// Clear the ROM drive header from flash
+bool scsiDiskClearRomDrive();
 // Program ROM drive and rename image file
 bool scsiDiskProgramRomDrive(const char *filename, int scsi_id, int blocksize, S2S_CFG_TYPE type);
 

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -2,8 +2,8 @@
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform.h"
 
-const char *g_azlog_firmwareversion = ZULU_FW_VERSION " " __DATE__ " " __TIME__;
-bool g_azlog_debug = true;
+const char *g_log_firmwareversion = ZULU_FW_VERSION " " __DATE__ " " __TIME__;
+bool g_log_debug = true;
 
 // This memory buffer can be read by debugger and is also saved to zululog.txt
 #define LOGBUFMASK (LOGBUFSIZE - 1)
@@ -14,7 +14,7 @@ uint32_t g_log_magic;
 char g_logbuffer[LOGBUFSIZE + 1];
 uint32_t g_logpos;
 
-void azlog_raw(const char *str)
+void log_raw(const char *str)
 {
     // Keep log from reboot / bootloader if magic matches expected value
     if (g_log_magic != 0xAA55AA55)
@@ -33,11 +33,11 @@ void azlog_raw(const char *str)
     // Keep buffer null-terminated
     g_logbuffer[g_logpos & LOGBUFMASK] = '\0';
 
-    azplatform_log(str);
+    platform_log(str);
 }
 
 // Log byte as hex
-void azlog_raw(uint8_t value)
+void log_raw(uint8_t value)
 {
     const char *nibble = "0123456789ABCDEF";
     char hexbuf[5] = {
@@ -45,11 +45,11 @@ void azlog_raw(uint8_t value)
         nibble[(value >>  4) & 0xF], nibble[(value >>  0) & 0xF],
         0
     };
-    azlog_raw(hexbuf);
+    log_raw(hexbuf);
 }
 
 // Log integer as hex
-void azlog_raw(uint32_t value)
+void log_raw(uint32_t value)
 {
     const char *nibble = "0123456789ABCDEF";
     char hexbuf[11] = {
@@ -60,11 +60,11 @@ void azlog_raw(uint32_t value)
         nibble[(value >>  4) & 0xF], nibble[(value >>  0) & 0xF],
         0
     };
-    azlog_raw(hexbuf);
+    log_raw(hexbuf);
 }
 
 // Log integer as hex
-void azlog_raw(uint64_t value)
+void log_raw(uint64_t value)
 {
     const char *nibble = "0123456789ABCDEF";
     char hexbuf[19] = {
@@ -79,11 +79,11 @@ void azlog_raw(uint64_t value)
         nibble[(value >>  4) & 0xF], nibble[(value >>  0) & 0xF],
         0
     };
-    azlog_raw(hexbuf);
+    log_raw(hexbuf);
 }
 
 // Log integer as decimal
-void azlog_raw(int value)
+void log_raw(int value)
 {
     char decbuf[16] = {0};
     char *p = &decbuf[14];
@@ -99,29 +99,29 @@ void azlog_raw(int value)
         *--p = '-';
     }
 
-    azlog_raw(p);
+    log_raw(p);
 }
 
-void azlog_raw(bytearray array)
+void log_raw(bytearray array)
 {
     for (size_t i = 0; i < array.len; i++)
     {
-        azlog_raw(array.data[i]);
-        azlog_raw(" ");
+        log_raw(array.data[i]);
+        log_raw(" ");
         if (i > 32)
         {
-            azlog_raw("... (total ", (int)array.len, ")");
+            log_raw("... (total ", (int)array.len, ")");
             break;
         }
     }
 }
 
-uint32_t azlog_get_buffer_len()
+uint32_t log_get_buffer_len()
 {
     return g_logpos;
 }
 
-const char *azlog_get_buffer(uint32_t *startpos)
+const char *log_get_buffer(uint32_t *startpos)
 {
     uint32_t default_pos = 0;
     if (startpos == NULL)

--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -6,32 +6,32 @@
 #include <stddef.h>
 
 // Get total number of bytes that have been written to log
-uint32_t azlog_get_buffer_len();
+uint32_t log_get_buffer_len();
 
 // Get log as a string.
 // If startpos is given, continues log reading from previous position and updates the position.
-const char *azlog_get_buffer(uint32_t *startpos);
+const char *log_get_buffer(uint32_t *startpos);
 
 // Whether to enable debug messages
-extern bool g_azlog_debug;
+extern bool g_log_debug;
 
 // Firmware version string
-extern const char *g_azlog_firmwareversion;
+extern const char *g_log_firmwareversion;
 
 // Log string
-void azlog_raw(const char *str);
+void log_raw(const char *str);
 
 // Log byte as hex
-void azlog_raw(uint8_t value);
+void log_raw(uint8_t value);
 
 // Log integer as hex
-void azlog_raw(uint32_t value);
+void log_raw(uint32_t value);
 
 // Log integer as hex
-void azlog_raw(uint64_t value);
+void log_raw(uint64_t value);
 
 // Log integer as decimal
-void azlog_raw(int value);
+void log_raw(int value);
 
 // Log array of bytes
 struct bytearray {
@@ -39,9 +39,9 @@ struct bytearray {
     const uint8_t *data;
     size_t len;
 };
-void azlog_raw(bytearray array);
+void log_raw(bytearray array);
 
-inline void azlog_raw()
+inline void log_raw()
 {
     // End of template recursion
 }
@@ -50,30 +50,30 @@ extern "C" unsigned long millis();
 
 // Variadic template for printing multiple items
 template<typename T, typename T2, typename... Rest>
-inline void azlog_raw(T first, T2 second, Rest... rest)
+inline void log_raw(T first, T2 second, Rest... rest)
 {
-    azlog_raw(first);
-    azlog_raw(second);
-    azlog_raw(rest...);
+    log_raw(first);
+    log_raw(second);
+    log_raw(rest...);
 }
 
 // Format a complete log message
 template<typename... Params>
-inline void azlog(Params... params)
+inline void logmsg(Params... params)
 {
-    azlog_raw("[", (int)millis(), "ms] ");
-    azlog_raw(params...);
-    azlog_raw("\n");
+    log_raw("[", (int)millis(), "ms] ");
+    log_raw(params...);
+    log_raw("\n");
 }
 
 // Format a complete debug message
 template<typename... Params>
-inline void azdbg(Params... params)
+inline void dbgmsg(Params... params)
 {
-    if (g_azlog_debug)
+    if (g_log_debug)
     {
-        azlog_raw("[", (int)millis(), "ms] DBG ");
-        azlog_raw(params...);
-        azlog_raw("\n");
+        log_raw("[", (int)millis(), "ms] DBG ");
+        log_raw(params...);
+        log_raw("\n");
     }
 }

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -65,7 +65,7 @@ static void printNewPhase(int phase, bool initiator = false)
 {
     g_LogData = false;
     g_LogInitiatorCommand = false;
-    if (!g_azlog_debug)
+    if (!g_log_debug)
     {
         return;
     }
@@ -73,45 +73,45 @@ static void printNewPhase(int phase, bool initiator = false)
     switch(phase)
     {
         case BUS_FREE:
-            azdbg("-- BUS_FREE");
+            dbgmsg("-- BUS_FREE");
             break;
         
         case BUS_BUSY:
-            azdbg("-- BUS_BUSY");
+            dbgmsg("-- BUS_BUSY");
             break;
         
         case ARBITRATION:
-            azdbg("---- ARBITRATION");
+            dbgmsg("---- ARBITRATION");
             break;
         
         case SELECTION:
             if (initiator)
-                azdbg("---- SELECTION");
+                dbgmsg("---- SELECTION");
             else
-                azdbg("---- SELECTION: ", (int)(*SCSI_STS_SELECTED & 7));
+                dbgmsg("---- SELECTION: ", (int)(*SCSI_STS_SELECTED & 7));
             break;
         
         case RESELECTION:
-            azdbg("---- RESELECTION");
+            dbgmsg("---- RESELECTION");
             break;
         
         case STATUS:
             if (initiator)
             {
-                azdbg("---- STATUS");
+                dbgmsg("---- STATUS");
                 g_LogData = true;
             }
             else if (scsiDev.status == GOOD)
             {
-                azdbg("---- STATUS: 0 GOOD");
+                dbgmsg("---- STATUS: 0 GOOD");
             }
             else if (scsiDev.status == CHECK_CONDITION && scsiDev.target)
             {
-                azdbg("---- STATUS: 2 CHECK_CONDITION, sense ", (uint32_t)scsiDev.target->sense.asc);
+                dbgmsg("---- STATUS: 2 CHECK_CONDITION, sense ", (uint32_t)scsiDev.target->sense.asc);
             }
             else
             {
-                azdbg("---- STATUS: ", (int)scsiDev.status);
+                dbgmsg("---- STATUS: ", (int)scsiDev.status);
             }
             break;
         
@@ -122,32 +122,32 @@ static void printNewPhase(int phase, bool initiator = false)
         
         case DATA_IN:
             if (!initiator && scsiDev.target->syncOffset > 0)
-                azdbg("---- DATA_IN, syncOffset ", (int)scsiDev.target->syncOffset,
+                dbgmsg("---- DATA_IN, syncOffset ", (int)scsiDev.target->syncOffset,
                                    " syncPeriod ", (int)scsiDev.target->syncPeriod);
             else
-                azdbg("---- DATA_IN");
+                dbgmsg("---- DATA_IN");
             break;
         
         case DATA_OUT:
             if (!initiator && scsiDev.target->syncOffset > 0)
-                azdbg("---- DATA_OUT, syncOffset ", (int)scsiDev.target->syncOffset,
+                dbgmsg("---- DATA_OUT, syncOffset ", (int)scsiDev.target->syncOffset,
                                     " syncPeriod ", (int)scsiDev.target->syncPeriod);
             else
-                azdbg("---- DATA_OUT");
+                dbgmsg("---- DATA_OUT");
             break;
         
         case MESSAGE_IN:
-            azdbg("---- MESSAGE_IN");
+            dbgmsg("---- MESSAGE_IN");
             g_LogData = true;
             break;
         
         case MESSAGE_OUT:
-            azdbg("---- MESSAGE_OUT");
+            dbgmsg("---- MESSAGE_OUT");
             g_LogData = true;
             break;
         
         default:
-            azdbg("---- PHASE: ", phase);
+            dbgmsg("---- PHASE: ", phase);
             break;
     }
 }
@@ -162,7 +162,7 @@ void scsiLogPhaseChange(int new_phase)
     {
         if (old_phase == DATA_IN || old_phase == DATA_OUT)
         {
-            azdbg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
+            dbgmsg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
         }
         g_InByteCount = g_OutByteCount = 0;
         g_DataChecksum = 0;
@@ -176,7 +176,7 @@ void scsiLogPhaseChange(int new_phase)
             int syncper = scsiDev.target->syncPeriod;
             int syncoff = scsiDev.target->syncOffset;
             int mbyte_per_s = (1000 + syncper * 2) / (syncper * 4);
-            azlog("SCSI ID ", (int)scsiDev.target->targetId,
+            logmsg("SCSI ID ", (int)scsiDev.target->targetId,
                   " negotiated synchronous mode ", mbyte_per_s, " MB/s ",
                   "(period 4x", syncper, " ns, offset ", syncoff, " bytes)");
         }
@@ -196,7 +196,7 @@ void scsiLogInitiatorPhaseChange(int new_phase)
     {
         if (old_phase == DATA_IN || old_phase == DATA_OUT)
         {
-            azdbg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
+            dbgmsg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
         }
         g_InByteCount = g_OutByteCount = 0;
         g_DataChecksum = 0;
@@ -210,10 +210,10 @@ void scsiLogDataIn(const uint8_t *buf, uint32_t length)
 {
     if (g_LogData)
     {
-        azdbg("------ IN: ", bytearray(buf, length));
+        dbgmsg("------ IN: ", bytearray(buf, length));
     }
 
-    if (g_azlog_debug)
+    if (g_log_debug)
     {
         // BSD checksum algorithm
         for (uint32_t i = 0; i < length; i++)
@@ -230,15 +230,15 @@ void scsiLogDataOut(const uint8_t *buf, uint32_t length)
 {
     if (buf == scsiDev.cdb || g_LogInitiatorCommand)
     {
-        azdbg("---- COMMAND: ", getCommandName(buf[0]));
+        dbgmsg("---- COMMAND: ", getCommandName(buf[0]));
     }
     
     if (g_LogData)
     {
-        azdbg("------ OUT: ", bytearray(buf, length));
+        dbgmsg("------ OUT: ", bytearray(buf, length));
     }
 
-    if (g_azlog_debug)
+    if (g_log_debug)
     {
         // BSD checksum algorithm
         for (uint32_t i = 0; i < length; i++)


### PR DESCRIPTION
To reduce functional and code differences with the BlueSCSI fork of the project, some changes were merged back.

Changes considered:

* BlueSCSI/BlueSCSI-v2@07eacef98933b197b927b73ebd635106e5f4855c:  This is an independent fix for the CDROM read-only image issue. I think Morio's fix in #144 is better than this, because it works for read-only harddrives also.

* BlueSCSI/BlueSCSI-v2@ce81e51882bf4b4c50aa0533c90b5794e9262a6e: Merged

* BlueSCSI/BlueSCSI-v2@8207709c7519144c0a4d145400521b04312b26df: Merged

* BlueSCSI/BlueSCSI-v2@dc75772d8804f1b9f397a59e62197b6e6d6bac80: Merged

* BlueSCSI/BlueSCSI-v2@209d60167775571b2b755a024437be632465225d: Implemented by Morio in 144.

* BlueSCSI/BlueSCSI-v2@833cc8f7802ac9d1f6acc4aaba384d6199acee7d: Implemented by Morio in 144.

---

* BlueSCSI/BlueSCSI-v2@807175a6ae94ed4496e7ffdc1741f08b2764ecad: Removed warning, kept config option

* BlueSCSI/BlueSCSI-v2@8b5dccf516ec73665ad8e1eb2300ab738a067569: I think it is better to do USB logging in separate thread, will address in separate pull request

* BlueSCSI/BlueSCSI-v2@03cbd7461e93a727727129227b2cc295e4916443: The sector numbers printed are needed for debugging SD card issues. Changed the message to debug level.

* BlueSCSI/BlueSCSI-v2@405c61c1d5bca6cb2358a0af69ad862a70975cb4: Doesn't seem very useful log message.

* BlueSCSI/BlueSCSI-v2@7b6b821bdd96077f7acfcdcc3a0ac78975e01b12: Doesn't affect ZuluSCSI, only related to BlueSCSI local changes

---

* BlueSCSI/BlueSCSI-v2@61aa6567ba9f6cf987fd711438d23e2d68c7430c: Did equivalent changes from azplatform -> platform
* BlueSCSI/BlueSCSI-v2@306fb0e1f0ff6796f3e5da84f879f2767cb4fbcc: Renamed azlog -> logmsg, the `log()` used by BlueSCSI conflicts with standard logarithm math function.
