### PR TITLE
CD-ROM image listing from directories

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -373,51 +373,16 @@ bool findHDDImages()
       bool is_tp = (tolower(name[0]) == 't' && tolower(name[1]) == 'p');
       if (is_hd || is_cd || is_fd || is_mo || is_re || is_tp)
       {
-        // Check file extension
-        // We accept anything except known compressed files
-        bool is_compressed = false;
-        const char *extension = strrchr(name, '.');
-        if (extension)
-        {
-          const char *archive_exts[] = {
-            ".tar", ".tgz", ".gz", ".bz2", ".tbz2", ".xz", ".zst", ".z",
-            ".zip", ".zipx", ".rar", ".lzh", ".lha", ".lzo", ".lz4", ".arj",
-            ".dmg", ".hqx", ".cpt", ".7z", ".s7z",
-            NULL
-          };
-
-          for (int i = 0; archive_exts[i]; i++)
-          {
-            if (strcasecmp(extension, archive_exts[i]) == 0)
-            {
-              is_compressed = true;
-              break;
-            }
-          }
-        }
-
-        if (is_compressed)
-        {
-          logmsg("-- Ignoring compressed file ", name);
-          continue;
-        }
-
-        if (strcasecmp(extension, ".cue") == 0)
-        {
-          continue; // .cue will be handled with corresponding .bin
-        }
-
         // Check if the image should be loaded to microcontroller flash ROM drive
         bool is_romdrive = false;
+        const char *extension = strrchr(name, '.');
         if (extension && strcasecmp(extension, ".rom") == 0)
         {
           is_romdrive = true;
         }
-        else if (extension && strcasecmp(extension, ".rom_loaded") == 0)
-        {
-          // Already loaded ROM drive, ignore the image
-          continue;
-        }
+
+        // skip file if the name indicates it is not a valid image container
+        if (!is_romdrive && !scsiDiskFilenameValid(name)) continue;
 
         // Defaults for Hard Disks
         int id  = 1; // 0 and 3 are common in Macs for physical HD and CD, so avoid them.

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -842,7 +842,7 @@ void cdromReinsertFirstImage(image_config_t &img)
     {
         // Multiple images for this drive, force restart from first one
         dbgmsg("---- Restarting from first CD-ROM image");
-        img.image_index = 9;
+        img.image_index = IMAGE_INDEX_MAX;
         cdromSwitchNextImage(img);
     }
     else if (img.ejected)

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -858,14 +858,9 @@ void cdromReinsertFirstImage(image_config_t &img)
 bool cdromSwitchNextImage(image_config_t &img)
 {
     // Check if we have a next image to load, so that drive is closed next time the host asks.
-    img.image_index++;
     char filename[MAX_FILE_PATH];
     int target_idx = img.scsiId & 7;
-    if (!scsiDiskGetImageNameFromConfig(img, filename, sizeof(filename)))
-    {
-        img.image_index = 0;
-        scsiDiskGetImageNameFromConfig(img, filename, sizeof(filename));
-    }
+    scsiDiskGetNextImageName(img, filename, sizeof(filename));
 
 #ifdef ENABLE_AUDIO_OUTPUT
     // if in progress for this device, terminate audio playback immediately (Annex C)

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -843,6 +843,7 @@ void cdromReinsertFirstImage(image_config_t &img)
         // Multiple images for this drive, force restart from first one
         dbgmsg("---- Restarting from first CD-ROM image");
         img.image_index = IMAGE_INDEX_MAX;
+        img.current_image[0] = '\0';
         cdromSwitchNextImage(img);
     }
     else if (img.ejected)

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -56,6 +56,9 @@
 #define HDIMG_BLK_POS 5                 // Position to embed block size numbers
 #define MAX_FILE_PATH 64                // Maximum file name length
 
+// Image definition options
+#define IMAGE_INDEX_MAX 9               // Maximum number of 'IMG0' style statements parsed
+
 // SCSI config
 #define NUM_SCSIID  8          // Maximum number of supported SCSI-IDs (The minimum is 0)
 #define NUM_SCSILUN 1          // Maximum number of LUNs supported     (Currently has to be 1)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -591,17 +591,17 @@ static int findNextImageAfter(image_config_t &img,
 
         // keep track of the first item to allow wrapping
         // without having to iterate again
-        if (first_name[0] == '\0' || strcmp(buf, first_name) < 0)
+        if (first_name[0] == '\0' || strcasecmp(buf, first_name) < 0)
         {
             strncpy(first_name, buf, sizeof(first_name));
         }
 
         // discard if no selected name, or if candidate is before (or is) selected
-        if (filename[0] == '\0' || strcmp(buf, filename) <= 0) continue;
+        if (filename[0] == '\0' || strcasecmp(buf, filename) <= 0) continue;
 
         // if we got this far and the candidate is either 1) not set, or 2) is a
         // lower item than what has been encountered thus far, it is the best choice
-        if (candidate_name[0] == '\0' || strcmp(buf, candidate_name) < 0)
+        if (candidate_name[0] == '\0' || strcasecmp(buf, candidate_name) < 0)
         {
             strncpy(candidate_name, buf, sizeof(candidate_name));
         }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -636,10 +636,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     section[4] = '0' + target_idx;
 
     // sanity check: is provided buffer is long enough to store a filename?
-    if (buflen < MAX_FILE_PATH)
-    {
-        panic("scsiDiskGetNextImageName called with illegal buflen");
-    }
+    assert(buflen >= MAX_FILE_PATH);
 
     if (img.image_directory)
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -540,6 +540,16 @@ static void scsiDiskLoadConfig(int target_idx, const char *section)
     memset(tmp, 0, sizeof(tmp));
     ini_gets(section, "Serial", "", tmp, sizeof(tmp), CONFIGFILE);
     if (tmp[0]) memcpy(img.serial, tmp, sizeof(img.serial));
+
+    if (strlen(section) == 5 && strncmp(section, "SCSI", 4) == 0) // allow within target [SCSIx] blocks only
+    {
+        ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
+        if (tmp[0])
+        {
+            logmsg("-- SCSI", target_idx, " using image directory \'", tmp, "'");
+            img.image_directory = true;
+        }
+    }
 }
 
 int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -425,8 +425,11 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int
 
         return true;
     }
