### PR TITLE
Initiator: allow bus to settle after REQ

### DIFF
--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_Pico.pio
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_Pico.pio
@@ -40,6 +40,7 @@
 
 start:
     wait 0 gpio REQ             side 1  ; Wait for REQ low
+    nop                 [1]     side 1  ; Wait for signals to settle
     in pins, 9                  side 0  ; Assert ACK, read GPIO
     in null, 7                  side 0  ; Padding bits
     wait 1 gpio REQ             side 0  ; Wait for REQ high

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_Pico.pio.h
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_Pico.pio.h
@@ -13,24 +13,25 @@
 // -------------------- //
 
 #define scsi_host_async_read_wrap_target 0
-#define scsi_host_async_read_wrap 6
+#define scsi_host_async_read_wrap 7
 
 static const uint16_t scsi_host_async_read_program_instructions[] = {
             //     .wrap_target
     0x90a0, //  0: pull   block           side 1     
     0xb027, //  1: mov    x, osr          side 1     
     0x3011, //  2: wait   0 gpio, 17      side 1     
-    0x4009, //  3: in     pins, 9         side 0     
-    0x4067, //  4: in     null, 7         side 0     
-    0x2091, //  5: wait   1 gpio, 17      side 0     
-    0x1042, //  6: jmp    x--, 2          side 1     
+    0xb142, //  3: nop                    side 1 [1] 
+    0x4009, //  4: in     pins, 9         side 0     
+    0x4067, //  5: in     null, 7         side 0     
+    0x2091, //  6: wait   1 gpio, 17      side 0     
+    0x1042, //  7: jmp    x--, 2          side 1     
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program scsi_host_async_read_program = {
     .instructions = scsi_host_async_read_program_instructions,
-    .length = 7,
+    .length = 8,
     .origin = -1,
 };
 

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_RP2040.pio
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_RP2040.pio
@@ -40,6 +40,7 @@
 
 start:
     wait 0 gpio REQ             side 1  ; Wait for REQ low
+    nop                 [1]     side 1  ; Wait for signals to settle
     in pins, 9                  side 0  ; Assert ACK, read GPIO
     in null, 7                  side 0  ; Padding bits
     wait 1 gpio REQ             side 0  ; Wait for REQ high

--- a/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_RP2040.pio.h
+++ b/lib/ZuluSCSI_platform_RP2040/scsi_accel_host_RP2040.pio.h
@@ -13,24 +13,25 @@
 // -------------------- //
 
 #define scsi_host_async_read_wrap_target 0
-#define scsi_host_async_read_wrap 6
+#define scsi_host_async_read_wrap 7
 
 static const uint16_t scsi_host_async_read_program_instructions[] = {
             //     .wrap_target
     0x90a0, //  0: pull   block           side 1     
     0xb027, //  1: mov    x, osr          side 1     
     0x3009, //  2: wait   0 gpio, 9       side 1     
-    0x4009, //  3: in     pins, 9         side 0     
-    0x4067, //  4: in     null, 7         side 0     
-    0x2089, //  5: wait   1 gpio, 9       side 0     
-    0x1042, //  6: jmp    x--, 2          side 1     
+    0xb142, //  3: nop                    side 1 [1] 
+    0x4009, //  4: in     pins, 9         side 0     
+    0x4067, //  5: in     null, 7         side 0     
+    0x2089, //  6: wait   1 gpio, 9       side 0     
+    0x1042, //  7: jmp    x--, 2          side 1     
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program scsi_host_async_read_program = {
     .instructions = scsi_host_async_read_program_instructions,
-    .length = 7,
+    .length = 8,
     .origin = -1,
 };
 
@@ -41,4 +42,3 @@ static inline pio_sm_config scsi_host_async_read_program_get_default_config(uint
     return c;
 }
 #endif
-


### PR DESCRIPTION
Fixes instability in initiator transfers.

@androda changes in pull request: https://github.com/BlueSCSI/BlueSCSI-v2/pull/92 applied to ZuluSCSI