### PR TITLE
First stab at getting custom start end sectors

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -652,7 +652,20 @@ static void reinitSCSI()
     g_scsi_settings.initDevice(scsiId, g_hw_config.device_type());
 
     logmsg("Direct/Raw mode enabled, using hardware switches for configuration");
-    success = scsiDiskOpenHDDImage(scsiId, "RAW:0:0xFFFFFFFF",scsiId, 0,
+    char raw_filename[32];  
+    uint32_t start =  g_scsi_settings.getDevice(scsiId)->sectorSDBegin; 
+    uint32_t end = g_scsi_settings.getDevice(scsiId)->sectorSDEnd;
+
+    if (start == end && end == 0)
+    {
+      strcpy(raw_filename, "RAW:0:0xFFFFFFFF");
+    } 
+    else
+    {
+      snprintf(raw_filename, sizeof(raw_filename), "RAW:0x%X:0x%X", start, end);
+    }
+    
+    success = scsiDiskOpenHDDImage(scsiId, raw_filename, scsiId, 0,
                                    g_hw_config.blocksize(), g_hw_config.device_type());
     if (success)
     {

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -87,6 +87,8 @@ const char **ZuluSCSISettings::deviceInitST32430N(uint8_t scsiId)
 {
     static const char *st32430n[4] = {"SEAGATE", devicePresetName[DEV_PRESET_ST32430N], PLATFORM_REVISION, ""};
     m_dev[scsiId].deviceType = S2S_CFG_FIXED;
+    m_dev[scsiId].sectorSDBegin = 0;
+    m_dev[scsiId].sectorSDEnd = 4397055; // 2147MB into bytes and divide 512 - 1
     m_devPreset[scsiId] = DEV_PRESET_ST32430N;
     return st32430n;
 }
@@ -133,6 +135,7 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
     else if (g_hw_config.is_active() && g_hw_config.device_preset() ==  DEV_PRESET_ST32430N)
     {
         driveinfo = deviceInitST32430N(scsiId);
+        m_devPreset[scsiId] = DEV_PRESET_ST32430N;
         known_preset = true;
     }
     else
@@ -219,6 +222,9 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
     cfg.reinsertAfterEject = ini_getbool(section, "ReinsertAfterEject", cfg.reinsertAfterEject, CONFIGFILE);
     cfg.disableMacSanityCheck = ini_getbool(section, "DisableMacSanityCheck", cfg.disableMacSanityCheck, CONFIGFILE);
 
+    cfg.sectorSDBegin = ini_getl(section, "SectorSDBegin", cfg.sectorSDBegin, CONFIGFILE);
+    cfg.sectorSDEnd = ini_getl(section, "SectorSDEnd", cfg.sectorSDEnd, CONFIGFILE);
+
     char tmp[32];
     ini_gets(section, "Vendor", "", tmp, sizeof(tmp), CONFIGFILE);
     if (tmp[0])
@@ -294,6 +300,9 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgDev.reinsertOnInquiry = true;
     cfgDev.reinsertAfterEject = true;
     cfgDev.disableMacSanityCheck = false;
+
+    cfgDev.sectorSDBegin = 0;
+    cfgDev.sectorSDEnd = 0;
 
     // System-specific defaults
 

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -89,6 +89,9 @@ typedef struct __attribute__((__packed__)) scsi_device_settings_t
     bool reinsertOnInquiry;
     bool reinsertAfterEject;
     bool disableMacSanityCheck;
+
+    uint32_t sectorSDBegin;
+    uint32_t sectorSDEnd;
 } scsi_device_settings_t;
 
 
@@ -131,9 +134,9 @@ protected:
     const char **deviceInitST32430N(uint8_t scsiId);
 
     // Informative name of the preset configuration, or NULL for defaults
-    // The last presetName is for the System preset name. The rest are for
-    // corresponding SCSI Ids.
     scsi_system_preset_t m_sysPreset;
+    // The last preset is for the device specific under [SCSI] in the CONFIGFILE
+    // The rest are for corresponding SCSI Ids e.g. [SCSI0] in the CONFIGFILE.
     scsi_device_preset_t m_devPreset[8];
 
     // These are setting for host compatibility


### PR DESCRIPTION
This sets a custom end sector for the ZuluSCSI v1.2 ST32430N setting so the drive presents itself as the correct size.

Much larger changes are needed if they will be used in a ini file or save to flash and loaded on boot.