### PR TITLE
CDROM: Table of contents and addressing improvements

### DIFF
--- a/lib/CUEParser/src/CUEParser.cpp
+++ b/lib/CUEParser/src/CUEParser.cpp
@@ -62,7 +62,7 @@ const CUETrackInfo *CUEParser::next_track()
 
     bool got_track = false;
     bool got_data = false;
-    bool got_paused = false;
+    bool got_pause = false; // true if a period of silence (INDEX 00) was encountered for a track
     while(!(got_track && got_data) && start_line())
     {
         if (strncasecmp(m_parse_pos, "FILE ", 5) == 0)
@@ -86,7 +86,7 @@ const CUETrackInfo *CUEParser::next_track()
             m_track_info.track_start = 0;
             got_track = true;
             got_data = false;
-            got_paused = false;
+            got_pause = false;
         }
         else if (strncasecmp(m_parse_pos, "PREGAP ", 7) == 0)
         {
@@ -105,7 +105,7 @@ const CUETrackInfo *CUEParser::next_track()
             if (index == 0)
             {
                 m_track_info.track_start = time;
-                got_paused = true;
+                got_pause = true;
             }
             else if (index == 1)
             {
@@ -117,7 +117,7 @@ const CUETrackInfo *CUEParser::next_track()
         next_line();
     }
 
-    if (got_data && !got_paused)
+    if (got_data && !got_pause)
     {
         m_track_info.track_start = m_track_info.data_start;
     }

--- a/lib/CUEParser/src/CUEParser.cpp
+++ b/lib/CUEParser/src/CUEParser.cpp
@@ -57,7 +57,7 @@ void CUEParser::restart()
 const CUETrackInfo *CUEParser::next_track()
 {
     // Previous track info is needed to track file offset
-    uint32_t prev_data_start = m_track_info.data_start;
+    uint32_t prev_track_start = m_track_info.track_start;
     uint32_t prev_sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode); // Defaults to 2352 before first track
 
     bool got_track = false;
@@ -71,7 +71,7 @@ const CUETrackInfo *CUEParser::next_track()
             m_track_info.file_mode = parse_file_mode(skip_space(p));
             m_track_info.file_offset = 0;
             m_track_info.track_mode = CUETrack_AUDIO;
-            prev_data_start = 0;
+            prev_track_start = 0;
             prev_sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);
         }
         else if (strncasecmp(m_parse_pos, "TRACK ", 6) == 0)
@@ -109,7 +109,6 @@ const CUETrackInfo *CUEParser::next_track()
             }
             else if (index == 1)
             {
-                m_track_info.file_offset += (uint64_t)(time - prev_data_start) * prev_sector_length;
                 m_track_info.data_start = time;
                 got_data = true;
             }
@@ -124,9 +123,14 @@ const CUETrackInfo *CUEParser::next_track()
     }
 
     if (got_track && got_data)
+    {
+        m_track_info.file_offset += (uint64_t)(m_track_info.track_start - prev_track_start) * prev_sector_length;
         return &m_track_info;
+    }
     else
+    {
         return nullptr;
+    }
 }
 
 bool CUEParser::start_line()

--- a/lib/CUEParser/src/CUEParser.cpp
+++ b/lib/CUEParser/src/CUEParser.cpp
@@ -80,7 +80,6 @@ const CUETrackInfo *CUEParser::next_track()
             m_track_info.track_number = strtoul(track_num, &endptr, 10);
             m_track_info.track_mode = parse_track_mode(skip_space(endptr));
             m_track_info.sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);
-            m_track_info.pregap_start = 0;
             m_track_info.unstored_pregap_length = 0;
             m_track_info.data_start = 0;
             m_track_info.track_start = 0;
