### PR TITLE
RP2040 SDIO: Increase stopTransmission timeout.

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -263,7 +263,7 @@ bool SdioCard::stopTransmission(bool blocking)
     }
     else
     {
-        uint32_t end = millis() + 100;
+        uint32_t end = millis() + 5000;
         while (millis() < end && isBusy())
         {
             if (m_stream_callback)
@@ -421,6 +421,8 @@ bool SdioCard::writeSectors(uint32_t sector, const uint8_t* src, size_t n)
     }
     else
     {
+        // TODO: Instead of CMD12 stopTransmission command, according to SD spec we should send stopTran token.
+        // stopTransmission seems to work in practice.
         return stopTransmission(true);
     }
 }


### PR DESCRIPTION
Some cards were taking longer to respond after a large amount of writes.

While reviewing SDIO spec, it appears that this should actually be using "Stop Tran token" instead of "Stop Transmission command". It appears to work well so far though so only made the minimal timeout change.