-
-    return false;
+    else
+    {
+        logmsg("---- Failed to load image '", filename, "', ignoring");
+        return false;
+    }
 }
 
 static void checkDiskGeometryDivisible(image_config_t &img)
@@ -574,7 +577,7 @@ void scsiDiskLoadConfig(int target_idx)
     if (scsiDiskGetImageNameFromConfig(img, filename, sizeof(filename)))
     {
         int blocksize = (img.deviceType == S2S_CFG_OPTICAL) ? 2048 : 512;
-        logmsg("-- Opening ", filename, " for id:", target_idx, ", specified in " CONFIGFILE);
+        logmsg("-- Opening '", filename, "' for id:", target_idx, ", specified in " CONFIGFILE);
         scsiDiskOpenHDDImage(target_idx, filename, target_idx, 0, blocksize);
     }
 }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -664,7 +664,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
             logmsg("Image directory was empty for ID", target_idx);
             return 0;
         }
-        else if (buflen < nextlen + dirlen + 1)
+        else if (buflen < nextlen + dirlen + 2)
         {
             logmsg("Directory '", dirname, "' and file '", nextname, "' exceed allowed length");
             return 0;
@@ -673,8 +673,8 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
         {
             // construct a return value
             strncpy(buf, dirname, buflen);
-            buf[dirlen] = '/';
-            strncpy(buf + dirlen + 1, nextname, buflen - dirlen - 1);
+            if (buf[strlen(buf) - 1] != '/') strcat(buf, "/");
+            strcat(buf, nextname);
             return dirlen + nextlen;
         }
     }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -605,6 +605,7 @@ void scsiDiskLoadConfig(int target_idx)
     // Check if we have image specified by name
     char filename[MAX_FILE_PATH];
     image_config_t &img = g_DiskImages[target_idx];
