### PR TITLE
Fix regression in CD-ROM READ(6) command (#231)

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1741,6 +1741,7 @@ extern "C" int scsiCDRomCommand()
             (((uint32_t) scsiDev.cdb[2]) << 8) +
             scsiDev.cdb[3];
         uint32_t blocks = scsiDev.cdb[4];
+        if (blocks == 0) blocks = 256;
 
         doReadCD(lba, blocks, 0, 0x10, 0, true);
     }


### PR DESCRIPTION
Block count of 0 means 256 blocks in SCSI READ(6) command. This bug was introduced in commit fcac5ae and is present in versions 2023-05-24 and 2023-05-25.