### PR TITLE
DaynaPort: Only buffer one outbound packet 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -185,7 +185,7 @@ build_flags =
     -DPICO_CYW43_ARCH_POLL=1
 	-DCYW43_LWIP=0
 	-DCYW43_USE_OTP_MAC=0
-    -DPIO_FRAMEWORK_ARDUINO_NO_USB
+;    -DPIO_FRAMEWORK_ARDUINO_NO_USB
 
 ; Variant of RP2040 platform, based on Raspberry Pico board and a carrier PCB
 ; Differs in pinout from ZuluSCSI_RP2040 platform, but shares most of the code.


### PR DESCRIPTION
This PR changes to only buffer one packet outbound instead of NETWORK_PACKET_QUEUE_SIZE. If the buffer is full, it will block the SCSI bus temporarily in order to flush the packet (have not encountered this case yet).

**Consider this a PR for discussion** ... This needs to be verified on the fastest machine that supports daynaport (PowerPC of some denomination?), but it would provide quite a bit of relief to the SRAM congestion on the Daynaport target.

I performed some testing and found the outbound queue depth does not exceed 1 on either an accelerated SE/30 or Quadra 650@40mhz under ideal or worst case conditions. I found sending packets directly from scsiNetworkCommand seemed to work fine with a minor speed improvement, but I'm not sure what the longest acceptable time to perform work in the SCSI call is or worst case time of cyw43_send_ethernet as it is black box code with no documentation that I can find. I suspect the call simply buffers the packet into the Wifi SoC's SRAM... worst case time observed is about 0x12000 cycles as measured by rp2040.getCycleCount64(), best case around 0x4000. 

Ideal test conditions: AP a few feet from Quadra 650, with a wired computer downloading a file from the the Mac's web sharing. ~160KB/s mac->computer speed observed.

Worst case: Mac located as far away as possible without huge packet loss. ~60KB/s mac->computer speed observed.