+    img.image_index = IMAGE_INDEX_MAX;
     if (scsiDiskGetNextImageName(img, filename, sizeof(filename)))
     {
         int blocksize = (img.deviceType == S2S_CFG_OPTICAL) ? 2048 : 512;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -577,13 +577,13 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     {
         // there may be more than one image but we've ran out of new ones
         // wrap back to the first image
-        img.image_index = 9;
+        img.image_index = IMAGE_INDEX_MAX;
         return scsiDiskGetNextImageName(img, buf, buflen);
     }
     else
     {
         // images are not defined in config
-        img.image_index = 0;
+        img.image_index = IMAGE_INDEX_MAX;
         return 0;
     }
 }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -556,35 +556,143 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 {
     int target_idx = img.scsiId & 7;
 
-    img.image_index++;
-    if (img.image_index > IMAGE_INDEX_MAX)
-    {
-        img.image_index = 0;
-    }
-
     char section[6] = "SCSI0";
     section[4] = '0' + target_idx;
 
-    char key[5] = "IMG0";
-    key[3] = '0' + img.image_index;
-
-    int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
-    if (buf[0] != '\0')
+    // sanity check: is provided buffer is long enough to store a filename?
+    if (buflen < MAX_FILE_PATH)
     {
-        return ret;
+        panic("scsiDiskGetNextImageName called with illegal buflen");
     }
-    else if (img.image_index > 0)
+
+    if (img.image_directory)
     {
-        // there may be more than one image but we've ran out of new ones
-        // wrap back to the first image
-        img.image_index = IMAGE_INDEX_MAX;
-        return scsiDiskGetNextImageName(img, buf, buflen);
+        // is this needed to prevent an inadvertent callback during all these opens?
+        platform_set_sd_callback(NULL, NULL);
+
+        // image directory was found during startup
+        FsFile dir;
+        char key[] = "ImgDir";
+        ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+        if (buf[0] != '\0')
+        {
+            if (!dir.open(buf))
+            {
+                logmsg("ImgDir '", buf, "' couldn't be opened.");
+            }
+            if (!dir.isDir())
+            {
+                logmsg("ImgDir '", buf, "' is not a directory.");
+                dir.close();
+                return false;
+            }
+        }
+        else
+        {
+            // If image_directory set but ImageDir is not, could be used to
+            // indicate an image directory configured via folder structure.
+            // Not implemented, so treat this as equivalent to missing ImageDir
+            return false;
+        }
+
+        // Find the filename with the lowest lexical order _after_ the
+        // currently selected file. If there is none, or if there is no
+        // current file, use the lowest filename encountered.
+        char first_name[MAX_FILE_PATH] = {'\0'};
+        char candidate_name[MAX_FILE_PATH] = {'\0'};
+        FsFile file;
+        while (file.openNext(&dir, O_RDONLY))
+        {
+            if (file.isDir()) continue;
+            if (!file.getName(buf, MAX_FILE_PATH))
+            {
+                logmsg("Image directory had invalid file for ID", target_idx);
+                continue;
+            }
+            if (!scsiDiskFilenameValid(buf)) continue;
+
+            // keep track of the first item to allow wrapping
+            // without having to iterate again
+            if (first_name[0] == '\0' || strcmp(buf, first_name) < 0)
+            {
+                strncpy(first_name, buf, sizeof(first_name));
+            }
+
+            // discard if no selected name, or if candidate is before (or is) selected
+            if (img.current_image[0] == '\0' || strcmp(buf, img.current_image) <= 0) continue;
+
+            // if we got this far and the candidate is either 1) not set, or 2) is a
+            // lower item than what has been encountered thus far, it is the best choice
+            if (candidate_name[0] == '\0' || strcmp(buf, candidate_name) < 0)
+            {
+                strncpy(candidate_name, buf, sizeof(candidate_name));
+            }
+        }
+
+        // create base path for the result
+        // *TODO* this needs handling for leading and trailing slashes
+        int dirlen = dir.getName(buf, buflen);
+        dir.close(); // done with this
+        if (dirlen > 0 && dirlen - 1 < buflen)
+        {
+            buf[dirlen] = '/';
+            dirlen++;
+        }
+        else
+        {
+            logmsg("Image directory name invalid for ID", target_idx);
+        }
+
+        // append the filename
+        if (candidate_name[0] != '\0')
+        {
+            strncpy(img.current_image, candidate_name, sizeof(img.current_image));
+            strncpy(buf + dirlen, candidate_name, buflen - dirlen);
+            img.image_index++;
+            return dirlen + strlen(candidate_name);
+        }
+        else if (first_name[0] != '\0')
+        {
+            strncpy(img.current_image, first_name, sizeof(img.current_image));
+            strncpy(buf + dirlen, first_name, buflen - dirlen);
+            img.image_index = 0;
+            return dirlen + strlen(first_name);
+        }
+        else
+        {
+            logmsg("Image directory was empty for ID", target_idx);
+            return 0;
+        }
     }
     else
     {
-        // images are not defined in config
-        img.image_index = IMAGE_INDEX_MAX;
-        return 0;
+        img.image_index++;
+        if (img.image_index > IMAGE_INDEX_MAX)
+        {
+            img.image_index = 0;
+        }
+
+        char key[5] = "IMG0";
+        key[3] = '0' + img.image_index;
+
+        int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+        if (buf[0] != '\0')
+        {
+            return ret;
+        }
+        else if (img.image_index > 0)
+        {
+            // there may be more than one image but we've ran out of new ones
+            // wrap back to the first image
+            img.image_index = IMAGE_INDEX_MAX;
+            return scsiDiskGetNextImageName(img, buf, buflen);
+        }
+        else
+        {
+            // images are not defined in config
+            img.image_index = IMAGE_INDEX_MAX;
+            return 0;
+        }
     }
 }
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -547,7 +547,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     int target_idx = img.scsiId & 7;
 
     img.image_index++;
