### PR TITLE
Add X68000 and MegaSTE detection, and fix logic error

### DIFF
--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "23.11.13"
+#define FW_VER_NUM      "23.11.20"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -1,8 +1,8 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2023 Rabbit Hole Computing™
+ * Copyright (c) 2023 Eric Helgeson
  * 
  * This file is licensed under the GPL version 3 or any later version.  
- * It is derived from scsiPhy.c in SCSI2SD V6.
  * 
  * https://www.gnu.org/licenses/gpl-3.0.html
  * ----
@@ -33,7 +33,7 @@
 // SCSI system and device settings
 ZuluSCSISettings g_scsi_settings;
 
-const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000"};
+const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000"};
 const char *devicePresetName[] = {"", "ST32430N"};
 
 // Helper function for case-insensitive string compare
@@ -294,17 +294,17 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
 
     // System-specific defaults
 
-    if (strequals(systemPresetName[SYS_PRESET_NONE], ""))
+    if (strequals(systemPresetName[SYS_PRESET_NONE], presetName))
     {
         // Preset name is empty, use default configuration
         m_sysPreset = SYS_PRESET_NONE;
     }
-    else if (strequals(systemPresetName[SYS_PRESET_MAC], "Mac"))
+    else if (strequals(systemPresetName[SYS_PRESET_MAC], presetName))
     {
         m_sysPreset = SYS_PRESET_MAC;
         cfgSys.quirks = S2S_CFG_QUIRKS_APPLE;
     }
-    else if (strequals(systemPresetName[SYS_PRESET_MACPLUS], "MacPlus"))
+    else if (strequals(systemPresetName[SYS_PRESET_MACPLUS], presetName))
     {
         m_sysPreset = SYS_PRESET_MACPLUS;
         cfgSys.quirks = S2S_CFG_QUIRKS_APPLE;
@@ -312,9 +312,25 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
         cfgSys.enableSCSI2 = false;
         cfgSys.selectionDelay = 0;
     }
-    else if (strequals(systemPresetName[SYS_PRESET_MPC3000], "MPC3000"))
+    else if (strequals(systemPresetName[SYS_PRESET_MPC3000], presetName))
     {
+        m_sysPreset = SYS_PRESET_MPC3000;
         cfgSys.initPreDelay = 600;
+    }
+    else if (strequals(systemPresetName[SYS_PRESET_MEGASTE], presetName))
+    {
+        m_sysPreset = SYS_PRESET_MEGASTE;
+        cfgSys.quirks = S2S_CFG_QUIRKS_NONE;
+        cfgSys.mapLunsToIDs = true;
+        cfgSys.enableParity = false;
+    }
+    else if (strequals(systemPresetName[SYS_PRESET_X68000], presetName))
+    {
+        m_sysPreset = SYS_PRESET_X68000;
+        cfgSys.selectionDelay = 0;
+        cfgSys.quirks = S2S_CFG_QUIRKS_NONE;
+        cfgSys.enableSCSI2 = false;
+        cfgSys.maxSyncSpeed = 5;
     }
     else
     {

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -1,8 +1,8 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2023 Rabbit Hole Computing™
+ * Copyright (c) 2023 Eric Helgeson
  * 
  * This file is licensed under the GPL version 3 or any later version.  
- * It is derived from scsiPhy.c in SCSI2SD V6.
  * 
  * https://www.gnu.org/licenses/gpl-3.0.html
  * ----
@@ -33,7 +33,9 @@ typedef enum
     SYS_PRESET_NONE = 0,
     SYS_PRESET_MAC,
     SYS_PRESET_MACPLUS,
-    SYS_PRESET_MPC3000
+    SYS_PRESET_MPC3000,
+    SYS_PRESET_MEGASTE,
+    SYS_PRESET_X68000
 } scsi_system_preset_t;
 
 typedef enum

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -3,7 +3,7 @@
 # Settings that apply to all SCSI IDs
 
 # Select a system preset to apply default settings
-# Known systems: "Mac", "MacPlus", "MPC3000"
+# Known systems: "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000"
 #System="Mac"
 
 #Debug = 0   # Same effect as DIPSW2, enables verbose log messages


### PR DESCRIPTION
All the system preset with the new centralized settings had a logic error where it wasn't matching the value set in the ini file. Applied a fix to this issue.

Added two new system presets:
 - MegaSTE
 - X68000

 The two presets were taken from:
 https://github.com/BlueSCSI/BlueSCSI-v2/commit/74236c8483c9cc0c1c482ac556c1024660d5d1bf
 https://github.com/BlueSCSI/BlueSCSI-v2/commit/be6d1adbbd64fb7de436efdb82d0d95c823124e8

 Co-authored-by: Eric Helgeson <erichelgeson@gmail.com>