### PR TITLE
Restore implicit device settings

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
@@ -101,7 +101,7 @@ void HardwareConfig::init_state(bool is_active)
         m_blocksize = RAW_FALLBACK_BLOCKSIZE;
     }
 
-//    initDeviceSettingsPreset(m_scsi_id, m_device_preset);
+
 }
 
 #endif // ZULUSCSI_HARDWARE_CONFIG

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,6 +147,16 @@ board_build.core = earlephilhower
 extra_scripts = src/build_bootloader.py
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2040/rp2040_btldr.ld
 board_build.ldscript = lib/ZuluSCSI_platform_RP2040/rp2040-daynaport.ld
+debug_tool = cmsis-dap
+debug_build_flags =
+    -O2 -ggdb -g3
+    -DLOGBUFSIZE=4096
+    -DPREFETCH_BUFFER_SIZE=0
+    -DSCSI2SD_BUFFER_SIZE=57344
+    ; This controls the depth of 2 x NETWORK_PACKET_MAX_SIZE (1520 bytes)
+    ; For example a queue size of 10 would be 10 x 2 x 1520 = 30400 bytes
+    -DNETWORK_PACKET_QUEUE_SIZE=10
+
 lib_deps =
     SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.0-gpt
     minIni

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -497,6 +497,7 @@ bool findHDDImages()
         if (is_re) type = S2S_CFG_REMOVABLE;
         if (is_tp) type = S2S_CFG_SEQUENTIAL;
 
+        g_scsi_settings.initDevice(id & 7, type);
         // Open the image file
         if (id < NUM_SCSIID && is_romdrive)
         {
@@ -648,7 +649,7 @@ static void reinitSCSI()
   {
     bool success;
     uint8_t scsiId = g_hw_config.scsi_id();
-    g_scsi_settings.initDevicePreset(scsiId, g_hw_config.device_preset());
+    g_scsi_settings.initDevice(scsiId, g_hw_config.device_type());
 
     logmsg("Direct/Raw mode enabled, using hardware switches for configuration");
     success = scsiDiskOpenHDDImage(scsiId, "RAW:0:0xFFFFFFFF",scsiId, 0,
@@ -681,6 +682,7 @@ static void reinitSCSI()
     {
   #ifdef RAW_FALLBACK_ENABLE
       logmsg("No images found, enabling RAW fallback partition");
+      g_scsi_settings.initDevice(RAW_FALLBACK_SCSI_ID, S2S_CFG_FIXED);
       scsiDiskOpenHDDImage(RAW_FALLBACK_SCSI_ID, "RAW:0:0xFFFFFFFF", RAW_FALLBACK_SCSI_ID, 0,
                           RAW_FALLBACK_BLOCKSIZE);
   #else

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -510,6 +510,7 @@ static void scsiDiskSetConfig(int target_idx)
         tmp[2] += target_idx;
         scsiDiskCheckDir(tmp, target_idx, &img, S2S_CFG_FLOPPY_14MB, "floppy");
     }
+    g_scsi_settings.initDevice(target_idx, (S2S_CFG_TYPE)img.deviceType);
 }
 
 // Finds filename with the lowest lexical order _after_ the given filename in
@@ -707,28 +708,6 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 
 void scsiDiskLoadConfig(int target_idx)
 {
-    // Get values from system preset, if any
-    char presetName[32] = {};
-
-    // Get values from device preset, if any
-    char section[6] = "SCSI0";
-    section[4] = '0' + target_idx;
-#ifdef ZULUSCSI_HARDWARE_CONFIG
-    const char *hwDevicePresetName = g_scsi_settings.getDevicePresetName(target_idx);
-    if (g_hw_config.is_active())
-    {
-        if (strlen(hwDevicePresetName) < sizeof(presetName))
-        {
-            strncpy(presetName, hwDevicePresetName, sizeof(presetName) - 1);
-        }
-    }
-    else
-#endif
-    {
-        ini_gets(section, "Device", "", presetName, sizeof(presetName), CONFIGFILE);
-    }
-    g_scsi_settings.initDevicePName(target_idx, presetName);
-
     // Then settings specific to target ID
     scsiDiskSetConfig(target_idx);
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -141,6 +141,7 @@ bool scsiDiskActivateRomDrive()
     }
 
     logmsg("---- Activating ROM drive, SCSI id ", (int)hdr.scsi_id, " size ", (int)(hdr.imagesize / 1024), " kB");
+    g_scsi_settings.initDevice(hdr.scsi_id, hdr.drivetype);
     bool status = scsiDiskOpenHDDImage(hdr.scsi_id, "ROM:", hdr.scsi_id, 0, hdr.blocksize, hdr.drivetype);
 
     if (!status)

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -23,6 +23,7 @@
 #ifdef __cplusplus
 
 #include <stdint.h>
+#include <scsi2sd.h>
 
 // Index 8 is the system defaults
 // Index 0-7 represent device settings
@@ -102,8 +103,7 @@ public:
     // Copy any shared device setting done the initSystemSettings as default settings, 
     // or return the default config if unknown device type.
     // Then overwrite any settings with those in the CONFIGFILE
-    scsi_device_settings_t *initDevicePName(uint8_t scsiId, const char *presetName);
-    scsi_device_settings_t *initDevicePreset(uint8_t scsiId, const scsi_device_preset_t preset);
+    scsi_device_settings_t *initDevice(uint8_t scsiId, S2S_CFG_TYPE type);
     // return the system settings struct to read values
     scsi_system_settings_t *getSystem();
 
@@ -125,7 +125,7 @@ public:
 protected:
     // Set default drive vendor / product info after the image file
     // is loaded and the device type is known.
-    void setDefaultDriveInfo(uint8_t scsiId, const char *presetName);
+    void setDefaultDriveInfo(uint8_t scsiId, const char *presetName, S2S_CFG_TYPE type);
 
     // Settings for the specific device
     const char **deviceInitST32430N(uint8_t scsiId);


### PR DESCRIPTION
This is a fix for issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/340

The device type from a filename (e.g. NE5.img) and its implicit scsi vendor and model stings weren't being set after moving a lot off the SCSI settings code to ZuluSCSI_settings.cpp.

This fix addresses the issue. Although more effort, it might make sense to move more of the SCSI device setup to ZuluSCSI_settings.cpp like image discovery. The current fix just plugs into ZuluSCSI.cpp `findHDDImages()`.