### PR TITLE
Boot delay improvement

### DIFF
--- a/lib/minIni/minGlue.h
+++ b/lib/minIni/minGlue.h
@@ -1,15 +1,13 @@
-/*  Glue functions for the minIni library to SdFat library */
+/*  Glue functions for the minIni library to the cache functions in minIni_cache.cpp */
 
 #include <SdFat.h>
 
-extern SdFs SD;
-
 #define INI_READONLY 1
 #define INI_FILETYPE                    FsFile
-#define ini_openread(filename,file)     ((file)->open(SD.vol(), filename, O_RDONLY))
-#define ini_close(file)                 ((file)->close())
-#define ini_read(buffer,size,file)      ((file)->fgets((buffer),(size)) > 0)
-
 #define INI_FILEPOS                     fspos_t
-#define ini_tell(file,pos)              ((file)->fgetpos(pos))
-#define ini_seek(file,pos)              ((file)->fsetpos(pos))
+
+bool ini_openread(const char *filename, INI_FILETYPE *fp);
+bool ini_close(INI_FILETYPE *fp);
+bool ini_read(char *buffer, int size, INI_FILETYPE *fp);
+void ini_tell(INI_FILETYPE *fp, INI_FILEPOS *pos);
+void ini_seek(INI_FILETYPE *fp, INI_FILEPOS *pos);

--- a/lib/minIni/minIni_cache.cpp
+++ b/lib/minIni/minIni_cache.cpp
@@ -1,0 +1,147 @@
+// Custom .ini file access caching layer for minIni.
+// This reduces boot delay by only reading the ini file once
+// after boot or SD-card removal.
+
+#include <minGlue.h>
+#include <SdFat.h>
+
+// This can be overridden in platformio.ini
+// Set to 0 to disable the cache.
+#ifndef INI_CACHE_SIZE
+#define INI_CACHE_SIZE 4096
+#endif
+
+// Use the SdFs instance from main program
+extern SdFs SD;
+
+static struct {
+    bool valid;
+    INI_FILETYPE *fp;
+
+#if INI_CACHE_SIZE > 0
+    const char *filename;
+    uint32_t filelen;
+    INI_FILEPOS current_pos;
+    char cachedata[INI_CACHE_SIZE];
+#endif
+} g_ini_cache;
+
+// Invalidate any cached file contents
+void invalidate_ini_cache()
+{
+    g_ini_cache.valid = false;
+    g_ini_cache.fp = NULL;
+}
+
+// Read the config file into RAM
+void reload_ini_cache(const char *filename)
+{
+    g_ini_cache.valid = false;
+    g_ini_cache.fp = NULL;
+
+#if INI_CACHE_SIZE > 0
+    g_ini_cache.filename = filename;
+    FsFile config = SD.open(filename, O_RDONLY);
+    g_ini_cache.filelen = config.fileSize();
+    if (config.isOpen() && g_ini_cache.filelen <= INI_CACHE_SIZE)
+    {
+        if (config.read(g_ini_cache.cachedata, g_ini_cache.filelen) == g_ini_cache.filelen)
+        {
+            g_ini_cache.valid = true;
+        }
+    }
+    config.close();
+#endif
+}
+
+// Open .ini file either from cache or from SD card
+bool ini_openread(const char *filename, INI_FILETYPE *fp)
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.valid &&
+        (filename == g_ini_cache.filename || strcmp(filename, g_ini_cache.filename) == 0))
+    {
+        fp->close();
+        g_ini_cache.fp = fp;
+        g_ini_cache.current_pos.position = 0;
+        return true;
+    }
+#endif
+
+    return fp->open(SD.vol(), filename, O_RDONLY);
+}
+
+// Close previously opened file
+bool ini_close(INI_FILETYPE *fp)
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.fp == fp)
+    {
+        g_ini_cache.fp = NULL;
+        return true;
+    }
+    else
+#endif
+    {
+        return fp->close();
+    }
+}
+
+// Read a single line from cache or from SD card
+bool ini_read(char *buffer, int size, INI_FILETYPE *fp)
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.fp == fp)
+    {
+        // Read one line from cache
+        uint32_t srcpos = g_ini_cache.current_pos.position;
+        int dstpos = 0;
+        while (srcpos < g_ini_cache.filelen &&
+               dstpos < size - 1)
+        {
+            char b = g_ini_cache.cachedata[srcpos++];
+            buffer[dstpos++] = b;
+
+            if (b == '\n') break;
+        }
+        buffer[dstpos] = 0;
+        g_ini_cache.current_pos.position = srcpos;
+        return dstpos > 0;
+    }
+    else
+#endif
+    {
+        // Read from SD card
+        return fp->fgets(buffer, size) > 0;
+    }
+}
+
+// Get the position inside the file
+void ini_tell(INI_FILETYPE *fp, INI_FILEPOS *pos)
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.fp == fp)
+    {
+        *pos = g_ini_cache.current_pos;
+    }
+    else
+#endif
+    {
+        fp->fgetpos(pos);
+    }
+}
+
+// Go back to previously saved position
+void ini_seek(INI_FILETYPE *fp, INI_FILEPOS *pos)
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.fp == fp)
+    {
+        g_ini_cache.current_pos = *pos;
+    }
+    else
+#endif
+    {
+        fp->fsetpos(pos);
+    }
+}

