### PR TITLE
SCSI2SD: Set Inquiry standard version based on EnableSCSI2 setting

### DIFF
--- a/lib/SCSI2SD/src/firmware/inquiry.c
+++ b/lib/SCSI2SD/src/firmware/inquiry.c
@@ -224,6 +224,11 @@ uint32_t s2s_getStandardInquiry(
 	memcpy(out, StandardResponse, buflen);
 	out[1] = cfg->deviceTypeModifier;
 
+	if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_SCSI2))
+	{
+		out[2] = 1; // Report only SCSI 1 compliance version
+	}
+
 	if (scsiDev.compatMode >= COMPAT_SCSI2)
 	{
 		out[3] = 2; // SCSI 2 response format.


### PR DESCRIPTION
Related issue #123.

Previously Inquiry command always reported SCSI-2 compliance.

This changes behavior only when `EnableSCSI2 = 0` is set.
Would be good to test this change with some platform that is known to need that setting, e.g. MacPlus.

