### PR TITLE
Fix watchdog timeout

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -678,7 +678,7 @@ static void watchdog_callback(unsigned alarm_num)
         }
     }
 
-    hardware_alarm_set_target(3, delayed_by_ms(get_absolute_time(), 1000));
+    hardware_alarm_set_target(alarm_num, delayed_by_ms(get_absolute_time(), 1000));
 }
 
 // This function can be used to periodically reset watchdog timer for crash handling.

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -638,10 +638,14 @@ static void watchdog_callback(unsigned alarm_num)
             logmsg("scsiDev.phase: ", (int)scsiDev.phase);
             scsi_accel_log_state();
 
-            uint32_t *p = (uint32_t*)__get_PSP();
+#ifdef __MBED__
+            uint32_t *p =  (uint32_t*)__get_PSP();
+#else
+            uint32_t *p =  (uint32_t*)__get_MSP();
+#endif
             for (int i = 0; i < 8; i++)
             {
-                if (p == &__StackTop) break; // End of stack
+            if (p == &__StackTop) break; // End of stack
 
                 logmsg("STACK ", (uint32_t)p, ":    ", p[0], " ", p[1], " ", p[2], " ", p[3]);
                 p += 4;
@@ -654,14 +658,18 @@ static void watchdog_callback(unsigned alarm_num)
         if (g_watchdog_timeout <= 0)
         {
             logmsg("--------------");
-            logmsg("WATCHDOG TIMEOUT!");
+            logmsg("WATCHDOG TIMEOUT, already attempted bus reset, rebooting");
             logmsg("Platform: ", g_platform_name);
             logmsg("FW Version: ", g_log_firmwareversion);
             logmsg("GPIO states: out ", sio_hw->gpio_out, " oe ", sio_hw->gpio_oe, " in ", sio_hw->gpio_in);
             logmsg("scsiDev.cdb: ", bytearray(scsiDev.cdb, 12));
             logmsg("scsiDev.phase: ", (int)scsiDev.phase);
 
-            uint32_t *p = (uint32_t*)__get_PSP();
+#ifdef __MBED__
+            uint32_t *p =  (uint32_t*)__get_PSP();
+#else
+            uint32_t *p =  (uint32_t*)__get_MSP();
+#endif
             for (int i = 0; i < 8; i++)
             {
                 if (p == &__StackTop) break; // End of stack
@@ -686,7 +694,6 @@ static void watchdog_callback(unsigned alarm_num)
 void platform_reset_watchdog()
 {
     g_watchdog_timeout = WATCHDOG_CRASH_TIMEOUT;
-
 
     if (!g_watchdog_initialized)
     {


### PR DESCRIPTION
Fixes the watchdog time out for the ZuluSCSI Pico DaynaPort target and any builds using Earl E Philhower's Pico PlatoformIO framework