--- a/lib/minIni/minIni_cache.h
+++ b/lib/minIni/minIni_cache.h
@@ -1,0 +1,10 @@
+// Custom .ini file access caching layer for minIni.
+// This reduces boot delay by only reading the ini file once
+// after boot or SD-card removal.
+
+#pragma once
+
+void invalidate_ini_cache();
+
+// Note: filename must be statically allocated, pointer is stored.
+void reload_ini_cache(const char *filename);

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ build_flags =
     -DPREFETCH_BUFFER_SIZE=0
     -DMAX_SECTOR_SIZE=2048
     -DSCSI2SD_BUFFER_SIZE=4096
+    -DINI_CACHE_SIZE=0
     -DUSE_ARDUINO=1
 lib_deps =
     SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.0-gpt

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -447,8 +447,9 @@ static void reinitSCSI()
   // Error if there are 0 image files
   if (scsiDiskCheckAnyImagesConfigured())
   {
-    // Ok, there is an image
-    blinkStatus(BLINK_STATUS_OK);
+    // Ok, there is an image, turn LED on for the time it takes to perform init
+    LED_ON();
+    delay(100);
   }
   else
   {
@@ -524,6 +525,9 @@ extern "C" void zuluscsi_setup(void)
       azplatform_disable_led();
     }
   }
+
+  // Counterpart for the LED_ON in reinitSCSI().
+  LED_OFF();
 }
 
 extern "C" void zuluscsi_main_loop(void)

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -42,6 +42,7 @@
 
 #include <SdFat.h>
 #include <minIni.h>
+#include <minIni_cache.h>
 #include <string.h>
 #include <strings.h>
 #include <ctype.h>
@@ -402,9 +403,14 @@ void readSCSIDeviceConfig()
 
 static bool mountSDCard()
 {
+  invalidate_ini_cache();
+
   // Check for the common case, FAT filesystem as first partition
   if (SD.begin(SD_CONFIG))
+  {
+    reload_ini_cache(CONFIGFILE);
     return true;
+  }
 
   // Do we have any kind of card?
   if (!SD.card() || SD.sdErrorCode() != 0)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -80,6 +80,7 @@ bool scsiIsReadFinished(const uint8_t *data)
 #endif
 
 // SD card sector size is always 512 bytes
+extern SdFs SD;
 #define SD_SECTOR_SIZE 512
 
 /************************************************/


### PR DESCRIPTION
Related to #138, reduce the boot delay from about 1 second to less than 0.3 seconds.
This allows using "SCSI Timeout: short" setting on Amiga.