### PR TITLE
CDROM: Fix START STOP UNIT preventing drive use

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1520,11 +1520,6 @@ extern "C" int scsiCDRomCommand()
                 cdromPerformEject(img);
             }
         }
-        else
-        {
-            // flow through to disk handler
-            commandHandled = 0;
-        }
     }
     else if (command == 0x25)
     {


### PR DESCRIPTION
This fixes an issue I observed where two different Macs would issue a START STOP UNIT with LoEj=0,Start=0 to stop a virtual CD-ROM drive during restart but never try to reinitialize the drive afterwards. This makes it look like the device has "disappeared" until it is power cycled.

I also tested this on a modern Linux system using `sg3_utils` against an older Matshita drive. Executing START STOP UNIT as above the unit would just spin down in response and continue to indicate a good condition to TEST UNIT READY as long as a disk was in the drive. Media commands issued while in this state would cause it to spin back up again without a matching START STOP UNIT command with Start=1.

To be candid, I'm not 100% confident that the above tests are robust: there may be a re-initialization issue for the device during bus reset or a Linux driver interfering with the utility tests.