### PR TITLE
Apply ZigZagJoe's patch to fix initiator mode

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -767,7 +767,9 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
 {
     int status = -1;
 
-    if (start_sector < 0xFFFFFF && sectorcount <= 256)
+    // Read6 command supports 21 bit LBA - max of 0x1FFFFF
+    // ref: https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf pg 134
+    if (start_sector < 0x1FFFFF && sectorcount <= 256)
     {
         // Use READ6 command for compatibility with old SCSI1 drives
         uint8_t command[6] = {0x08,


### PR DESCRIPTION
Applying @ZigZagJoe patch from issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/330

Quote from the issue:
> ZuluSCSI currently handles oddly sized drives >1GB incorrectly in initiator mode.
> 
> Scenario: IBM DCAS32160 - 4226725 sectors in length. As this is not evenly divisible by 512 (g_initiator_state.max_sector_per_transfer), it trys to use READ(6) rather than READ(10) to read the last 165 sectors. However, READ(6) has a maximum sector of 0x1FFFFF (21 bits), but the code is checking start_sector < 0xFFFFFF (24 bits). This results in failure to read each of these remaining 165 sectors and an incomplete image.
> 
> Verified issue is corrected when checking for start_sector < 0x1FFFFF for READ(6) path.