### PR TITLE
Fix SD card IO timeout wrapping

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -263,8 +263,8 @@ bool SdioCard::stopTransmission(bool blocking)
     }
     else
     {
-        uint32_t end = millis() + 5000;
-        while (millis() < end && isBusy())
+        uint32_t start = millis();
+        while ((uint32_t)(millis() - start) < 5000 && isBusy())
         {
             if (m_stream_callback)
             {


### PR DESCRIPTION
Fix for issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/328

This should fix the issue, though it hasn't been tested.

Thank you @carlk3 for doing some code review.