### PR TITLE
Revert removing audio stop during START/STOP UNIT for CDs.

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1492,6 +1492,10 @@ extern "C" int scsiCDRomCommand()
     uint8_t command = scsiDev.cdb[0];
     if (command == 0x1B)
     {
+#if ENABLE_AUDIO_OUTPUT
+        // terminate audio playback if active on this target (MMC-1 Annex C)
+        audio_stop(img.scsiId & 7);
+#endif
         if ((scsiDev.cdb[4] & 2))
         {
             // CD-ROM load & eject


### PR DESCRIPTION
Some audio players use START/STOP UNIT to halt audio playback. I inadvertently removed this in 299656a157eacf6ed3b5981ce67476a264935779