### PR TITLE
Fix communication with Wi-Fi Desk Accessory

### DIFF
--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -36,6 +36,26 @@ extern "C" {
 
 #define NETWORK_PACKET_MAX_SIZE     1520
 
+struct __attribute__((packed)) wifi_network_entry {
+	char ssid[64];
+	char bssid[6];
+	int8_t rssi;
+	uint8_t channel;
+	uint8_t flags;
+#define WIFI_NETWORK_FLAG_AUTH 0x1
+	uint8_t _padding;
+};
+
+#define WIFI_NETWORK_LIST_ENTRY_COUNT 10
+extern struct wifi_network_entry wifi_network_list[WIFI_NETWORK_LIST_ENTRY_COUNT];
+
+struct __attribute__((packed)) wifi_join_request {
+	char ssid[64];
+	char key[64];
+	uint8_t channel;
+	uint8_t _padding;
+};
+
 int scsiNetworkCommand(void);
 int scsiNetworkEnqueue(const uint8_t *buf, size_t len);
 int scsiNetworkPurge(void);

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform_network.cpp
@@ -35,8 +35,6 @@ extern "C" {
 #define PICO_W_LONG_BLINK_DELAY 200
 #define PICO_W_SHORT_BLINK_DELAY 75
 
-struct wifi_network_entry wifi_network_list[WIFI_NETWORK_LIST_ENTRY_COUNT] = { 0 };
-
 // A default DaynaPort-compatible MAC
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
 
@@ -225,7 +223,7 @@ static int platform_network_wifi_scan_result(void *env, const cyw43_ev_scan_resu
 		entry->rssi = result->rssi;
 	}
 	if (result->auth_mode & 7)
-		entry->flags = WIFI_NETWORK_FLAGS_AUTH;
+		entry->flags = WIFI_NETWORK_FLAG_AUTH;
 	strncpy(entry->ssid, (const char *)result->ssid, sizeof(entry->ssid));
 	entry->ssid[sizeof(entry->ssid) - 1] = '\0';
 	memcpy(entry->bssid, result->bssid, sizeof(entry->bssid));

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform_network.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform_network.h
@@ -24,26 +24,6 @@
 extern "C" {
 #endif
 
-struct __attribute__((packed)) wifi_network_entry {
-	char ssid[64];
-	char bssid[6];
-	int8_t rssi;
-	uint8_t channel;
-	uint8_t flags;
-	uint8_t _padding;
-#define WIFI_NETWORK_FLAGS_AUTH 0x1
-};
-
-#define WIFI_NETWORK_LIST_ENTRY_COUNT 10
-extern struct wifi_network_entry wifi_network_list[WIFI_NETWORK_LIST_ENTRY_COUNT];
-
-struct __attribute__((packed)) wifi_join_request {
-	char ssid[64];
-	char key[64];
-	uint8_t channel;
-	uint8_t _padding;
-};
-
 bool platform_network_supported();
 void platform_network_poll();
 int platform_network_init(char *mac);

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -394,7 +394,7 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int
             return false;
         }
         uint32_t sector_begin = 0, sector_end = 0;
-        if (img.file.isRom())
+        if (img.file.isRom() || type == S2S_CFG_NETWORK)
         {
             // ROM is always contiguous, no need to log
         }
@@ -458,7 +458,11 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int
 
         setDefaultDriveInfo(target_idx);
 
-        if (img.prefetchbytes > 0)
+        if (type == S2S_CFG_NETWORK)
+        {
+            // prefetch not used, skip emitting log message
+        }
+        else if (img.prefetchbytes > 0)
         {
             logmsg("---- Read prefetch enabled: ", (int)img.prefetchbytes, " bytes");
         }


### PR DESCRIPTION
Added changes from the original commit to the DaynaPort code and the latest pull request to get Wi-Fi Desk Accessory to communicate with the ZuluSCSI Pico.

Also fixed emitting erroneous log messages when a network device is being emulated.