### PR TITLE
Add windows line ending to log output

### DIFF
--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -84,7 +84,7 @@ inline void logmsg(Params... params)
 {
     log_raw("[", (int)millis(), "ms] ");
     log_raw(params...);
-    log_raw("\n");
+    log_raw("\r\n");
 }
 
 // Format a complete debug message
@@ -95,6 +95,6 @@ inline void dbgmsg(Params... params)
     {
         log_raw("[", (int)millis(), "ms] DBG ");
         log_raw(params...);
-        log_raw("\n");
+        log_raw("\r\n");
     }
 }


### PR DESCRIPTION
This is done so the default PuTTY settings line break correctly.