### PR TITLE
ZuluSCSI GD32 V1.1: Fix PhyMode=2 (DMA_TIMER) with AHA2940UW

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
@@ -369,6 +369,17 @@ extern "C" void SCSI_TIMER_DMACHB_IRQ()
         }
         else
         {
+            // Wait for final ACK to go low, shouldn't take long.
+            int maxwait = 10000;
+            while (TIMER_CNT(SCSI_TIMER) < 1)
+            {
+                if (maxwait-- < 0)
+                {
+                    logmsg("SCSI_TIMER_DMACHB_IRQ: timeout waiting for final ACK");
+                    break;
+                }
+            }
+
             // No more data available
             stop_dma();
         }


### PR DESCRIPTION
On V1.1, PhyMode 2 could terminate transfer before last ack from host was received. In practice this happened if host waited more than 2 µs after the last REQ. This resulted in watchdog timeouts in the logs.

This has occurred in particular with AHA2940UW, where the SCSI MESSAGE_IN phase has up to 18 µs delay from the host.