@@ -91,7 +90,6 @@ const CUETrackInfo *CUEParser::next_track()
         {
             const char *time_str = skip_space(m_parse_pos + 7);
             m_track_info.unstored_pregap_length = parse_time(time_str);
-            m_track_info.pregap_start = 0;
         }
         else if (strncasecmp(m_parse_pos, "INDEX ", 6) == 0)
         {
@@ -104,7 +102,6 @@ const CUETrackInfo *CUEParser::next_track()
 
             if (index == 0)
             {
-                m_track_info.pregap_start = time;
                 m_track_info.track_start = time;
             }
             else if (index == 1)

--- a/lib/CUEParser/src/CUEParser.cpp
+++ b/lib/CUEParser/src/CUEParser.cpp
@@ -62,6 +62,7 @@ const CUETrackInfo *CUEParser::next_track()
 
     bool got_track = false;
     bool got_data = false;
+    bool got_paused = false;
     while(!(got_track && got_data) && start_line())
     {
         if (strncasecmp(m_parse_pos, "FILE ", 5) == 0)
@@ -85,6 +86,7 @@ const CUETrackInfo *CUEParser::next_track()
             m_track_info.track_start = 0;
             got_track = true;
             got_data = false;
+            got_paused = false;
         }
         else if (strncasecmp(m_parse_pos, "PREGAP ", 7) == 0)
         {
@@ -103,6 +105,7 @@ const CUETrackInfo *CUEParser::next_track()
             if (index == 0)
             {
                 m_track_info.track_start = time;
+                got_paused = true;
             }
             else if (index == 1)
             {
@@ -115,7 +118,7 @@ const CUETrackInfo *CUEParser::next_track()
         next_line();
     }
 
-    if (got_data && m_track_info.track_start == 0)
+    if (got_data && !got_paused)
     {
         m_track_info.track_start = m_track_info.data_start;
     }

--- a/lib/CUEParser/src/CUEParser.h
+++ b/lib/CUEParser/src/CUEParser.h
@@ -65,9 +65,6 @@ struct CUETrackInfo
     // Unstored pregap length, in CD frames, or 0
     uint32_t unstored_pregap_length;
 
-    // LBA start position of the pregap of this track (in CD frames)
-    uint32_t pregap_start;
-
     // LBA start position of the data area of this track (in CD frames)
     uint32_t data_start;
 

--- a/lib/CUEParser/src/CUEParser.h
+++ b/lib/CUEParser/src/CUEParser.h
@@ -53,22 +53,24 @@ struct CUETrackInfo
     // Source file name and file type, and offset to start of track data in bytes.
     char filename[CUE_MAX_FILENAME+1];
     CUEFileMode file_mode;
-    uint64_t file_offset;
+    uint64_t file_offset; // corresponds to track_start below
 
     // Track number and mode in CD format
     int track_number;
     CUETrackMode track_mode;
 
-    // Sector length for this track in bytes in the file, or 0 for audio files
+    // Sector length for this track in bytes, assuming BINARY or MOTOROLA file modes.
     uint32_t sector_length;
 
-    // Unstored pregap length, in CD frames, or 0
+    // The CD frames of PREGAP time at the start of this track, or 0 if none are present.
+    // These frames of silence are not stored in the underlying data file.
     uint32_t unstored_pregap_length;
 
-    // LBA start position of the data area of this track (in CD frames)
+    // LBA start position of the data area (INDEX 01) of this track (in CD frames)
     uint32_t data_start;
 
-    // Track start, either pregap_start or if no pregap, data_start.
+    // LBA for the beginning of the track, which will be INDEX 00 if that is present.
+    // Otherwise this will be INDEX 01 matching data_start above.
     uint32_t track_start;
 };
 

--- a/lib/CUEParser/test/CUEParser_test.cpp
+++ b/lib/CUEParser/test/CUEParser_test.cpp
@@ -67,17 +67,18 @@ FILE "Sound.wav" WAVE
     COMMENT("Test TRACK 03 (audio with index 0)");
     track = parser.next_track();
     TEST(track != NULL);
-    uint32_t start3 = ((7 * 60) + 55) * 75 + 65;
+    uint32_t start3_i0 = ((7 * 60) + 55) * 75 + 58;
+    uint32_t start3_i1 = ((7 * 60) + 55) * 75 + 65;
     if (track)
     {
         TEST(strcmp(track->filename, "Image Name.bin") == 0);
         TEST(track->file_mode == CUEFile_BINARY);
-        TEST(track->file_offset == 2048 * start2 + 2352 * (start3 - start2));
+        TEST(track->file_offset == 2048 * start2 + 2352 * (start3_i0 - start2));
         TEST(track->track_number == 3);
         TEST(track->track_mode == CUETrack_AUDIO);
         TEST(track->sector_length == 2352);
-        TEST(track->pregap_start == ((7 * 60) + 55) * 75 + 58);
-        TEST(track->data_start == start3);
+        TEST(track->track_start == start3_i0);
+        TEST(track->data_start == start3_i1);
     }
 
     COMMENT("Test TRACK 11 (audio from wav)");
@@ -91,7 +92,7 @@ FILE "Sound.wav" WAVE
         TEST(track->track_number == 11);
         TEST(track->track_mode == CUETrack_AUDIO);
         TEST(track->sector_length == 0);
-        TEST(track->pregap_start == 0);
+        TEST(track->track_start == 0);
         TEST(track->data_start == 2 * 75);
     }
 

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -146,30 +146,6 @@ static const uint8_t FullTOC[] =
     0x00, // 45: PMIN
     0x00, // 46: PSEC
     0x00, // 47: PFRAME