-    if (img.image_index > 9)
+    if (img.image_index > IMAGE_INDEX_MAX)
     {
         img.image_index = 0;
     }

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -542,10 +542,15 @@ static void scsiDiskLoadConfig(int target_idx, const char *section)
     if (tmp[0]) memcpy(img.serial, tmp, sizeof(img.serial));
 }
 
-// Check if image file name is overridden in config
-bool scsiDiskGetImageNameFromConfig(image_config_t &img, char *buf, size_t buflen)
+int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 {
     int target_idx = img.scsiId & 7;
+
+    img.image_index++;
+    if (img.image_index > 9)
+    {
+        img.image_index = 0;
+    }
 
     char section[6] = "SCSI0";
     section[4] = '0' + target_idx;
@@ -553,8 +558,24 @@ bool scsiDiskGetImageNameFromConfig(image_config_t &img, char *buf, size_t bufle
     char key[5] = "IMG0";
     key[3] = '0' + img.image_index;
 
-    ini_gets(section, key, "", buf, buflen, CONFIGFILE);
-    return buf[0] != '\0';
+    int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+    if (buf[0] != '\0')
+    {
+        return ret;
+    }
+    else if (img.image_index > 0)
+    {
+        // there may be more than one image but we've ran out of new ones
+        // wrap back to the first image
+        img.image_index = 9;
+        return scsiDiskGetNextImageName(img, buf, buflen);
+    }
+    else
+    {
+        // images are not defined in config
+        img.image_index = 0;
+        return 0;
+    }
 }
 
 void scsiDiskLoadConfig(int target_idx)
@@ -574,7 +595,7 @@ void scsiDiskLoadConfig(int target_idx)
     // Check if we have image specified by name
     char filename[MAX_FILE_PATH];
     image_config_t &img = g_DiskImages[target_idx];
-    if (scsiDiskGetImageNameFromConfig(img, filename, sizeof(filename)))
+    if (scsiDiskGetNextImageName(img, filename, sizeof(filename)))
     {
         int blocksize = (img.deviceType == S2S_CFG_OPTICAL) ? 2048 : 512;
         logmsg("-- Opening '", filename, "' for id:", target_idx, ", specified in " CONFIGFILE);

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -552,6 +552,82 @@ static void scsiDiskLoadConfig(int target_idx, const char *section)
     }
 }
 
