### PR TITLE
Fix PhyMode=1(PIO) on ZuluSCSI GD32 V1.1 (fix #245)

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -190,6 +190,7 @@ extern SdioConfig g_sd_sdio_config_crash;
 
 // Check if a DMA request for SD card read has completed.
 // This is used to optimize the timing of data transfers on SCSI bus.
+// When called outside of SD callback processing, always returns false.
 bool check_sd_read_done();
 
 #endif

--- a/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
@@ -318,6 +318,8 @@ bool SdioCard::readSectors(uint32_t sector, uint8_t* dst, size_t n)
 // This is used to optimize the timing of data transfers on SCSI bus.
 bool check_sd_read_done()
 {
+    if (!m_stream_callback) return false;
+
     return (DMA_CHCTL(DMA1, DMA_CH3) & DMA_CHXCTL_CHEN)
         && (DMA_INTF(DMA1) & DMA_FLAG_ADD(DMA_FLAG_FTF, DMA_CH3));
 }


### PR DESCRIPTION
With the GD32 SDIO driver, check_sd_read_done() was returning true even when no SD card read was in progress. This is because unlike the SPI driver, the SDIO driver does not disable the DMA channel.

Also fixed a bug where scsiIsWriteFinished() erroneously returned true on this early return, causing this to be a data corruption instead of a hang.

Only affects GD32 V1.1 platform when PhyMode=1 setting is specified in zuluscsi.ini.