-    // b0
-    0x01, // 48: session number
-    0x54, // 49: ADR/Control
-    0x00, // 50: TNO
-    0xB1, // 51: POINT
-    0x79, // 52: Min BCD
-    0x59, // 53: Sec BCD
-    0x74, // 54: Frame BCD
-    0x00, // 55: Zero
-    0x79, // 56: PMIN BCD
-    0x59, // 57: PSEC BCD
-    0x74, // 58: PFRAME BCD
-    // c0
-    0x01, // 59: session number
-    0x54, // 60: ADR/Control
-    0x00, // 61: TNO
-    0xC0, // 62: POINT
-    0x00, // 63: Min
-    0x00, // 64: Sec
-    0x00, // 65: Frame
-    0x00, // 66: Zero
-    0x00, // 67: PMIN
-    0x00, // 68: PSEC
-    0x00  // 69: PFRAME
 };
 
 static const uint8_t DiscInformation[] =
@@ -638,10 +614,6 @@ static void doReadFullTOC(int convertBCD, uint8_t session, uint16_t allocationLe
 
     // Leadout track position
     LBA2MSFBCD(img.scsiSectors, &scsiDev.data[34]);
-
-    // Append recordable disc records b0 and c0 indicating non-recordable disc
-    memcpy(scsiDev.data + len, &FullTOC[48], 22);
-    len += 22;
 
     // Correct the record length in header
     uint16_t toclen = len - 2;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -581,7 +581,7 @@ static void formatRawTrackInfo(const CUETrackInfo *track, uint8_t *dest)
     dest[6] = 0x00;
     dest[7] = 0; // HOUR
 
-    LBA2MSFBCD(track->data_start, &dest[8], false);
+    LBA2MSF(track->data_start, &dest[8], false);
 }
 
 static void doReadFullTOC(uint8_t session, uint16_t allocationLength)
@@ -628,7 +628,7 @@ static void doReadFullTOC(uint8_t session, uint16_t allocationLength)
     scsiDev.data[23] = lasttrack;
 
     // Leadout track position
-    LBA2MSFBCD(img.scsiSectors, &scsiDev.data[34], false);
+    LBA2MSF(img.scsiSectors, &scsiDev.data[34], false);
 
     // Correct the record length in header
     uint16_t toclen = len - 2;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1253,10 +1253,12 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
         {
             // Formatted Q subchannel data
             // Refer to table 354 in T10/1545-D MMC-4 Revision 5a
+            // and ECMA-130 22.3.3
             *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
             *buf++ = trackinfo.track_number;
             *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
-            LBA2MSF(lba + idx, buf, false); buf += 3;
+            int32_t rel = (int32_t)(lba + idx) - (int32_t)trackinfo.data_start;
+            LBA2MSF(rel, buf, true); buf += 3;
             *buf++ = 0;
             LBA2MSF(lba + idx, buf, false); buf += 3;
             *buf++ = 0; *buf++ = 0; // CRC (optional)

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1753,6 +1753,21 @@ extern "C" int scsiCDRomCommand()
         // expect a pickup move to the given LBA
         commandHandled = 0;
     }
+    else if (scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE
+            && command == 0xCD)
+    {
+        // vendor-specific command issued by the AppleCD Audio Player in
+        // response to fast-forward or rewind commands. Might be seek,
+        // might be reposition. Exact MSF value below is unknown.
+        //
+        // Byte 0: 0xCD
+        // Byte 1: 0x10 for rewind, 0x00 for fast-forward
+        // Byte 2: 0x00
+        // Byte 3: 'M' in hex
+        // Byte 4: 'S' in hex
+        // Byte 5: 'F' in hex
+        commandHandled = 0;
+    }
     else
     {
         commandHandled = 0;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1708,6 +1708,17 @@ extern "C" int scsiCDRomCommand()
 
         doReadSubchannel(time, subq, parameter, track_number, allocationLength);
     }
