### PR TITLE
Fix device selector for ZuluSCSI V1.2

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.cpp
@@ -62,38 +62,37 @@ void HardwareConfig::init_state(bool is_active)
     {
         m_scsi_id = (gpio_input_port_get(DIPSW_SCSI_ID_BIT_PORT) & DIPSW_SCSI_ID_BIT_PINS) >> DIPSW_SCSI_ID_BIT_SHIFT;
         m_device_preset = DEV_PRESET_NONE;
-        scsi_device_settings_t &cfg_dev = *g_scsi_settings.getDevice(m_scsi_id);
 
         uint8_t rotary_select = (gpio_input_port_get(DIPROT_DEVICE_SEL_BIT_PORT) & DIPROT_DEVICE_SEL_BIT_PINS) >> DIPROT_DEVICE_SEL_BIT_SHIFT;
         switch (rotary_select)
         {
         case 0:
-            cfg_dev.deviceType = S2S_CFG_FIXED;
+            m_device_type = S2S_CFG_FIXED;
         break;
         case 1:
-            cfg_dev.deviceType = S2S_CFG_OPTICAL;
+            m_device_type = S2S_CFG_OPTICAL;
         break;
         case 2:
-            cfg_dev.deviceType = S2S_CFG_FLOPPY_14MB;
+            m_device_type = S2S_CFG_FLOPPY_14MB;
         break;
         case 3:
-            cfg_dev.deviceType = S2S_CFG_REMOVABLE;
+            m_device_type = S2S_CFG_REMOVABLE;
         break;
         case 4:
-            cfg_dev.deviceType = S2S_CFG_MO;
+            m_device_type = S2S_CFG_MO;
         break;
         case 5:
             m_device_preset = DEV_PRESET_ST32430N;
-            cfg_dev.deviceType = S2S_CFG_FIXED;
+            m_device_type = S2S_CFG_FIXED;
         break;
         case 6:
-            cfg_dev.deviceType = S2S_CFG_SEQUENTIAL;
+            m_device_type = S2S_CFG_SEQUENTIAL;
         break;
         default:
-            cfg_dev.deviceType = S2S_CFG_FIXED;
+            m_device_type = S2S_CFG_FIXED;
         }
 
-        if (cfg_dev.deviceType == S2S_CFG_OPTICAL)
+        if (m_device_type == S2S_CFG_OPTICAL)
         {
             m_blocksize = DEFAULT_BLOCKSIZE_OPTICAL;
         }

--- a/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.h
+++ b/lib/ZuluSCSI_platform_GD32F205/platform_hw_config.h
@@ -25,6 +25,7 @@
 */
 
 #pragma once
+#ifdef ZULUSCSI_HARDWARE_CONFIG
 #include <scsi2sd.h>
 #include <ZuluSCSI_settings.h>
 
@@ -73,4 +74,4 @@ protected:
 extern HardwareConfig g_hw_config;
 
 #endif // __cplusplus
-
+#endif // ZULUSCSI_HARDWARE_CONFIG

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -289,7 +289,16 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int
         }
         else if (img.file.contiguousRange(&sector_begin, &sector_end))
         {
-            dbgmsg("---- Image file is contiguous, SD card sectors ", (int)sector_begin, " to ", (int)sector_end);
+#ifdef ZULUSCSI_HARDWARE_CONFIG
+            if (g_hw_config.is_active())
+            {
+                dbgmsg("----  Device spans SD card sectors ", (int)sector_begin, " to ", (int)sector_end);
+            }
+            else
+#endif // ZULUSCSI_HARDWARE_CONFIG
+            {
+                dbgmsg("---- Image file is contiguous, SD card sectors ", (int)sector_begin, " to ", (int)sector_end);
+            }
         }
         else
         {


### PR DESCRIPTION
The init of the direct mode saved the device selection to the settings struct directly. This happened before the settings were initialized, so the device selection was lost.

The code already set the device mode from a member variable in the class in platform_hw_config.cpp after the setting struct was initialized. So a simple switch from saving the device mode directly in the settings struct to storing it in the member variable fixed the issue.

Also switched the debug text in direct mode mentioning the image file's start and end sectors on the SD card to referring to the device spanning the start and end sectors of the SD card.