### PR TITLE
Improvements for ZuluSCSI v1.2

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -343,7 +343,7 @@ static void set_termination(uint32_t port, uint32_t pin, const char *switch_name
     }
     else
     {
-        logmsg(switch_name, "is OFF: SCSI termination disabled");
+        logmsg(switch_name, " is OFF: Disabling SCSI termination");
     }
 }
 
@@ -351,9 +351,10 @@ static bool get_debug(uint32_t port, uint32_t pin, const char *switch_name)
 {
     if (gpio_input_bit_get(port, pin))
     {
-        logmsg(switch_name, " is ON: enabling debug messages");
+        logmsg(switch_name, " is ON: Enabling debug messages");
         return true;
     }
+    logmsg(switch_name, " is OFF: Disabling debug messages");
     return false;
 }
 
@@ -361,9 +362,10 @@ static bool get_quirks(uint32_t port, uint32_t pin, const char *switch_name)
 {
     if (gpio_input_bit_get(port, pin))
     {
-        logmsg(switch_name, " is ON: enabling Apple quirks by default");
+        logmsg(switch_name, " is ON: Enabling Apple quirks by default");
         return true;
     }
+    logmsg(switch_name, " is OFF: Disabling Apple quirks mode by default");
     return false;
 }
 

--- a/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
@@ -58,50 +58,50 @@ void HardwareConfig::init_gpios()
 void HardwareConfig::init_state(bool is_active)
 {
     m_is_active = is_active;
-    m_scsi_id = (gpio_input_port_get(DIPSW_SCSI_ID_BIT_PORT) & DIPSW_SCSI_ID_BIT_PINS) >> DIPSW_SCSI_ID_BIT_SHIFT;
-    m_device_preset = DEV_PRESET_NONE;
-    logmsg("SCSI ID set via DIP switch to ", m_scsi_id);
-    scsi_device_settings_t &cfg_dev = *g_scsi_settings.getDevice(m_scsi_id);
-
-    uint8_t rotary_select = (gpio_input_port_get(DIPROT_DEVICE_SEL_BIT_PORT) & DIPROT_DEVICE_SEL_BIT_PINS) >> DIPROT_DEVICE_SEL_BIT_SHIFT;
-    switch (rotary_select)
+    if (m_is_active)
     {
-    case 0:
-         cfg_dev.deviceType = S2S_CFG_FIXED;
-    break;
-    case 1:
-        cfg_dev.deviceType = S2S_CFG_OPTICAL;
-    break;
-    case 2:
-        cfg_dev.deviceType = S2S_CFG_FLOPPY_14MB;
-    break;
-    case 3:
-        cfg_dev.deviceType = S2S_CFG_REMOVABLE;
-    break;
-    case 4:
-        cfg_dev.deviceType = S2S_CFG_MO;
-    break;
-    case 5:
-        m_device_preset = DEV_PRESET_ST32430N;
-        cfg_dev.deviceType = S2S_CFG_FIXED;
-    break;
-    case 6:
-        cfg_dev.deviceType = S2S_CFG_SEQUENTIAL;
-    break;
-    default:
-        cfg_dev.deviceType = S2S_CFG_FIXED;
-    }
-    
-    if (cfg_dev.deviceType == S2S_CFG_OPTICAL)
-    {
-        m_blocksize = DEFAULT_BLOCKSIZE_OPTICAL;
-    }
-    else
-    {
-        m_blocksize = RAW_FALLBACK_BLOCKSIZE;
-    }
+        m_scsi_id = (gpio_input_port_get(DIPSW_SCSI_ID_BIT_PORT) & DIPSW_SCSI_ID_BIT_PINS) >> DIPSW_SCSI_ID_BIT_SHIFT;
+        m_device_preset = DEV_PRESET_NONE;
+        scsi_device_settings_t &cfg_dev = *g_scsi_settings.getDevice(m_scsi_id);
 
+        uint8_t rotary_select = (gpio_input_port_get(DIPROT_DEVICE_SEL_BIT_PORT) & DIPROT_DEVICE_SEL_BIT_PINS) >> DIPROT_DEVICE_SEL_BIT_SHIFT;
+        switch (rotary_select)
+        {
+        case 0:
+            cfg_dev.deviceType = S2S_CFG_FIXED;
+        break;
+        case 1:
+            cfg_dev.deviceType = S2S_CFG_OPTICAL;
+        break;
+        case 2:
+            cfg_dev.deviceType = S2S_CFG_FLOPPY_14MB;
+        break;
+        case 3:
+            cfg_dev.deviceType = S2S_CFG_REMOVABLE;
+        break;
+        case 4:
+            cfg_dev.deviceType = S2S_CFG_MO;
+        break;
+        case 5:
+            m_device_preset = DEV_PRESET_ST32430N;
+            cfg_dev.deviceType = S2S_CFG_FIXED;
+        break;
+        case 6:
+            cfg_dev.deviceType = S2S_CFG_SEQUENTIAL;
+        break;
+        default:
+            cfg_dev.deviceType = S2S_CFG_FIXED;
+        }
 
+        if (cfg_dev.deviceType == S2S_CFG_OPTICAL)
+        {
+            m_blocksize = DEFAULT_BLOCKSIZE_OPTICAL;
+        }
+        else
+        {
+            m_blocksize = RAW_FALLBACK_BLOCKSIZE;
+        }
+    }
 }
 
 #endif // ZULUSCSI_HARDWARE_CONFIG

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -652,6 +652,7 @@ static void reinitSCSI()
     g_scsi_settings.initDevice(scsiId, g_hw_config.device_type());
 
     logmsg("Direct/Raw mode enabled, using hardware switches for configuration");
+    logmsg("-- SCSI ID set via DIP switch to ", (int) g_hw_config.scsi_id());
     char raw_filename[32];  
     uint32_t start =  g_scsi_settings.getDevice(scsiId)->sectorSDBegin; 
     uint32_t end = g_scsi_settings.getDevice(scsiId)->sectorSDEnd;


### PR DESCRIPTION
Improved logging output, including logging of DIP switch states and SCSI ID reporting when in direct/raw mode