+// Finds filename with the lowest lexical order _after_ the given filename in
+// the given folder. If there is no file after the given one, or if there is
+// no current file, this will return the lowest filename encountered.
+static int findNextImageAfter(image_config_t &img,
+        const char* dirname, const char* filename,
+        char* buf, size_t buflen)
+{
+    FsFile dir;
+    if (dirname[0] == '\0')
+    {
+        logmsg("Image directory name invalid for ID", (img.scsiId & 7));
+        return 0;
+    }
+    if (!dir.open(dirname))
+    {
+        logmsg("Image directory '", dirname, "' couldn't be opened");
+    }
+    if (!dir.isDir())
+    {
+        logmsg("Can't find images in '", dirname, "', not a directory");
+        dir.close();
+        return 0;
+    }
+
+    char first_name[MAX_FILE_PATH] = {'\0'};
+    char candidate_name[MAX_FILE_PATH] = {'\0'};
+    FsFile file;
+    while (file.openNext(&dir, O_RDONLY))
+    {
+        if (file.isDir()) continue;
+        if (!file.getName(buf, MAX_FILE_PATH))
+        {
+            logmsg("Image directory '", dirname, "'had invalid file");
+            continue;
+        }
+        if (!scsiDiskFilenameValid(buf)) continue;
+
+        // keep track of the first item to allow wrapping
+        // without having to iterate again
+        if (first_name[0] == '\0' || strcmp(buf, first_name) < 0)
+        {
+            strncpy(first_name, buf, sizeof(first_name));
+        }
+
+        // discard if no selected name, or if candidate is before (or is) selected
+        if (filename[0] == '\0' || strcmp(buf, filename) <= 0) continue;
+
+        // if we got this far and the candidate is either 1) not set, or 2) is a
+        // lower item than what has been encountered thus far, it is the best choice
+        if (candidate_name[0] == '\0' || strcmp(buf, candidate_name) < 0)
+        {
+            strncpy(candidate_name, buf, sizeof(candidate_name));
+        }
+    }
+
+    if (candidate_name[0] != '\0')
+    {
+        img.image_index++;
+        strncpy(img.current_image, candidate_name, sizeof(img.current_image));
+        strncpy(buf, candidate_name, buflen);
+        return strlen(candidate_name);
+    }
+    else if (first_name[0] != '\0')
+    {
+        img.image_index = 0;
+        strncpy(img.current_image, first_name, sizeof(img.current_image));
+        strncpy(buf, first_name, buflen);
+        return strlen(first_name);
+    }
+    else
+    {
+        logmsg("Image directory '", dirname, "' was empty");
+        return 0;
+    }
+}
+
 int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 {
     int target_idx = img.scsiId & 7;
@@ -568,97 +644,38 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     if (img.image_directory)
     {
         // image directory was found during startup
-        FsFile dir;
+        char dirname[MAX_FILE_PATH];
         char key[] = "ImgDir";
-        ini_gets(section, key, "", buf, buflen, CONFIGFILE);
-        if (buf[0] != '\0')
-        {
-            if (!dir.open(buf))
-            {
-                logmsg("ImgDir '", buf, "' couldn't be opened.");
-            }
-            if (!dir.isDir())
-            {
-                logmsg("ImgDir '", buf, "' is not a directory.");
-                dir.close();
-                return false;
-            }
-        }
-        else
+        int dirlen = ini_gets(section, key, "", dirname, sizeof(dirname), CONFIGFILE);
+        if (!dirlen)
         {
             // If image_directory set but ImageDir is not, could be used to
             // indicate an image directory configured via folder structure.
             // Not implemented, so treat this as equivalent to missing ImageDir
-            return false;
+            return 0;
         }
 
-        // Find the filename with the lowest lexical order _after_ the
-        // currently selected file. If there is none, or if there is no
-        // current file, use the lowest filename encountered.
-        char first_name[MAX_FILE_PATH] = {'\0'};
-        char candidate_name[MAX_FILE_PATH] = {'\0'};
-        FsFile file;
-        while (file.openNext(&dir, O_RDONLY))
-        {
-            if (file.isDir()) continue;
-            if (!file.getName(buf, MAX_FILE_PATH))
-            {
-                logmsg("Image directory had invalid file for ID", target_idx);
-                continue;
-            }
-            if (!scsiDiskFilenameValid(buf)) continue;
+        // find the next filename
+        char nextname[MAX_FILE_PATH];
+        int nextlen = findNextImageAfter(img, dirname, img.current_image, nextname, sizeof(nextname));
 
-            // keep track of the first item to allow wrapping
-            // without having to iterate again
-            if (first_name[0] == '\0' || strcmp(buf, first_name) < 0)
-            {
-                strncpy(first_name, buf, sizeof(first_name));
-            }
-
-            // discard if no selected name, or if candidate is before (or is) selected
-            if (img.current_image[0] == '\0' || strcmp(buf, img.current_image) <= 0) continue;
-
-            // if we got this far and the candidate is either 1) not set, or 2) is a
-            // lower item than what has been encountered thus far, it is the best choice
-            if (candidate_name[0] == '\0' || strcmp(buf, candidate_name) < 0)
-            {
-                strncpy(candidate_name, buf, sizeof(candidate_name));
-            }
-        }
-
-        // create base path for the result
-        // *TODO* this needs handling for leading and trailing slashes
-        int dirlen = dir.getName(buf, buflen);
-        dir.close(); // done with this
-        if (dirlen > 0 && dirlen - 1 < buflen)
-        {
-            buf[dirlen] = '/';
-            dirlen++;
-        }
-        else
-        {
-            logmsg("Image directory name invalid for ID", target_idx);
-        }
-
-        // append the filename
-        if (candidate_name[0] != '\0')
-        {
-            strncpy(img.current_image, candidate_name, sizeof(img.current_image));
-            strncpy(buf + dirlen, candidate_name, buflen - dirlen);
-            img.image_index++;
-            return dirlen + strlen(candidate_name);
-        }
-        else if (first_name[0] != '\0')
-        {
-            strncpy(img.current_image, first_name, sizeof(img.current_image));
-            strncpy(buf + dirlen, first_name, buflen - dirlen);
-            img.image_index = 0;
-            return dirlen + strlen(first_name);
-        }
-        else
+        if (nextlen == 0)
         {
             logmsg("Image directory was empty for ID", target_idx);
             return 0;
+        }
+        else if (buflen < nextlen + dirlen + 1)
+        {
+            logmsg("Directory '", dirname, "' and file '", nextname, "' exceed allowed length");
+            return 0;
+        }
+        else
+        {
+            // construct a return value
+            strncpy(buf, dirname, buflen);
+            buf[dirlen] = '/';
+            strncpy(buf + dirlen + 1, nextname, buflen - dirlen - 1);
+            return dirlen + nextlen;
         }
     }
     else

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -446,6 +446,43 @@ static void checkDiskGeometryDivisible(image_config_t &img)
     }
 }
 
