### PR TITLE
Initiator mode updates

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/rp2040.ld
+++ b/lib/ZuluSCSI_platform_RP2040/rp2040.ld
@@ -22,7 +22,7 @@
 MEMORY
 {
     FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 352k
-    RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 240k  /* Leave space for pico-debug */
+    RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 256k  /* Leave space for pico-debug */
     SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
 }

--- a/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.cpp
@@ -62,9 +62,9 @@ void scsiHostPhyReset(void)
     g_scsiHostPhyReset = false;
 }
 
-// Select a device, id 0-7.
+// Select a device and an initiator, ids 0-7.
 // Returns true if the target answers to selection request.
-bool scsiHostPhySelect(int target_id)
+bool scsiHostPhySelect(int target_id, uint8_t initiator_id)
 {
     SCSI_RELEASE_OUTPUTS();
 
@@ -85,9 +85,6 @@ bool scsiHostPhySelect(int target_id)
             return false;
         }
     }
-
-    // Choose initiator ID different than target ID
-    uint8_t initiator_id = (target_id == 7) ? 0 : 7;
 
     // Selection phase
     scsiLogInitiatorPhaseChange(SELECTION);

--- a/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.h
+++ b/lib/ZuluSCSI_platform_RP2040/scsiHostPhy.h
@@ -34,8 +34,10 @@ extern volatile int g_scsiHostPhyReset;
 void scsiHostPhyReset(void);
 
 // Select a device, id 0-7.
+// target_id - target device id 0-7
+// initiator_id - host device id 0-7
 // Returns true if the target answers to selection request.
-bool scsiHostPhySelect(int target_id);
+bool scsiHostPhySelect(int target_id, uint8_t initiator_id);
 
 // Read the current communication phase as signaled by the target
 // Matches SCSI_PHASE enumeration from scsi.h.

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,6 +98,7 @@ lib_deps =
     ZuluSCSI_platform_RP2040
     SCSI2SD
     CUEParser
+debug_build_flags = -O2 -ggdb -g3
 build_flags =
     -O2 -Isrc -ggdb -g3
     -Wall -Wno-sign-compare -Wno-ignored-qualifiers

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -560,10 +560,14 @@ bool scsiRequestSense(int target_id, uint8_t *sense_key)
 // Execute UNIT START STOP command to load/unload media
 bool scsiStartStopUnit(int target_id, bool start)
 {
-    uint8_t command[6] = {0x1B, 0, 0, 0, 0, 0};
+    uint8_t command[6] = {0x1B, 0x1, 0, 0, 0, 0};
     uint8_t response[4] = {0};
 
-    if (start) command[4] |= 1;
+    if (start)
+    {
+        command[4] |= 1; // Start
+        command[1] = 0;  // Immediate
+    }
 
     int status = scsiInitiatorRunCommand(target_id,
                                          command, sizeof(command),

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -201,11 +201,11 @@ void scsiInitiatorMainLoop()
                 if (total_bytes >= 0xFFFFFFFF && SD.fatType() != FAT_TYPE_EXFAT)
                 {
                     // Note: the FAT32 limit is 4 GiB - 1 byte
-                    logmsg("Image files equal or larger than 4 GiB are only possible on exFAT filesystem");
-                    logmsg("Please reformat the SD card with exFAT format to image this drive fully");
-
-                    g_initiator_state.sectorcount = (uint32_t)0xFFFFFFFF / g_initiator_state.sectorsize;
-                    logmsg("Will image first 4 GiB - 1 = ", (int)g_initiator_state.sectorcount, " sectors");
+                    logmsg("Target SCSI ID ", g_initiator_state.target_id, " image size is equal or larger than 4 GiB.");
+                    logmsg("This is larger than the max filesize supported by SD card's filesystem");
+                    logmsg("Please reformat the SD card with exFAT format to image this target");
+                    g_initiator_state.drives_imaged |= 1 << g_initiator_state.target_id;
+                    return;
                 }
             }
             else if (startstopok)
@@ -312,7 +312,7 @@ void scsiInitiatorMainLoop()
                 {
                     logmsg("SD Card only has ", (int)(sd_card_free_bytes / (1024 * 1024)),
                            " MiB - not enough free space to image SCSI ID ", g_initiator_state.target_id);
-                    g_initiator_state.drives_imaged = 1 << g_initiator_state.target_id;
+                    g_initiator_state.drives_imaged |= 1 << g_initiator_state.target_id;
                     return;
                 }
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -31,7 +31,7 @@
 #DisableROMDrive = 1 # Disable the ROM drive if it has been loaded to flash
 #ROMDriveSCSIID = 7 # Override ROM drive's SCSI ID
 
-#Initiaor settings
+#Initiator settings
 #InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
 #InitiatorImageHandling = 0 # 0: skip exisitng images, 1: create new image with incrementing suffix, 2: overwrite exising image
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -31,6 +31,10 @@
 #DisableROMDrive = 1 # Disable the ROM drive if it has been loaded to flash
 #ROMDriveSCSIID = 7 # Override ROM drive's SCSI ID
 
+#Initiaor settings
+#InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
+#InitiatorImageHandling = 0 # 0: skip exisitng images, 1: create new image with incrementing suffix, 2: overwrite exising image
+
 # Settings that can be specified either per-device or for all devices.
 #Vendor = "QUANTUM"
 #Product = "FIREBALL1"


### PR DESCRIPTION
## Changes to initiator mode

Added settings to zuluscsi.ini

> [SCSI]
> #Initiator settings
> InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
> InitiatorImageHandling = 0 # 0: skip exisitng images, 1: create new image with incrementing suffix, 2: overwrite exising image

Added check against the size of the target image to the free space on the SD card

Changed behavior of checking 4GB file size limit of non exFAT file systems. 
Instead of attempting to truncate image to 4GB, it now skips the target 

Does an immediate stop request when done imaging a target