### PR TITLE
Implement supply voltage monitoring

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -54,6 +54,10 @@ extern const char *g_platform_name;
 #   include "ZuluSCSI_v1_1_gpio.h"
 #endif
 
+#ifndef PLATFORM_VDD_WARNING_LIMIT_mV
+#define PLATFORM_VDD_WARNING_LIMIT_mV 2800
+#endif
+
 // Debug logging functions
 void platform_log(const char *s);
 

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
@@ -60,6 +60,10 @@ extern const char *g_platform_name;
 #define SD_USE_SDIO 1
 #define PLATFORM_HAS_PARITY_CHECK 1
 
+#ifndef PLATFORM_VDD_WARNING_LIMIT_mV
+#define PLATFORM_VDD_WARNING_LIMIT_mV 2800
+#endif
+
 // NOTE: The driver supports synchronous speeds higher than 10MB/s, but this
 // has not been tested due to lack of fast enough SCSI adapter.
 // #define PLATFORM_MAX_SCSI_SPEED S2S_CFG_SPEED_TURBO


### PR DESCRIPTION
Implemented for RP2040 and GD32 platforms.

When the microcontroller supply voltage falls below 2.8 V (which is 0.2V lower than the nominal 3.0V from regulator), logs a warning message:

    [6254ms] WARNING: Detected supply voltage drop to 2797mV. Verify power supply is adequate.

This happens if the +5V supply drops below about 3.5V.

Normal logging delays apply, so if the power supply falls to zero such as on shutdown, the message doesn't get saved to SD card.

Fixes #174.