### PR TITLE
Initiator sense request from debug to standard log

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -568,7 +568,7 @@ bool scsiRequestSense(int target_id, uint8_t *sense_key)
                                          response, sizeof(response),
                                          NULL, 0);
 
-    dbgmsg("RequestSense response: ", bytearray(response, 18));
+    logmsg("RequestSense response: ", bytearray(response, 18));
 
     *sense_key = response[2];
     return status == 0;


### PR DESCRIPTION
In initiator mode the request sense command gets more information about errors. Moving it from the debug logging to standard logging will better inform users using initiator mode that an error has occurred.

This change is based on the work of androda in this commit: https://github.com/BlueSCSI/BlueSCSI-v2/commit/980fb0b3f331d19eb6ffac422ba4411957ab1223