### PR TITLE
Post UNIT_ATTENTION condition after CD medium change (fixes #247)

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1157,6 +1157,12 @@ void cdromCloseTray(image_config_t &img)
         dbgmsg("------ CDROM close tray on ID ", (int)target);
         img.ejected = false;
         img.cdrom_events = 2; // New media
+
+        if (scsiDev.boardCfg.flags & S2S_CFG_ENABLE_UNIT_ATTENTION)
+        {
+            dbgmsg("------ Posting UNIT ATTENTION after medium change");
+            scsiDev.targets[target].unitAttention = NOT_READY_TO_READY_TRANSITION_MEDIUM_MAY_HAVE_CHANGED;
+        }
     }
 }
 


### PR DESCRIPTION
Some hosts require separate unit_attention status response `0x2800 Medium may have changed` to detect a changed CD image.
Previously only `0x3A00 Medium Not Present` was sent through `Test Unit Ready` response.

By default unit attention is disabled in ZuluSCSI, so this edit doesn't change anything.
It's can be enabled in config together with the other unit attention conditions (boot and SD card change):

```
[SCSI]
EnableUnitAttention = 1
```