### PR TITLE
RP2040: Bootloader fixes

### DIFF
--- a/lib/ZuluSCSI_platform_BS2/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_BS2/ZuluSCSI_platform.cpp
@@ -30,6 +30,7 @@
 #include <hardware/spi.h>
 #include <hardware/flash.h>
 #include <hardware/structs/xip_ctrl.h>
+#include <hardware/structs/usb.h>
 #include <platform/mbed_error.h>
 #include <multicore.h>
 #include <USB/PluggableUSBSerial.h>
@@ -383,6 +384,7 @@ extern uint32_t __real_vectors_start;
 extern uint32_t __StackTop;
 static volatile void *g_bootloader_exit_req;
 
+__attribute__((section(".time_critical.platform_rewrite_flash_page")))
 bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE])
 {
     if (offset == PLATFORM_BOOTLOADER_SIZE)
@@ -392,6 +394,13 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
             logmsg("Invalid firmware file, starts with: ", bytearray(buffer, 16));
             return false;
         }
+    }
+
+    if (NVIC_GetEnableIRQ(USBCTRL_IRQn))
+    {
+        logmsg("Disabling USB during firmware flashing");
+        NVIC_DisableIRQ(USBCTRL_IRQn);
+        usb_hw->main_ctrl = 0;
     }
 
     dbgmsg("Writing flash at offset ", offset, " data ", bytearray(buffer, 4));
@@ -422,6 +431,7 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
         if (actual != expected)
         {
             logmsg("Flash verify failed at offset ", offset + i * 4, " got ", actual, " expected ", expected);
+            __enable_irq();
             return false;
         }
     }

--- a/lib/ZuluSCSI_platform_BS2/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_BS2/ZuluSCSI_platform.cpp
@@ -95,7 +95,9 @@ void platform_init()
     // Get flash chip size
     uint8_t cmd_read_jedec_id[4] = {0x9f, 0, 0, 0};
     uint8_t response_jedec[4] = {0};
+    __disable_irq();
     flash_do_cmd(cmd_read_jedec_id, response_jedec, 4);
+    __enable_irq();
     g_flash_chip_size = (1 << response_jedec[3]);
     logmsg("Flash chip size: ", (int)(g_flash_chip_size / 1024), " kB");
 

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -111,7 +111,9 @@ void platform_init()
     // Get flash chip size
     uint8_t cmd_read_jedec_id[4] = {0x9f, 0, 0, 0};
     uint8_t response_jedec[4] = {0};
+    __disable_irq();
     flash_do_cmd(cmd_read_jedec_id, response_jedec, 4);
+    __enable_irq();
     g_flash_chip_size = (1 << response_jedec[3]);
     logmsg("Flash chip size: ", (int)(g_flash_chip_size / 1024), " kB");
 

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -30,6 +30,7 @@
 #include <hardware/spi.h>
 #include <hardware/flash.h>
 #include <hardware/structs/xip_ctrl.h>
+#include <hardware/structs/usb.h>
 #include <platform/mbed_error.h>
 #include <multicore.h>
 #include <USB/PluggableUSBSerial.h>
@@ -464,6 +465,7 @@ extern uint32_t __real_vectors_start;
 extern uint32_t __StackTop;
 static volatile void *g_bootloader_exit_req;
 
+__attribute__((section(".time_critical.platform_rewrite_flash_page")))
 bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE])
 {
     if (offset == PLATFORM_BOOTLOADER_SIZE)
@@ -473,6 +475,13 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
             logmsg("Invalid firmware file, starts with: ", bytearray(buffer, 16));
             return false;
         }
+    }
+
+    if (NVIC_GetEnableIRQ(USBCTRL_IRQn))
+    {
+        logmsg("Disabling USB during firmware flashing");
+        NVIC_DisableIRQ(USBCTRL_IRQn);
+        usb_hw->main_ctrl = 0;
     }
 
     dbgmsg("Writing flash at offset ", offset, " data ", bytearray(buffer, 4));
@@ -503,6 +512,7 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
         if (actual != expected)
         {
             logmsg("Flash verify failed at offset ", offset + i * 4, " got ", actual, " expected ", expected);
+            __enable_irq();
             return false;
         }
     }


### PR DESCRIPTION
Fixes three causes for random hangs at boot time on RP2040:

* When USB cable was connected while using SD card bootloader, sometimes the USB packet would arrive during flash writing and trigger [bug in mbed-os RP2040 USB driver](https://github.com/arduino/ArduinoCore-mbed/issues/409)
* It seems that `platform_rewrite_flash_page()` crashes randomly if it is not in RAM. Not sure of the root cause.
* During boot flash chip size check hangs if the system tick interrupt happens to occur at the same time. Fixed by disabling interrupts during the size check.