### PR TITLE
Fix a few CDROM audio playback on older mac issues

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -288,9 +288,18 @@ static void doModeSense(
 		break;
 
 	case S2S_CFG_OPTICAL:
-		mediumType = 0x02; // 120mm CDROM, data only.
-		deviceSpecificParam = 0;
-		density = 0x01; // User data only, 2048bytes per sector.
+		if (scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE)
+		{
+			mediumType = 0x00;
+			deviceSpecificParam = 0;
+			density = 0x00;
+		}
+		else
+		{
+			mediumType = 0x02; // 120mm CDROM, data only.
+			deviceSpecificParam = 0;
+			density = 0x01; // User data only, 2048bytes per sector.
+		}
 		break;
 
 	case S2S_CFG_SEQUENTIAL:

--- a/lib/ZuluSCSI_platform_GD32F205/audio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/audio.cpp
@@ -55,7 +55,8 @@ extern bool g_audio_stopped;
 
 
 // historical playback status information
-static audio_status_code audio_last_status[8] = {ASC_NO_STATUS};
+static audio_status_code audio_last_status[8] = {ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS,
+                                                 ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS};
 
 // volume information for targets
 static volatile uint16_t volumes[8] = {
@@ -410,5 +411,14 @@ void audio_set_channel(uint8_t id, uint16_t chn) {
     channels[id & 7] = chn;
 }
 
+uint64_t audio_get_file_position()
+{
+    return fpos;
+}
+
+void audio_set_file_position(uint32_t lba)
+{
+    fpos = 2352 * (uint64_t)lba;
+}
 
 #endif // ENABLE_AUDIO_OUTPUT

--- a/lib/ZuluSCSI_platform_RP2040/audio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/audio.cpp
@@ -140,7 +140,6 @@ static uint32_t fleft;
 // historical playback status information
 static audio_status_code audio_last_status[8] = {ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS,
                                                  ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS};
-.
 // volume information for targets
 static volatile uint16_t volumes[8] = {
     DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH,

--- a/lib/ZuluSCSI_platform_RP2040/audio.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/audio.cpp
@@ -138,8 +138,9 @@ static uint64_t fpos;
 static uint32_t fleft;
 
 // historical playback status information
-static audio_status_code audio_last_status[8] = {ASC_NO_STATUS};
-
+static audio_status_code audio_last_status[8] = {ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS,
+                                                 ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS, ASC_NO_STATUS};
+.
 // volume information for targets
 static volatile uint16_t volumes[8] = {
     DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH, DEFAULT_VOLUME_LEVEL_2CH,
@@ -585,4 +586,14 @@ void audio_set_channel(uint8_t id, uint16_t chn) {
     channels[id & 7] = chn;
 }
 
+uint64_t audio_get_file_position()
+{
+    return fpos;
+}
+
+void audio_set_file_position(uint32_t lba)
+{
+    fpos = 2352 * (uint64_t)lba;
+
+}
 #endif // ENABLE_AUDIO_OUTPUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ lib_deps =
 upload_protocol = stlink
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.100301.220327
     framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
-debug_tool = cmsis-dap
+debug_tool = stlink
 extra_scripts = src/build_bootloader.py
 debug_build_flags = 
      -Os -Wall -Wno-sign-compare -ggdb -g3

--- a/src/ZuluSCSI_audio.h
+++ b/src/ZuluSCSI_audio.h
@@ -146,3 +146,16 @@ uint16_t audio_get_channel(uint8_t id);
  * \param chn   The new channel information.
  */
 void audio_set_channel(uint8_t id, uint16_t chn);
+
+/**
+ * Gets the byte position in the audio image
+ * 
+ * \return byte position in the audio image
+*/
+uint64_t audio_get_file_position();
+
+/**
+ * Sets the playback position in the audio image via the lba
+ * 
+*/
+void audio_set_file_position(uint32_t lba);

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -89,7 +89,7 @@
 // Default SCSI drive information when Apple quirks are enabled
 #define APPLE_DRIVEINFO_FIXED     {"CDC",      "ZuluSCSI HDD",      PLATFORM_REVISION, "1.0"}
 #define APPLE_DRIVEINFO_REMOVABLE {"IOMEGA",   "BETA230",           PLATFORM_REVISION, "2.02"}
-#define APPLE_DRIVEINFO_OPTICAL   {"MATSHITA", "CD-ROM CR-8004A",   PLATFORM_REVISION, "2.0a"}
+#define APPLE_DRIVEINFO_OPTICAL   {"MATSHITA", "CD-ROM CR-8004",    PLATFORM_REVISION, "1.1f"}
 #define APPLE_DRIVEINFO_FLOPPY    {"IOMEGA",     "Io20S         *F", "PP33", ""}
 #define APPLE_DRIVEINFO_MAGOPT    {"MOST",     "RMD-5200",          PLATFORM_REVISION, "1.0"}
 #define APPLE_DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",       "2.0f", ""}

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -177,9 +177,9 @@ static void printNewPhase(int phase, bool initiator = false)
             if (!initiator && scsiDev.target->syncOffset > 0)
                 dbgmsg("---- DATA_OUT, syncOffset ", (int)scsiDev.target->syncOffset,
                                     " syncPeriod ", (int)scsiDev.target->syncPeriod);
-	    // log Xebec vendor commands data
-	    else if (scsiDev.cdb[0] == 0x0C || scsiDev.cdb[0] == 0x0F)
-		    g_LogData = true;
+            // log Xebec vendor commands data
+            else if (scsiDev.cdb[0] == 0x0C || scsiDev.cdb[0] == 0x0F)
+                g_LogData = true;
             else
                 dbgmsg("---- DATA_OUT");
             break;
@@ -212,17 +212,17 @@ void scsiLogPhaseChange(int new_phase)
         {
             dbgmsg("---- Total IN: ", g_InByteCount, " OUT: ", g_OutByteCount, " CHECKSUM: ", (int)g_DataChecksum);
         }
-	// log Xebec vendor command
+        // log Xebec vendor command
         if (old_phase == DATA_OUT && scsiDev.cdb[0] == 0x0C && g_OutByteCount == 8)
-	{
-		int cylinders = ((uint16_t)scsiDev.data[0] << 8) + scsiDev.data[1];
-		int heads = scsiDev.data[2];
-		int reducedWrite = ((uint16_t)scsiDev.data[3] << 8) + scsiDev.data[4];
-		int writePrecomp = ((uint16_t)scsiDev.data[5] << 8) + scsiDev.data[6];
-		int eccBurst = scsiDev.data[7];
-		dbgmsg("---- Xebec Initialize Drive Characteristics: cylinders=", cylinders, " heads=", heads,
-				" reducedWrite=", reducedWrite, " writePrecomp=", writePrecomp, " eccBurst=", eccBurst);
-	}
+        {
+            int cylinders = ((uint16_t)scsiDev.data[0] << 8) + scsiDev.data[1];
+            int heads = scsiDev.data[2];
+            int reducedWrite = ((uint16_t)scsiDev.data[3] << 8) + scsiDev.data[4];
+            int writePrecomp = ((uint16_t)scsiDev.data[5] << 8) + scsiDev.data[6];
+            int eccBurst = scsiDev.data[7];
+            dbgmsg("---- Xebec Initialize Drive Characteristics: cylinders=", cylinders, " heads=", heads,
+                    " reducedWrite=", reducedWrite, " writePrecomp=", writePrecomp, " eccBurst=", eccBurst);
+        }
         g_InByteCount = g_OutByteCount = 0;
         g_DataChecksum = 0;
 

--- a/src/ZuluSCSI_mode.cpp
+++ b/src/ZuluSCSI_mode.cpp
@@ -53,8 +53,8 @@ static const uint8_t CDROMAudioControlParametersPage[] =
 0x04, // 'Immed' bit set, 'SOTC' bit not set
 0x00, // reserved
 0x00, // reserved
-0x80, // 1 LBAs/sec multip
-0x00, 0x4B, // 75 LBAs/sec
+0x00, // reserved was //  0x80, // 1 LBAs/sec multip
+0x00, 0x00, // obsolete was // 75 LBAs/sec 
 0x01, 0xFF, // output port 0 active, max volume
 0x02, 0xFF, // output port 1 active, max volume
 0x00, 0x00, // output port 2 inactive


### PR DESCRIPTION
- Playback time displays correctly
- Reported DATA IN length from GetConfiguration length corrected
- Initial status of CD-ROM corrected

Still not implemented:
- Next/Prev track while playing
- Fast forward/rewind