### PR TITLE
CD-ROM: code consolidation and bugfixes

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -492,7 +492,7 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
         if (firsttrack < 0) firsttrack = trackinfo->track_number;
         lasttrack = trackinfo->track_number;
 
-        if (track == 0 || track == trackinfo->track_number)
+        if (track <= trackinfo->track_number)
         {
             formatTrackInfo(trackinfo, &trackdata[8 * trackcount], MSF);
             trackcount += 1;
@@ -500,15 +500,12 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     }
 
     // Format lead-out track info
-    if (track == 0 || track == 0xAA)
-    {
-        CUETrackInfo leadout = {};
-        leadout.track_number = 0xAA;
-        leadout.track_mode = CUETrack_MODE1_2048;
-        leadout.data_start = img.scsiSectors;
-        formatTrackInfo(&leadout, &trackdata[8 * trackcount], MSF);
-        trackcount += 1;
-    }
+    CUETrackInfo leadout = {};
+    leadout.track_number = 0xAA;
+    leadout.track_mode = CUETrack_MODE1_2048;
+    leadout.data_start = img.scsiSectors;
+    formatTrackInfo(&leadout, &trackdata[8 * trackcount], MSF);
+    trackcount += 1;
 
     // Format response header
     uint16_t toc_length = 2 + trackcount * 8;
@@ -517,7 +514,7 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     scsiDev.data[2] = firsttrack;
     scsiDev.data[3] = lasttrack;
 
-    if (trackcount == 0)
+    if (track != 0xAA && trackcount < 2)
     {
         // Unknown track requested
         scsiDev.status = CHECK_CONDITION;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -602,16 +602,13 @@ static void formatRawTrackInfo(const CUETrackInfo *track, uint8_t *dest)
     dest[1] = control_adr;
     dest[2] = 0x00; // "TNO", always 0?
     dest[3] = track->track_number; // "POINT", contains track number
-
-    if (track->pregap_start > 0)
-    {
-        LBA2MSF(track->pregap_start, &dest[4]);
-    }
-    else
-    {
-        LBA2MSF(track->data_start, &dest[4]);
-    }
-
+    // Next three are ATIME. The spec doesn't directly address how these
+    // should be reported in the TOC, just giving a description of Q-channel
+    // data from Red Book/ECMA-130. On all disks tested so far these are
+    // given as 00/00/00.
+    dest[4] = 0x00;
+    dest[5] = 0x00;
+    dest[6] = 0x00;
     dest[7] = 0; // HOUR
 
     LBA2MSFBCD(track->data_start, &dest[8]);

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1347,7 +1347,7 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
             {
                 LBA2MSF(lba, buf);
                 dbgmsg("------ ABS M ", *(buf+1), " S ", *(buf+2), " F ", *(buf+3));
-                *buf += 4;
+                buf += 4;
             }
             else
             {
@@ -1362,7 +1362,7 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
             {
                 LBA2MSF(relpos, buf);
                 dbgmsg("------ REL M ", *(buf+1), " S ", *(buf+2), " F ", *(buf+3));
-                *buf += 4;
+                buf += 4;
             }
             else
             {


### PR DESCRIPTION
This has several proposed tweaks to CD-ROM code, including a fix for a significant bug with sub-channel MSF address reporting I introduced in my last PR.

In addition, this also consolidates the LBA/MSF conversion code to prepare for a possible adjustment to how MSF addresses are handled. I'll open an issue to document that one since it will likely involve more work.