+bool scsiDiskFilenameValid(const char* name)
+{
+    // Check file extension
+    const char *extension = strrchr(name, '.');
+    if (extension)
+    {
+        const char *ignore_exts[] = {
+            ".rom_loaded", ".cue",
+            NULL
+        };
+        const char *archive_exts[] = {
+            ".tar", ".tgz", ".gz", ".bz2", ".tbz2", ".xz", ".zst", ".z",
+            ".zip", ".zipx", ".rar", ".lzh", ".lha", ".lzo", ".lz4", ".arj",
+            ".dmg", ".hqx", ".cpt", ".7z", ".s7z",
+            NULL
+        };
+
+        for (int i = 0; ignore_exts[i]; i++)
+        {
+            if (strcasecmp(extension, ignore_exts[i]) == 0)
+            {
+                // ignore these without log message
+                return false;
+            }
+        }
+        for (int i = 0; archive_exts[i]; i++)
+        {
+            if (strcasecmp(extension, archive_exts[i]) == 0)
+            {
+                logmsg("-- Ignoring compressed file ", name);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 // Set target configuration to default values
 static void scsiDiskConfigDefaults(int target_idx)
 {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -567,9 +567,6 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 
     if (img.image_directory)
     {
-        // is this needed to prevent an inadvertent callback during all these opens?
-        platform_set_sd_callback(NULL, NULL);
-
         // image directory was found during startup
         FsFile dir;
         char key[] = "ImgDir";

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -99,7 +99,8 @@ void scsiDiskCloseSDCardImages();
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED);
 void scsiDiskLoadConfig(int target_idx);
 
-// During loading, checks if a filename is appropriate for further processing as a disk image
+// Checks if a filename extension is appropriate for further processing as a disk image.
+// The current implementation does not check the the filename prefix for validity.
 bool scsiDiskFilenameValid(const char* name);
 
 // Clear the ROM drive header from flash

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -32,6 +32,7 @@
 #include <scsi2sd.h>
 #include <scsiPhy.h>
 #include "ImageBackingStore.h"
+#include "ZuluSCSI_config.h"
 
 extern "C" {
 #include <disk.h>
@@ -65,6 +66,8 @@ struct image_config_t: public S2S_TargetCfg
 
     // True if there is a subdirectory of images for this target
     bool image_directory;
+    // the name of the currently mounted image in a dynamic image directory
+    char current_image[MAX_FILE_PATH] = {'\0'};
     // Index of image, for when image on-the-fly switching is used for CD drives
     uint8_t image_index = IMAGE_INDEX_MAX;
 

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -67,9 +67,9 @@ struct image_config_t: public S2S_TargetCfg
     // True if there is a subdirectory of images for this target
     bool image_directory;
     // the name of the currently mounted image in a dynamic image directory
-    char current_image[MAX_FILE_PATH] = {'\0'};
+    char current_image[MAX_FILE_PATH];
     // Index of image, for when image on-the-fly switching is used for CD drives
-    uint8_t image_index = IMAGE_INDEX_MAX;
+    uint8_t image_index;
 
     // Cue sheet file for CD-ROM images
     FsFile cuesheetfile;

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -69,6 +69,7 @@ struct image_config_t: public S2S_TargetCfg
     // the name of the currently mounted image in a dynamic image directory
     char current_image[MAX_FILE_PATH];
     // Index of image, for when image on-the-fly switching is used for CD drives
+    // This is also used for dynamic directories to track how many images have been seen
     uint8_t image_index;
 
     // Cue sheet file for CD-ROM images

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -63,6 +63,8 @@ struct image_config_t: public S2S_TargetCfg
     // For tape drive emulation, current position in blocks
     uint32_t tape_pos;
 
+    // True if there is a subdirectory of images for this target
+    bool image_directory;
     // Index of image, for when image on-the-fly switching is used for CD drives
     uint8_t image_index = IMAGE_INDEX_MAX;
 

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -39,6 +39,8 @@ extern "C" {
 #include <scsi.h>
 }
 
+#define IMAGE_INDEX_MAX 9
+
 // Extended configuration stored alongside the normal SCSI2SD target information
 struct image_config_t: public S2S_TargetCfg
 {
@@ -62,7 +64,7 @@ struct image_config_t: public S2S_TargetCfg
     uint32_t tape_pos;
 
     // Index of image, for when image on-the-fly switching is used for CD drives
-    int image_index;
+    uint8_t image_index = IMAGE_INDEX_MAX;
 
     // Cue sheet file for CD-ROM images
     FsFile cuesheetfile;

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -93,6 +93,9 @@ void scsiDiskCloseSDCardImages();
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED);
 void scsiDiskLoadConfig(int target_idx);
 
+// During loading, checks if a filename is appropriate for further processing as a disk image
+bool scsiDiskFilenameValid(const char* name);
+
 // Clear the ROM drive header from flash
 bool scsiDiskClearRomDrive();
 // Program ROM drive and rename image file

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -40,8 +40,6 @@ extern "C" {
 #include <scsi.h>
 }
 
-#define IMAGE_INDEX_MAX 9
-
 // Extended configuration stored alongside the normal SCSI2SD target information
 struct image_config_t: public S2S_TargetCfg
 {

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -108,9 +108,11 @@ bool scsiDiskActivateRomDrive();
 // Returns true if there is at least one image active
 bool scsiDiskCheckAnyImagesConfigured();
 
-// Check if image file name is overridden in config,
-// including image index for multi-image CD-ROM emulation
-bool scsiDiskGetImageNameFromConfig(image_config_t &img, char *buf, size_t buflen);
+// Gets the next image filename for the target, if configured for multiple
+// images. As a side effect this advances image tracking to the next image.
+// Returns the length of the new image filename, or 0 if the target is not
+// configured for multiple images.
+int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen);
 
 // Get pointer to extended image configuration based on target idx
 image_config_t &scsiDiskGetImageConfig(int target_idx);


### PR DESCRIPTION
Proposal to resolve #218 by adding an .ini file option called 'ImgDir' to read images out of a directory at runtime. This implementation follows the approach @PetteriAimonen outlined in the associated issue. It should also give a structure for supporting ini-free configuration in the future.

Basic image iteration works, including ejection events. However, there are  parts (like directory naming) that are incomplete and testing has not yet been completed on different operating systems. If this approach seems workable, I'll continue to develop this and mark it as ready for merging once issues are fixed.