### PR TITLE
Fixes for Apple vendor modepage sending

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -516,10 +516,8 @@ static void doModeSense(
 
 	idx += modeSenseCDCapabilitiesPage(pc, idx, pageCode, &pageFound);
 
-	if ((
-			(scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE) ||
-			(idx + sizeof(AppleVendorPage) <= allocLength)
-		) &&
+	if ((scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE) &&
+	    (idx + sizeof(AppleVendorPage) <= allocLength) &&
 		(pageCode == 0x30 || pageCode == 0x3F))
 	{
 		pageFound = 1;

--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -242,8 +242,8 @@ static const uint8_t SequentialDeviceConfigPage[] =
 static const uint8_t AppleVendorPage[] =
 {
 0x30, // Page code
-23, // Page length
-'A','P','P','L','E',' ','C','O','M','P','U','T','E','R',',',' ','I','N','C',' ',' ',' ',0x00
+0x16, // Page length
+'A','P','P','L','E',' ','C','O','M','P','U','T','E','R',',',' ','I','N','C',' ',' ',' '
 };
 
 static void pageIn(int pc, int dataIdx, const uint8_t* pageData, int pageLen)


### PR DESCRIPTION
There was a bug in ModeSense implementation that caused Apple vendor modepage 0x30 to be sent even when quirks were set to 0. This bug remains in SCSI2SDv6, but was earlier fixed in SCSI2SDv5. In ZuluSCSI code, the bug was masked by an extra 0x00 at the end of the modepage constant, which caused the length check to be negative in most cases.

The changes made here did not improve behavior in #272, but I think this is more correct and should work the same on most systems.

Requires testing on a Mac that cares about 0x30 modepage for CD-ROM before merging. Not sure which systems do this, Mac LC III does not seem to care.