### PR TITLE
Fix CD-ROM leadout LBA with BIN/CUE images

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -229,7 +229,7 @@ static uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack)
         image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
         uint32_t lastTrackBlocks = (img.file.size() - lasttrack->file_offset)
                 / lasttrack->sector_length;
-        return lasttrack->track_start + lastTrackBlocks + 1;
+        return lasttrack->track_start + lastTrackBlocks;
     }
     else
     {


### PR DESCRIPTION
E.g. if the last track has 1000 sectors, the valid LBAs are 0 to 999 and the leadout should start at LBA 1000.

Without this Linux is trying to read 1 sector beyond the end of the image and gives some errors in dmesg about that.

@saybur Can you check if this makes sense?