### PR TITLE
RP2040 Initiator mode: Fix error recovery after watchdog aborts command.

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -130,6 +130,12 @@ static void scsiInitiatorUpdateLed()
 // High level logic of the initiator mode
 void scsiInitiatorMainLoop()
 {
+    if (g_scsiHostPhyReset)
+    {
+        logmsg("Executing BUS RESET after aborted command");
+        scsiHostPhyReset();
+    }
+
     if (!g_initiator_state.imaging)
     {
         // Scan for SCSI drives one at a time


### PR DESCRIPTION
Previously initiator mode would get stuck if drive didn't respond to a command. Now it will be correctly aborted after 15 seconds and retried.