### PR TITLE
Experimental audio playback support from BIN/CUE files.

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -220,6 +220,23 @@ static const uint8_t ControlModePage[] =
 0x00, 0x00 // AEN holdoff period.
 };
 
+#ifdef ENABLE_AUDIO_OUTPUT
+static const uint8_t CDROMAudioControlParametersPage[] =
+{
+0x0E, // page code
+0x0E, // page length
+0x04, // 'Immed' bit set, 'SOTC' bit not set
+0x00, // reserved
+0x00, // reserved
+0x80, // 1 LBAs/sec multip
+0x00, 0x4B, // 75 LBAs/sec
+0x03, 0xFF, // output port 0 active, max volume
+0x03, 0xFF, // output port 1 active, max volume
+0x00, 0x00, // output port 2 inactive
+0x00, 0x00 // output port 3 inactive
+};
+#endif
+
 static const uint8_t SequentialDeviceConfigPage[] =
 {
 0x10, // page code
@@ -495,6 +512,21 @@ static void doModeSense(
 		pageIn(pc, idx, ControlModePage, sizeof(ControlModePage));
 		idx += sizeof(ControlModePage);
 	}
+
+#ifdef ENABLE_AUDIO_OUTPUT
+	if ((scsiDev.compatMode >= COMPAT_SCSI2)
+		&& (scsiDev.target->cfg->deviceType == S2S_CFG_OPTICAL)
+		&& (pageCode == 0x0E || pageCode == 0x3F))
+	{
+		pageFound = 1;
+		pageIn(
+			pc,
+			idx,
+			CDROMAudioControlParametersPage,
+			sizeof(CDROMAudioControlParametersPage));
+		idx += sizeof(CDROMAudioControlParametersPage);
+	}
+#endif
 
 	if ((scsiDev.target->cfg->deviceType == S2S_CFG_SEQUENTIAL) &&
 		(pageCode == 0x10 || pageCode == 0x3F))

--- a/lib/ZuluSCSI_platform_RP2040/audio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/audio.cpp
@@ -134,10 +134,17 @@ static uint16_t wire_buf_a[WIRE_BUFFER_SIZE];
 static uint16_t wire_buf_b[WIRE_BUFFER_SIZE];
 
 // tracking for audio playback
-static bool audio_active = false;
-static volatile bool audio_stopping = false;
+static uint8_t audio_owner; // SCSI ID or 0xFF when idle
+static volatile bool audio_paused = false;
 static FsFile audio_file;
 static uint32_t fleft;
+
+// historical playback status information
+static audio_status_code audio_last_status[8] = {ASC_NO_STATUS};
+static uint32_t audio_bytes_read[8] = {0};
+
+// mechanism for cleanly stopping DMA units
+static volatile bool audio_stopping = false;
 
 // trackers for the below function call
 static uint16_t sfcnt = 0; // sub-frame count; 2 per frame, 192 frames/block
@@ -318,7 +325,15 @@ void audio_dma_irq() {
 }
 
 bool audio_is_active() {
-    return audio_active;
+    return audio_owner != 0xFF;
+}
+
+bool audio_is_paused() {
+    return audio_paused;
+}
+
+uint8_t audio_get_owner() {
+    return audio_owner;
 }
 
 void audio_setup() {
@@ -338,7 +353,8 @@ void audio_setup() {
 }
 
 void audio_poll() {
-    if (!audio_active) return;
+    if (!audio_is_active()) return;
+    if (audio_paused) return;
     if (fleft == 0 && sbufst_a == STALE && sbufst_b == STALE) {
         // out of data and ready to stop
         audio_stop();
@@ -368,6 +384,7 @@ void audio_poll() {
         logmsg("Audio sample data underrun");
     }
     fleft -= toRead;
+    audio_bytes_read[audio_owner] += toRead;
 
     if (sbufst_a == FILLING) {
         sbufst_a = READY;
@@ -376,13 +393,17 @@ void audio_poll() {
     }
 }
 
-bool audio_play(const char* file, uint64_t start, uint64_t end, bool swap) {
+bool audio_play(uint8_t owner, const char* file, uint64_t start, uint64_t end, bool swap) {
     // stop any existing playback first
-    if (audio_active) audio_stop();
+    if (audio_is_active()) audio_stop();
 
     // dbgmsg("Request to play ('", file, "':", start, ":", end, ")");
 
     // verify audio file is present and inputs are (somewhat) sane
+    if (owner == 0xFF) {
+        logmsg("Illegal audio owner");
+        return false;
+    }
     if (start >= end) {
         logmsg("Invalid range for audio (", start, ":", end, ")");
         return false;
@@ -394,11 +415,17 @@ bool audio_play(const char* file, uint64_t start, uint64_t end, bool swap) {
         return false;
     }
     uint64_t len = audio_file.size();
-    if (start > len || end > len) {
-        logmsg("File '", file, "' playback request (",
-                start, ":", end, ":", len, ") outside bounds");
+    if (start > len) {
+        logmsg("File '", file, "' playback request start (",
+                start, ":", len, ") outside file bounds");
         audio_file.close();
         return false;
+    }
+    // truncate playback end to end of file
+    // we will not consider this to be an error at the moment
+    if (end > len) {
+        dbgmsg("------ Truncate audio play request end ", end, " to file size ", len);
+        end = len;
     }
     fleft = end - start;
     if (fleft <= 2 * AUDIO_BUFFER_SIZE) {
@@ -432,6 +459,9 @@ bool audio_play(const char* file, uint64_t start, uint64_t end, bool swap) {
     sbufswap = swap;
     sbufst_a = READY;
     sbufst_b = READY;
+    audio_owner = owner & 7;
+    audio_bytes_read[audio_owner] = AUDIO_BUFFER_SIZE * 2;
+    audio_last_status[audio_owner] = ASC_PLAYING;
 
     // prepare the wire buffers
     for (uint16_t i = 0; i < WIRE_BUFFER_SIZE; i++) {
@@ -465,12 +495,25 @@ bool audio_play(const char* file, uint64_t start, uint64_t end, bool swap) {
 
     // ready to go
     dma_channel_start(SOUND_DMA_CHA);
-    audio_active = true;
+    return true;
+}
+
+bool audio_set_paused(bool paused) {
+    if (!audio_is_active()) return false;
+    else if (audio_paused && paused) return false;
+    else if (!audio_paused && !paused) return false;
+
+    audio_paused = paused;
+    if (paused) {
+        audio_last_status[audio_owner] = ASC_PAUSED;
+    } else {
+        audio_last_status[audio_owner] = ASC_PLAYING;
+    }
     return true;
 }
 
 void audio_stop() {
-    if (!audio_active) return;
+    if (!audio_is_active()) return;
 
     // to help mute external hardware, send a bunch of '0' samples prior to
     // halting the datastream; easiest way to do this is invalidating the
@@ -490,7 +533,24 @@ void audio_stop() {
     if (audio_file.isOpen()) {
         audio_file.close();
     }
-    audio_active = false;
+    audio_last_status[audio_owner] = ASC_COMPLETED;
+    audio_owner = 0xFF;
+}
+
+audio_status_code audio_get_status_code(uint8_t id) {
+    audio_status_code tmp = audio_last_status[id & 7];
+    if (tmp == ASC_COMPLETED || tmp == ASC_ERRORED) {
+        audio_last_status[id & 7] = ASC_NO_STATUS;
+    }
+    return tmp;
+}
+
+uint32_t audio_get_bytes_read(uint8_t id) {
+    return audio_bytes_read[id & 7];
+}
+
+void audio_clear_bytes_read(uint8_t id) {
+    audio_bytes_read[id & 7] = 0;
 }
 
 #ifdef __cplusplus

--- a/lib/ZuluSCSI_platform_RP2040/audio.h
+++ b/lib/ZuluSCSI_platform_RP2040/audio.h
@@ -32,6 +32,20 @@ extern "C" {
 // these must be divisible by 1024
 #define AUDIO_BUFFER_SIZE 8192 // ~46.44ms
 
+/*
+ * Status codes for audio playback, matching the SCSI 'audio status codes'.
+ *
+ * The first two are for a live condition and will be returned repeatedly. The
+ * following two reflect a historical condition and are only returned once.
+ */
+enum audio_status_code {
+    ASC_PLAYING = 0x11,
+    ASC_PAUSED = 0x12,
+    ASC_COMPLETED = 0x13,
+    ASC_ERRORED = 0x14,
+    ASC_NO_STATUS = 0x15
+};
+
 /**
  * Handler for DMA interrupts
  *
@@ -53,6 +67,16 @@ void audio_dma_irq();
 bool audio_is_active();
 
 /**
+ * \return true if audio streaming is paused, false otherwise.
+ */
+bool audio_is_paused();
+
+/**
+ * \return the owner value passed to the _play() call, or 0xFF if no owner.
+ */
+uint8_t audio_get_owner();
+
+/**
  * Initializes the audio subsystem. Should be called only once, toward the end
  * of platform_late_init().
  */
@@ -66,18 +90,59 @@ void audio_poll();
 /**
  * Begins audio playback for a file.
  *
+ * \param owner  The SCSI ID that initiated this playback operation.
  * \param file   Path of a file containing PCM samples to play.
  * \param start  Byte offset within file where playback will begin, inclusive.
  * \param end    Byte offset within file where playback will end, exclusive.
  * \param swap   If false, little-endian sample order, otherwise big-endian.
  * \return       True if successful, false otherwise.
  */
-bool audio_play(const char* file, uint64_t start, uint64_t end, bool swap);
+bool audio_play(uint8_t owner, const char* file, uint64_t start, uint64_t end, bool swap);
+
+/**
+ * Pauses audio playback. This may be delayed slightly to allow sample buffers
+ * to purge.
+ *
+ * \param pause  If true, pause, otherwise resume.
+ * \return       True if operation changed audio output, false if no change.
+ */
+bool audio_set_paused(bool pause);
 
 /**
  * Stops audio playback.
  */
 void audio_stop();
+
+/**
+ * Provides SCSI 'audio status code' for the given target. Depending on the
+ * code this operation may produce side-effects, see the enum for details.
+ *
+ * \param id    The SCSI ID to provide status codes for.
+ * \return      The matching audio status code.
+ */
+audio_status_code audio_get_status_code(uint8_t id);
+
+/**
+ * Provides the number of sample bytes read in during an audio_play() call.
+ * This can be combined with an (external) starting offset to determine
+ * virtual CD positioning information. This is only an approximation since
+ * this tracker is always at the end of the most recently read sample data.
+ *
+ * This is intentionally not cleared by audio_stop(): audio_play() events will
+ * reset this information.
+ *
+ * \param id    The SCSI ID target to return data for.
+ * \return      The number of bytes read in during a playback.
+ */
+uint32_t audio_get_bytes_read(uint8_t id);
+
+/**
+ * Clears the byte counter in the above call. This is insensitive to whether
+ * audio playback is occurring but is safe to call in any event.
+ *
+ * \param id    The SCSI ID target to return data for.
+ */
+void audio_clear_bytes_read(uint8_t id);
 
 #ifdef __cplusplus
 }

--- a/src/ImageBackingStore.cpp
+++ b/src/ImageBackingStore.cpp
@@ -313,3 +313,15 @@ void ImageBackingStore::flush()
         m_fsfile.flush();
     }
 }
+
+size_t ImageBackingStore::name(char* filename, size_t len)
+{
+    if (!m_israw && !m_isrom)
+    {
+        return m_fsfile.getName(filename, len);
+    }
+    else
+    {
+        return 0;
+    }
+}

--- a/src/ImageBackingStore.h
+++ b/src/ImageBackingStore.h
@@ -71,6 +71,9 @@ public:
     // Flush any pending changes to filesystem
     void flush();
 
+    // If available, read filename and return actual length.
+    size_t name(char* filename, size_t len);
+
 protected:
     bool m_israw;
     bool m_isrom;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -929,7 +929,7 @@ void cdromGetAudioPlaybackStatus(uint8_t *status, uint32_t *current_lba, bool cu
     }
     if (current_lba) *current_lba = mechanism_status[target].last_lba
             + audio_get_bytes_read(target) / 2352;
-#elif
+#else
     if (status) *status = 0; // audio status code for 'unsupported/invalid' and not-playing indicator
     if (current_lba) *current_lba = mechanism_status[target].last_lba;
 #endif
@@ -1023,7 +1023,7 @@ static void doPlayAudio(uint32_t lba, uint32_t length)
         scsiDev.target->sense.asc = 0x6400; // ILLEGAL MODE FOR THIS TRACK
         scsiDev.phase = STATUS;
     }
-#elif
+#else
     dbgmsg("---- Target does not support audio playback");
     // per SCSI-2, targets not supporting audio respond to zero-length
     // PLAY AUDIO commands with ILLEGAL REQUEST; this seems to be a check
@@ -1055,7 +1055,7 @@ static void doPauseResumeAudio(bool resume)
         scsiDev.target->sense.asc = 0x2C00; // COMMAND SEQUENCE ERROR
         scsiDev.phase = STATUS;
     }
-#elif
+#else
     dbgmsg("---- Target does not support audio pausing");
     scsiDev.status = CHECK_CONDITION;
     scsiDev.target->sense.code = ILLEGAL_REQUEST; // assumed from PLAY AUDIO(10)

--- a/src/ZuluSCSI_cdrom.h
+++ b/src/ZuluSCSI_cdrom.h
@@ -22,9 +22,6 @@ bool cdromSwitchNextImage(image_config_t &img);
 bool cdromValidateCueSheet(image_config_t &img);
 
 // Audio playback status
-enum CDROMAudioPlaybackStatus {
-    CDROMAudio_Stopped = 0,
-    CDROMAudio_Playing = 1,
-    CDROMAudio_Paused = 2
-};
-void cdromGetAudioPlaybackStatus(CDROMAudioPlaybackStatus *status, uint32_t *current_lba);
+// boolean flag is true if just basic mechanism status (playback true/false)
+// is desired, or false if historical audio status codes should be returned
+void cdromGetAudioPlaybackStatus(uint8_t *status, uint32_t *current_lba, bool current_only);

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -75,6 +75,7 @@ static const char *getCommandName(uint8_t cmd)
         case 0x37: return "ReadDefectData";
         case 0x3B: return "WriteBuffer";
         case 0x3C: return "ReadBuffer";
+        case 0x42: return "CDROM Read SubChannel";
         case 0x43: return "CDROM Read TOC";
         case 0x44: return "CDROM Read Header";
         case 0x4A: return "GetEventStatusNotification";


### PR DESCRIPTION
First attempt at getting audio playback working with the new BIN/CUE support. This has been tested to play audio successfully using 'cdplay' on a modern Linux host. There are bugs and this is not ready for merging, but hopefully the PR can give an idea of potential changes for CD-DA. I'll keep developing this toward something more polished. Known issues:

- Annex C rules for commands to halt audio playback are not supported yet. This prevents playback from being stopped until the initial play command naturally terminates (pausing does work).
- Position tracking is limited to just audio playback, probably needs READ integration.
- Additional mode page support may be needed, I only added a boilerplate 0Eh. Volume control in particular might be pretty useful, but AFAIK there isn't much MODE SELECT support in the firmware?
- Testing has been pretty basic and needs to be expanded, particularly on period-correct systems.
- Testing of non-audio firmware behavior with audio commands needs to be done.