+    else if (command == 0x08)
+    {
+        // READ(6) for CDs (may need sector translation for cue file handling)
+        uint32_t lba =
+            (((uint32_t) scsiDev.cdb[1] & 0x1F) << 16) +
+            (((uint32_t) scsiDev.cdb[2]) << 8) +
+            scsiDev.cdb[3];
+        uint32_t blocks = scsiDev.cdb[4];
+
+        doReadCD(lba, blocks, 0, 0x10, 0, true);
+    }
     else if (command == 0x28)
     {
         // READ(10) for CDs (may need sector translation for cue file handling)

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -493,12 +493,12 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     uint8_t *trackdata = &scsiDev.data[4];
     int trackcount = 0;
     int firsttrack = -1;
-    int lasttrack = -1;
+    const CUETrackInfo *lasttrack = nullptr;
     const CUETrackInfo *trackinfo;
     while ((trackinfo = parser.next_track()) != NULL)
     {
         if (firsttrack < 0) firsttrack = trackinfo->track_number;
-        lasttrack = trackinfo->track_number;
+        lasttrack = trackinfo;
 
         if (track <= trackinfo->track_number)
         {
@@ -511,7 +511,7 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     CUETrackInfo leadout = {};
     leadout.track_number = 0xAA;
     leadout.track_mode = CUETrack_MODE1_2048;
-    leadout.data_start = img.scsiSectors;
+    leadout.data_start = getLeadOutLBA(lasttrack);
     formatTrackInfo(&leadout, &trackdata[8 * trackcount], MSF);
     trackcount += 1;
 
@@ -520,7 +520,7 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     scsiDev.data[0] = toc_length >> 8;
     scsiDev.data[1] = toc_length & 0xFF;
     scsiDev.data[2] = firsttrack;
-    scsiDev.data[3] = lasttrack;
+    scsiDev.data[3] = (lasttrack != nullptr) ? lasttrack->track_number : 0;
 
     if (track != 0xAA && trackcount < 2)
     {

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -229,7 +229,7 @@ static uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack)
         image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
         uint32_t lastTrackBlocks = (img.file.size() - lasttrack->file_offset)
                 / lasttrack->sector_length;
-        return lasttrack->data_start + lastTrackBlocks + 1;
+        return lasttrack->track_start + lastTrackBlocks + 1;
     }
     else
     {
@@ -975,7 +975,7 @@ static void doPlayAudio(uint32_t lba, uint32_t length)
         }
 
         uint64_t offset = trackinfo.file_offset
-                + trackinfo.sector_length * (lba - trackinfo.data_start);
+                + trackinfo.sector_length * (lba - trackinfo.track_start);
         dbgmsg("------ Play audio CD: ", (int)length, " sectors starting at ", (int)lba,
            ", track number ", trackinfo.track_number, ", data offset in file ", (int)offset);
 
@@ -1119,7 +1119,7 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
     getTrackFromLBA(parser, lba, &trackinfo);
 
     // Figure out the data offset in the file
-    uint64_t offset = trackinfo.file_offset + trackinfo.sector_length * (lba - trackinfo.data_start);
+    uint64_t offset = trackinfo.file_offset + trackinfo.sector_length * (lba - trackinfo.track_start);
     dbgmsg("------ Read CD: ", (int)length, " sectors starting at ", (int)lba,
            ", track number ", trackinfo.track_number, ", sector size ", (int)trackinfo.sector_length,
            ", main channel ", main_channel, ", sub channel ", sub_channel,

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -144,7 +144,7 @@ static const uint8_t FullTOC[] =
     0x00, // 43: Frame
     0x00, // 44: Zero
     0x00, // 45: PMIN
-    0x00, // 46: PSEC
+    0x02, // 46: PSEC
     0x00, // 47: PFRAME
 };
 
@@ -187,32 +187,37 @@ static const uint8_t DiscInformation[] =
 };
 
 // Convert logical block address to CD-ROM time
-static void LBA2MSF(uint32_t LBA, uint8_t* MSF)
+static void LBA2MSF(int32_t LBA, uint8_t* MSF, bool relative)
 {
-    MSF[2] = LBA % 75; // Frames
-    uint32_t rem = LBA / 75;
+    if (!relative) {
+        LBA += 150;
+    }
+    uint32_t ulba = LBA;
+    if (LBA < 0) {
+        ulba = LBA * -1;
+    }
+
+    MSF[2] = ulba % 75; // Frames
+    uint32_t rem = ulba / 75;
 
     MSF[1] = rem % 60; // Seconds
     MSF[0] = rem / 60; // Minutes
 }
 
 // Convert logical block address to CD-ROM time in binary coded decimal format
-static void LBA2MSFBCD(uint32_t LBA, uint8_t* MSF)
+static void LBA2MSFBCD(int32_t LBA, uint8_t* MSF, bool relative)
 {
-    uint8_t fra = LBA % 75;
-    uint32_t rem = LBA / 75;
-    uint8_t sec = rem % 60;
-    uint8_t min = rem / 60;
-
-    MSF[0] = ((min / 10) << 4) | (min % 10);
-    MSF[1] = ((sec / 10) << 4) | (sec % 10);
-    MSF[2] = ((fra / 10) << 4) | (fra % 10);
+    LBA2MSF(LBA, MSF, relative);
+    MSF[0] = ((MSF[0] / 10) << 4) | (MSF[0] % 10);
+    MSF[1] = ((MSF[1] / 10) << 4) | (MSF[1] % 10);
+    MSF[2] = ((MSF[2] / 10) << 4) | (MSF[2] % 10);
 }
 
 // Convert CD-ROM time to logical block address
-static uint32_t MSF2LBA(uint8_t m, uint8_t s, uint8_t f)
+static int32_t MSF2LBA(uint8_t m, uint8_t s, uint8_t f, bool relative)
 {
-    uint32_t lba = (m * 60 + s) * 75 + f;
+    int32_t lba = (m * 60 + s) * 75 + f;
+    if (!relative) lba -= 150;
     return lba;
 }
 
@@ -233,7 +238,7 @@ static void doReadTOCSimple(bool MSF, uint8_t track, uint16_t allocationLength)
         if (MSF)
         {
             scsiDev.data[8] = 0;
-            LBA2MSF(capacity, scsiDev.data + 9);
+            LBA2MSF(capacity, scsiDev.data + 9, false);
         }
         else
         {
@@ -257,6 +262,11 @@ static void doReadTOCSimple(bool MSF, uint8_t track, uint16_t allocationLength)
         uint32_t len = sizeof(SimpleTOC);
         memcpy(scsiDev.data, SimpleTOC, len);
 
+        if (MSF)
+        {
+            scsiDev.data[0x0A] = 0x02;
+        }
+
         uint32_t capacity = getScsiCapacity(
             scsiDev.target->cfg->sdSectorStart,
             scsiDev.target->liveCfg.bytesPerSector,
@@ -266,7 +276,7 @@ static void doReadTOCSimple(bool MSF, uint8_t track, uint16_t allocationLength)
         if (MSF)
         {
             scsiDev.data[0x10] = 0;
-            LBA2MSF(capacity, scsiDev.data + 0x11);
+            LBA2MSF(capacity, scsiDev.data + 0x11, false);
         }
         else
         {
@@ -292,10 +302,15 @@ static void doReadTOCSimple(bool MSF, uint8_t track, uint16_t allocationLength)
     }
 }
 
-static void doReadSessionInfoSimple(uint8_t session, uint16_t allocationLength)
+static void doReadSessionInfoSimple(bool msf, uint16_t allocationLength)
 {
     uint32_t len = sizeof(SessionTOC);
     memcpy(scsiDev.data, SessionTOC, len);
+
+    if (msf)
+    {
+        scsiDev.data[0x0A] = 0x02;
+    }
 
     if (len > allocationLength)
     {
@@ -410,7 +425,7 @@ static void formatTrackInfo(const CUETrackInfo *track, uint8_t *dest, bool use_M
     {
         // Time in minute-second-frame format
         dest[4] = 0;
-        LBA2MSF(track->data_start, &dest[5]);
+        LBA2MSF(track->data_start, &dest[5], false);
     }
     else
     {
@@ -513,14 +528,14 @@ static void doReadTOC(bool MSF, uint8_t track, uint16_t allocationLength)
     }
 }
 
-static void doReadSessionInfo(uint8_t session, uint16_t allocationLength)
+static void doReadSessionInfo(bool msf, uint16_t allocationLength)
 {
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     CUEParser parser;
     if (!loadCueSheet(img, parser))
     {
         // No CUE sheet, use hardcoded data
-        return doReadSessionInfoSimple(session, allocationLength);
+        return doReadSessionInfoSimple(msf, allocationLength);
     }
 
     uint32_t len = sizeof(SessionTOC);
@@ -566,7 +581,7 @@ static void formatRawTrackInfo(const CUETrackInfo *track, uint8_t *dest)
     dest[6] = 0x00;
     dest[7] = 0; // HOUR
 
-    LBA2MSFBCD(track->data_start, &dest[8]);
+    LBA2MSFBCD(track->data_start, &dest[8], false);
 }
 
 static void doReadFullTOC(int convertBCD, uint8_t session, uint16_t allocationLength)
@@ -613,7 +628,7 @@ static void doReadFullTOC(int convertBCD, uint8_t session, uint16_t allocationLe
     scsiDev.data[23] = lasttrack;
 
     // Leadout track position
-    LBA2MSFBCD(img.scsiSectors, &scsiDev.data[34]);
+    LBA2MSFBCD(img.scsiSectors, &scsiDev.data[34], false);
 
     // Correct the record length in header
     uint16_t toclen = len - 2;
@@ -666,7 +681,7 @@ void doReadHeader(bool MSF, uint32_t lba, uint16_t allocationLength)
     if (MSF)
     {
         scsiDev.data[4] = 0;
-        LBA2MSF(lba, &scsiDev.data[5]);
+        LBA2MSF(lba, &scsiDev.data[5], false);
     }
     else
     {
@@ -1215,7 +1230,7 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
             *buf++ = 0x00;
 
             // 4-byte data sector header
-            LBA2MSFBCD(lba + idx, buf);
+            LBA2MSFBCD(lba + idx, buf, false);
             buf += 3;
             *buf++ = 0x01; // Mode 1
         }
@@ -1241,9 +1256,9 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
             *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
             *buf++ = trackinfo.track_number;
             *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
-            LBA2MSF(lba + idx, buf); buf += 3;
+            LBA2MSF(lba + idx, buf, false); buf += 3;
             *buf++ = 0;
-            LBA2MSF(lba + idx, buf); buf += 3;
+            LBA2MSF(lba + idx, buf, false); buf += 3;
             *buf++ = 0; *buf++ = 0; // CRC (optional)
             *buf++ = 0; *buf++ = 0; *buf++ = 0; // (pad)
             *buf++ = 0; // No P subchannel
@@ -1294,7 +1309,7 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
             if (time)
             {
                 *buf++ = 0;
-                LBA2MSF(lba, buf);
+                LBA2MSF(lba, buf, false);
                 dbgmsg("------ ABS M ", *buf, " S ", *(buf+1), " F ", *(buf+2));
                 buf += 3;
             }
@@ -1306,20 +1321,21 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
                 *buf++ = (lba >>  0) & 0xFF;
             }
 
-            uint32_t relpos = (uint32_t)((int32_t)lba - (int32_t)trackinfo.data_start);
+            int32_t relpos = (int32_t)lba - (int32_t)trackinfo.data_start;
             if (time)
             {
                 *buf++ = 0;
-                LBA2MSF(relpos, buf);
+                LBA2MSF(relpos, buf, true);
                 dbgmsg("------ REL M ", *buf, " S ", *(buf+1), " F ", *(buf+2));
                 buf += 3;
             }
             else
             {
-                *buf++ = (relpos >> 24) & 0xFF; // Track relative position (may be negative)
-                *buf++ = (relpos >> 16) & 0xFF;
-                *buf++ = (relpos >>  8) & 0xFF;
-                *buf++ = (relpos >>  0) & 0xFF;
+                uint32_t urelpos = relpos;
+                *buf++ = (urelpos >> 24) & 0xFF; // Track relative position (may be negative)
+                *buf++ = (urelpos >> 16) & 0xFF;
+                *buf++ = (urelpos >>  8) & 0xFF;
+                *buf++ = (urelpos >>  0) & 0xFF;
             }
         }
         else
@@ -1470,8 +1486,8 @@ extern "C" int scsiCDRomCommand()
     else if (command == 0x47)
     {
         // PLAY AUDIO (MSF)
-        uint32_t start = MSF2LBA(scsiDev.cdb[3], scsiDev.cdb[4], scsiDev.cdb[5]);
-        uint32_t end   = MSF2LBA(scsiDev.cdb[6], scsiDev.cdb[7], scsiDev.cdb[8]);
+        uint32_t start = MSF2LBA(scsiDev.cdb[3], scsiDev.cdb[4], scsiDev.cdb[5], false);
+        uint32_t end   = MSF2LBA(scsiDev.cdb[6], scsiDev.cdb[7], scsiDev.cdb[8], false);
 
         uint32_t lba = start;
         if (scsiDev.cdb[3] == 0xFF
@@ -1525,8 +1541,8 @@ extern "C" int scsiCDRomCommand()
     {
         // ReadCD MSF
         uint8_t sector_type = (scsiDev.cdb[1] >> 2) & 7;
-        uint32_t start = MSF2LBA(scsiDev.cdb[3], scsiDev.cdb[4], scsiDev.cdb[5]);
-        uint32_t end   = MSF2LBA(scsiDev.cdb[6], scsiDev.cdb[7], scsiDev.cdb[8]);
+        uint32_t start = MSF2LBA(scsiDev.cdb[3], scsiDev.cdb[4], scsiDev.cdb[5], false);
+        uint32_t end   = MSF2LBA(scsiDev.cdb[6], scsiDev.cdb[7], scsiDev.cdb[8], false);
         uint8_t main_channel = scsiDev.cdb[9];
         uint8_t sub_channel = scsiDev.cdb[10];
 

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -326,7 +326,7 @@ fromBCD(uint8_t val)
     return ((val >> 4) * 10) + (val & 0xF);
 }
 
-static void doReadFullTOCSimple(int convertBCD, uint8_t session, uint16_t allocationLength)
+static void doReadFullTOCSimple(uint8_t session, uint16_t allocationLength)
 {
     // We only support session 1.
     if (session > 1)
@@ -341,7 +341,7 @@ static void doReadFullTOCSimple(int convertBCD, uint8_t session, uint16_t alloca
         uint32_t len = sizeof(FullTOC);
         memcpy(scsiDev.data, FullTOC, len);
 
-        if (convertBCD)
+        if (false)
         {
             int descriptor = 4;
             while (descriptor < len)
@@ -584,14 +584,14 @@ static void formatRawTrackInfo(const CUETrackInfo *track, uint8_t *dest)
     LBA2MSFBCD(track->data_start, &dest[8], false);
 }
 
-static void doReadFullTOC(int convertBCD, uint8_t session, uint16_t allocationLength)
+static void doReadFullTOC(uint8_t session, uint16_t allocationLength)
 {
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     CUEParser parser;
     if (!loadCueSheet(img, parser))
     {
         // No CUE sheet, use hardcoded data
-        return doReadFullTOCSimple(convertBCD, session, allocationLength);
+        return doReadFullTOCSimple(session, allocationLength);
     }
 
     // We only support session 1.
@@ -1421,8 +1421,7 @@ extern "C" int scsiCDRomCommand()
         {
             case 0: doReadTOC(MSF, track, allocationLength); break; // SCSI-2
             case 1: doReadSessionInfo(MSF, allocationLength); break; // MMC2
-            case 2: doReadFullTOC(0, track, allocationLength); break; // MMC2
-            case 3: doReadFullTOC(1, track, allocationLength); break; // MMC2
+            case 2: doReadFullTOC(track, allocationLength); break; // MMC2
             default:
             {
                 scsiDev.status = CHECK_CONDITION;

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -962,10 +962,8 @@ static void doPlayAudio(uint32_t lba, uint32_t length)
             lba = img.file.position() / 2352;
         }
 
-        // --- TODO --- determine proper track offset, software I tested with had a tendency
-        // to ask for offsets that seem to hint at 2048 here, not the 2352 you'd assume.
-        // Might be due to a mode page reporting something unexpected? Needs investigation.
-        uint64_t offset = trackinfo.file_offset + 2048 * (lba - trackinfo.data_start);
+        uint64_t offset = trackinfo.file_offset
+                + trackinfo.sector_length * (lba - trackinfo.data_start);
         dbgmsg("------ Play audio CD: ", (int)length, " sectors starting at ", (int)lba,
            ", track number ", trackinfo.track_number, ", data offset in file ", (int)offset);
 
@@ -981,7 +979,8 @@ static void doPlayAudio(uint32_t lba, uint32_t length)
 
         // playback request appears to be sane, so perform it
         // see earlier note for context on the block length below
-        if (!audio_play(target_id, &(img.file), offset, offset + length * 2048, false))
+        if (!audio_play(target_id, &(img.file), offset,
+                offset + length * trackinfo.sector_length, false))
         {
             // Underlying data/media error? Fake a disk scratch, which should
             // be a condition most CD-DA players are expecting

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -172,15 +172,6 @@ static const uint8_t FullTOC[] =
     0x00  // 69: PFRAME
 };
 
-static uint8_t SimpleHeader[] =
-{
-    0x01, // 2048byte user data, L-EC in 288 byte aux field.
-    0x00, // reserved
-    0x00, // reserved
-    0x00, // reserved
-    0x00,0x00,0x00,0x00 // Track start sector (LBA or MSF)
-};
-
 static const uint8_t DiscInformation[] =
 {
     0x00,   //  0: disc info length, MSB
@@ -382,18 +373,6 @@ static void doReadFullTOCSimple(int convertBCD, uint8_t session, uint16_t alloca
         scsiDev.dataLen = len;
         scsiDev.phase = DATA_IN;
     }
-}
-
-void doReadHeaderSimple(bool MSF, uint32_t lba, uint16_t allocationLength)
-{
-    uint32_t len = sizeof(SimpleHeader);
-    memcpy(scsiDev.data, SimpleHeader, len);
-    if (len > allocationLength)
-    {
-        len = allocationLength;
-    }
-    scsiDev.dataLen = len;
-    scsiDev.phase = DATA_IN;
 }
 
 void doReadDiscInformationSimple(uint16_t allocationLength)
@@ -679,6 +658,9 @@ static void doReadFullTOC(int convertBCD, uint8_t session, uint16_t allocationLe
 
 // SCSI-3 MMC Read Header command, seems to be deprecated in later standards.
 // Refer to ANSI X3.304-1997
+// The spec is vague, but based on experimentation with a Matshita drive this
+// command should return the sector header absolute time (see ECMA-130 21).
+// Given 2048-byte block sizes this effectively is 1:1 with the provided LBA.
 void doReadHeader(bool MSF, uint32_t lba, uint16_t allocationLength)
 {
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
@@ -688,41 +670,41 @@ void doReadHeader(bool MSF, uint32_t lba, uint16_t allocationLength)
     audio_stop(img.scsiId & 7);
 #endif
 
+    uint8_t mode = 1;
     CUEParser parser;
-    if (!loadCueSheet(img, parser))
+    if (loadCueSheet(img, parser))
     {
-        // No CUE sheet, use hardcoded data
-        return doReadHeaderSimple(MSF, lba, allocationLength);
+        // Search the track with the requested LBA
+        CUETrackInfo trackinfo = {};
+        getTrackFromLBA(parser, lba, &trackinfo);
+
+        // Track mode (audio / data)
+        if (trackinfo.track_mode == CUETrack_AUDIO)
+        {
+            scsiDev.data[0] = 0;
+        }
     }
 
-    // Take the hardcoded header as base
-    uint32_t len = sizeof(SimpleHeader);
-    memcpy(scsiDev.data, SimpleHeader, len);
-
-    // Search the track with the requested LBA
-    CUETrackInfo trackinfo = {};
-    getTrackFromLBA(parser, lba, &trackinfo);
-
-    // Track mode (audio / data)
-    if (trackinfo.track_mode == CUETrack_AUDIO)
-    {
-        scsiDev.data[0] = 0;
-    }
+    scsiDev.data[0] = mode;
+    scsiDev.data[1] = 0; // reserved
+    scsiDev.data[2] = 0; // reserved
+    scsiDev.data[3] = 0; // reserved
 
     // Track start
     if (MSF)
     {
         scsiDev.data[4] = 0;
-        LBA2MSF(trackinfo.data_start, &scsiDev.data[5]);
+        LBA2MSF(lba, &scsiDev.data[5]);
     }
     else
     {
-        scsiDev.data[4] = (trackinfo.data_start >> 24) & 0xFF;
-        scsiDev.data[5] = (trackinfo.data_start >> 16) & 0xFF;
-        scsiDev.data[6] = (trackinfo.data_start >>  8) & 0xFF;
-        scsiDev.data[7] = (trackinfo.data_start >>  0) & 0xFF;
+        scsiDev.data[4] = (lba >> 24) & 0xFF;
+        scsiDev.data[5] = (lba >> 16) & 0xFF;
+        scsiDev.data[6] = (lba >>  8) & 0xFF;
+        scsiDev.data[7] = (lba >>  0) & 0xFF;
     }
 
+    uint8_t len = 8;
     if (len > allocationLength)
     {
         len = allocationLength;


### PR DESCRIPTION
Fixes #210 and adjusts other aspects of the CD-ROM subsystem. This covers a bit of ground, so if it would be better to break up the PR I'd be happy to do so. Main changes:

- TOC handling has been retrofitted to more closely match observed behavior on devices, including some vendor-specific SCSI-2 options that appear to have been _de-facto_ standards before MMC.
- Addressing has been adjusted to improve the behavior of audio players. Playback tracking is now much more reliable. Fast-forwarding/rewinding and track seeking is still a bit iffy with some software and will need further work down the line.
- A few tweaks to CUE file parsing. This will eventually need pre-gap support add for the 'blank' sections of BIN files, which is causing some variance against actual disk TOCs.

Any feedback is welcome!