### PR TITLE
Fix IMGx=filename ignoring device type

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -704,6 +704,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
         int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
         if (buf[0] != '\0')
         {
+            img.deviceType = g_scsi_settings.getDevice(target_idx)->deviceType;
             return ret;
         }
         else if (img.image_index > 0)


### PR DESCRIPTION
This fixes an issue when there is an entry like this in `zuluscsi.ini`
```
[SCSI3]
IMG0="my_cd.iso"
Type = 2 # CD-ROM type
```
The image type in that particular code path wasn't set and sector length was incorrectly being set to 512B instead of 2048B.