### PR TITLE
Fix out of SRAM compile time issue

### DIFF
--- a/lib/SCSI2SD/src/firmware/log.h
+++ b/lib/SCSI2SD/src/firmware/log.h
@@ -14,14 +14,32 @@
 //
 //	You should have received a copy of the GNU General Public License
 //	along with SCSI2SD.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef SCSI2SD_LOG_H
+#define SCSI2SD_LOG_H
+#include <stdbool.h>
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+extern bool g_log_debug;
+
 extern void logmsg_buf(const unsigned char *buf, unsigned long size);
 extern void logmsg_f(const char *format, ...);
+
+extern void dbgmsg_buf(const unsigned char *buf, unsigned long size);
+extern void dbgmsg_f(const char *format, ...);
+
+// check if debug is enabled before calling the logging function
+#define DBGMSG_BUF(buf, size) \
+	if (g_log_debug) {dbgmsg_buf(buf, size);}
+
+#define DBGMSG_F(format, ...) \
+	if (g_log_debug) {dbgmsg_f(format, __VA_ARGS__);}
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif // SCSI2SD_LOG_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -166,7 +166,7 @@ build_flags =
     -DZULUSCSI_DAYNAPORT
 ; These take a large portion of the SRAM and can be adjusted
     -DLOGBUFSIZE=8192
-    -DPREFETCH_BUFFER_SIZE=7168
+    -DPREFETCH_BUFFER_SIZE=8192
     -DSCSI2SD_BUFFER_SIZE=57344
     ; This controls the depth of 2 x NETWORK_PACKET_MAX_SIZE (1520 bytes)
     ; For example a queue size of 10 would be 10 x 2 x 1520 = 30400 bytes

--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -36,7 +36,7 @@ uint32_t log_get_buffer_len();
 const char *log_get_buffer(uint32_t *startpos, uint32_t *available = nullptr);
 
 // Whether to enable debug messages
-extern bool g_log_debug;
+extern "C" bool g_log_debug;
 
 // Firmware version string
 extern const char *g_log_firmwareversion;
@@ -107,8 +107,17 @@ extern "C" {
 #endif
 // Log long hex string
 void logmsg_buf(const unsigned char *buf, unsigned long size);
+
+// Log long hex string
+void dbgmsg_buf(const unsigned char *buf, unsigned long size);
+
 // Log formatted string
 void logmsg_f(const char *format, ...);
+
+// Log formatted string
+void dbgmsg_f(const char *format, ...);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Was able to coax enough SRAM free by rewriting the functions:
```
void logmsg_buf(const unsigned char *buf, unsigned long size);
void logmsg_f(const char *format, ...);
```
used in `lib/SCSI2SD/src/firmware/network.c` from `src/ZuluSCSI_log.h`. They now use a shared buffer. There is possibly more SRAM savings if the above methods wrote directly to the global log buffer.

Their debug equivalents have also been added
```
void dbgmsg_buf(const unsigned char *buf, unsigned long size);
void dbgmsg_f(const char *format, ...);
```

And C macros have been added to test `g_debug_log` before calling the equivalent functions to avoid making unnecessary function calls in `lib/SCSI2SD/src/firmware/log.h`:
```
DBGMSG_BUF()
DBGMSG_F()
```