### PR TITLE
Log Xebec vendor command and decoded data

### DIFF
--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -175,6 +175,9 @@ static void printNewPhase(int phase, bool initiator = false)
             if (!initiator && scsiDev.target->syncOffset > 0)
                 dbgmsg("---- DATA_OUT, syncOffset ", (int)scsiDev.target->syncOffset,
                                     " syncPeriod ", (int)scsiDev.target->syncPeriod);
+	    // log Xebec vendor commands data
+	    else if (scsiDev.cdb[0] == 0x0C || scsiDev.cdb[0] == 0x0F)
+		    g_LogData = true;
             else
                 dbgmsg("---- DATA_OUT");
             break;
@@ -207,6 +210,17 @@ void scsiLogPhaseChange(int new_phase)
         {
             dbgmsg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
         }
+	// log Xebec vendor command
+        if (old_phase == DATA_OUT && scsiDev.cdb[0] == 0x0C && g_OutByteCount == 8)
+	{
+		int cylinders = ((uint16_t)scsiDev.data[0] << 8) + scsiDev.data[1];
+		int heads = scsiDev.data[2];
+		int reducedWrite = ((uint16_t)scsiDev.data[3] << 8) + scsiDev.data[4];
+		int writePrecomp = ((uint16_t)scsiDev.data[5] << 8) + scsiDev.data[6];
+		int eccBurst = scsiDev.data[7];
+		dbgmsg("---- Xebec Initialize Drive Characteristics: cylinders=", cylinders, " heads=", heads,
+				" reducedWrite=", reducedWrite, " writePrecomp=", writePrecomp, " eccBurst=", eccBurst);
+	}
         g_InByteCount = g_OutByteCount = 0;
         g_DataChecksum = 0;
 


### PR DESCRIPTION
I'm not sure if this is the best place to put this. The only other possibly better place is in SCSI2SD in the DATA_OUT callback function, but that is part of the library and so can't access the log functions. I'm also not sure if I need to add a check somewhere if debug logging is enabled.