### PR TITLE
RP2040 Initiator mode: set initiator ID in selection phase (#262, #264)

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
@@ -86,12 +86,15 @@ bool scsiHostPhySelect(int target_id)
         }
     }
 
+    // Choose initiator ID different than target ID
+    uint8_t initiator_id = (target_id == 7) ? 0 : 7;
+
     // Selection phase
     scsiLogInitiatorPhaseChange(SELECTION);
-    dbgmsg("------ SELECTING ", target_id);
+    dbgmsg("------ SELECTING ", target_id, " with initiator ID ", (int)initiator_id);
     SCSI_OUT(SEL, 1);
     delayMicroseconds(5);
-    SCSI_OUT_DATA(1 << target_id);
+    SCSI_OUT_DATA((1 << target_id) | (1 << initiator_id));
     delayMicroseconds(5);
     SCSI_OUT(BSY, 0);
 


### PR DESCRIPTION
Previously initiator mode only set the target ID bit on the SCSI bus in selection phase. Some Quantum Fireball drives did not respond to this.

This commit selects either 0 or 7 as the initiator ID, based on which is left free after the target ID.