### PR TITLE
Fix v1.0 mini logging debug with default settings

### DIFF
--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "24.02.15"
+#define FW_VER_NUM      "24.02.22"
 #define FW_VER_SUFFIX   "dev"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -29,7 +29,7 @@
 
 const char *g_log_firmwareversion = ZULU_FW_VERSION " " __DATE__ " " __TIME__;
 
-bool g_log_debug = true;
+bool g_log_debug = false;
 
 // This memory buffer can be read by debugger and is also saved to zululog.txt
 #define LOGBUFMASK (LOGBUFSIZE - 1)


### PR DESCRIPTION
Changed the global debug variable initial value to false. This fixes the ZuluSCSI v1.0 mini logging issue discovered in the following issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/385 Thanks to @dramirez1972 for finding the bug.