### PR TITLE
Update the ZuluSCSI v1.1+ firmware for the v1.2 launch

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -415,6 +415,7 @@ void platform_late_init()
         g_direct_mode = get_direct_mode(V1_2_DIPSW_DIRECT_MODE_PORT, V1_2_DIPSW_DIRECT_MODE_PIN, "DIPSW2");
         g_enable_apple_quirks = get_quirks(V1_2_DIPSW_QUIRKS_PORT, V1_2_DIPSW_QUIRKS_PIN, "DIPSW1");
         hw_config_init_state(g_direct_mode);
+
     }
 #else // PLATFORM_VERSION_1_1_PLUS - ZuluSCSI v1.0 and v1.0 minis gpio config
     #ifdef ZULUSCSI_V1_0_mini
@@ -426,6 +427,19 @@ void platform_late_init()
     #endif // ZULUSCSI_V1_0_mini
 #endif // PLATFORM_VERSION_1_1_PLUS
     
+}
+
+void platform_post_sd_card_init()
+{
+    #ifdef PLATFORM_VERSION_1_1_PLUS
+    if (ZSVersion_v1_2 == g_zuluscsi_version && g_scsi_settings.getSystem()->enableCDAudio)
+    {
+        logmsg("Audio enabled - an external audio DAC is required on the I2S expansion header");
+        init_audio_gpio();
+        g_audio_enabled = true;
+        audio_setup();
+    }
+    #endif
 }
 
 void platform_disable_led(void)
@@ -734,6 +748,20 @@ uint8_t platform_get_buttons()
     {
         buttons_debounced = 0;
     }
+
+#ifdef PLATFORM_VERSION_1_1_PLUS
+    if(g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2)
+    {
+        static uint8_t previous = 0x00;
+        uint8_t bitmask = buttons_debounced & USER_BTN_MASK;
+        uint8_t ejectors = (previous ^ bitmask) & previous;
+        previous = bitmask;
+        if (ejectors & USER_BTN_MASK)
+        {
+            logmsg("User button pressed - feature not yet implemented");
+        }
+    }
+#endif
 
     return buttons_debounced;
 }

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -104,6 +104,9 @@ void platform_init();
 // Initialization for main application, not used for bootloader
 void platform_late_init();
 
+// Initialization after the SD Card has been found
+void platform_post_sd_card_init();
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -281,6 +281,8 @@ void platform_late_init()
     greenpak_load_firmware();
 }
 
+void platform_post_sd_card_init() {}
+
 void platform_disable_led(void)
 {   
     gpio_mode_set(LED_PORT, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, LED_PINS);

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -86,6 +86,9 @@ void platform_init();
 // Initialization for main application, not used for bootloader
 void platform_late_init();
 
+// Initialization after the SD Card has been found
+void platform_post_sd_card_init();
+
 // Hooks
 void platform_end_of_loop_hook(void);
 

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -400,6 +400,8 @@ void platform_late_init()
     }
 }
 
+void platform_post_sd_card_init() {}
+
 bool platform_is_initiator_mode_enabled()
 {
     return g_scsi_initiator;

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.h
@@ -109,6 +109,9 @@ void platform_init();
 // Initialization for main application, not used for bootloader
 void platform_late_init();
 
+// Initialization after the SD Card has been found
+void platform_post_sd_card_init();
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.cpp
@@ -48,6 +48,13 @@ void platform_late_init()
      */
 }
 
+void platform_post_sd_card_init()
+{
+    /* This function can usually be left empty.
+     * It can be used for initialization code that should be run after the SD card is ready
+     */
+}
+
 void platform_disable_led(void)
 {
     /* This function disables the LED on the ZuluSCSI board

--- a/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_template/ZuluSCSI_platform.h
@@ -67,6 +67,9 @@ void platform_init();
 // Initialization for main application, not used for bootloader
 void platform_late_init();
 
+// Initialization after the SD Card has been found
+void platform_post_sd_card_init();
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -768,6 +768,7 @@ extern "C" void zuluscsi_setup(void)
       logmsg("Pre SCSI init boot delay in millis: ", boot_delay_ms);
       delay(boot_delay_ms);
     }
+    platform_post_sd_card_init();
     reinitSCSI();
     
     

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "23.12.08"
+#define FW_VER_NUM      "23.12.11"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -285,6 +285,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgSys.mapLunsToIDs = false;
     cfgSys.enableParity = true;
     cfgSys.useFATAllocSize = false;
+    cfgSys.enableCDAudio = false;
     
     // setting set for all or specific devices
     cfgDev.deviceType = S2S_CFG_NOT_SET;
@@ -373,7 +374,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgSys.mapLunsToIDs = ini_getbool("SCSI", "MapLunsToIDs", cfgSys.mapLunsToIDs, CONFIGFILE);
     cfgSys.enableParity =  ini_getbool("SCSI", "EnableParity", cfgSys.enableParity, CONFIGFILE);
     cfgSys.useFATAllocSize = ini_getbool("SCSI", "UseFATAllocSize", cfgSys.useFATAllocSize, CONFIGFILE);
-
+    cfgSys.enableCDAudio = ini_getbool("SCSI", "EnableCDAudio", cfgSys.enableCDAudio, CONFIGFILE);
     return &cfgSys;
 }
 

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -64,6 +64,7 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
     bool mapLunsToIDs;
     bool enableParity;
     bool useFATAllocSize;
+    bool enableCDAudio;
 } scsi_system_settings_t;
 
 // This struct should only have new setting added to the end

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -35,6 +35,8 @@
 #InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
 #InitiatorImageHandling = 0 # 0: skip exisitng images, 1: create new image with incrementing suffix, 2: overwrite exising image
 
+#EnableCDAudio = 0 # Enable CD audio - an external I2S DAC on the v1.2 is required
+
 # Settings that can be specified either per-device or for all devices.
 
 # Select a device preset to apply default settings


### PR DESCRIPTION
Some minor ZuluSCSI v1.2 pre-launch changes:
 - Emit log entry when user button is pressed
 - Add a `zuluscsi.ini` flag to enable audio on the v1.2 over I2S