### PR TITLE
Fix a timing issue on the v1.1 in TIMER_DMA mode

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -75,6 +75,7 @@ build_flags =
      -DENABLE_DEDICATED_SPI=1
      -DHAS_SDIO_CLASS
      -DZULUSCSI_V1_1
+     -DPREFETCH_BUFFER_SIZE=4096
 
 ; ZuluSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
 [env:ZuluSCSI_RP2040]


### PR DESCRIPTION
When reading from the ZuluSCSI v1.1 in PhyMode=2 (TIMER_DMA), the ZuluSCSI will hit a  "start_dataInTransfer() timeout waiting for previous to finish" error. This will hang a LC III and seems to cause a data error when reading via dd on a Linux machine.

It seems that if there are around 16 sectors in the prefetch buffer the above error occurs. Halving the PREFETCH_BUFFER from 8k to 4k seems to resolve this issue without a noticeable speed reduction.

It should be noted that in it's default configuration with a GreenPAK laid down, this does not occur. Thus there maybe a better way to resolve this issue than limiting the PREFETCH_BUFFER across the board for the ZuluSCSI v1.1.