### PR TITLE
Allow custom block sizes

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -461,10 +461,10 @@ bool findHDDImages()
         if (blksize)
         {
           int blktmp = strtoul(blksize + 1, NULL, 10);
-          if (blktmp == 256 || blktmp == 512 || blktmp == 1024 ||
-              blktmp == 2048 || blktmp == 4096 || blktmp == 8192)
+          if (8 <= blktmp && blktmp <= 64 * 1024)
           {
             blk = blktmp;
+            logmsg("-- Using custom block size, ",(int) blk," from filename: ", name);
           }
         }
 


### PR DESCRIPTION
Addressing issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/338

Allowing block sizes from 8 bytes to 64kB
They can be non-standard sizes that are not 512 divisible
Using the format `HD1_[blocksize].img`