### PR TITLE
Temporary fix for DMA_TIMER mode on ZuluSCSI v1.1

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsi_accel_dma.cpp
@@ -21,6 +21,8 @@
 
 #include "scsi_accel_dma.h"
 #include <ZuluSCSI_log.h>
+#include <ZuluSCSI_disk.h>
+#include <scsi2sd.h>
 #include <gd32f20x_timer.h>
 #include <gd32f20x_rcu.h>
 #include <assert.h>
@@ -67,6 +69,20 @@ static bool g_scsi_dma_use_greenpak;
 
 void scsi_accel_timer_dma_init()
 {
+    // TODO: find root cause of of DMA timeout
+    // Temporary fix, setting prefetch prefetch buffer to 4k seems to fix a timing issue
+    // in Timer DMA SCSI phy mode only
+    
+    image_config_t* img;
+    for (uint8_t i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        img = &scsiDiskGetImageConfig(i);
+        if (img->prefetchbytes > 4096)
+        {
+            img->prefetchbytes = 4096;
+        }
+    }
+
     g_scsi_dma_state = SCSIDMA_IDLE;
     g_scsi_dma_use_greenpak = false;
     rcu_periph_clock_enable(SCSI_TIMER_RCU);


### PR DESCRIPTION
The ZuluSCSI v1.1 in DMA_TIMER mode would only boot to the Welcome screen before freezing on a Mac LC III. Setting the prefetch buffer to 4k seems to fix the issue, but doesn't address the root cause.

This fix sets the limit of the prefetch buffer to 4k only in, PhyMode = 2, DMA_TIMER mode, so the other modes can take advantage of of the full size of the prefetch buffer.