### PR TITLE
Fix Plextor 0xD8 SCSI vendor command

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -518,7 +518,7 @@ bool findHDDImages()
               logmsg("---- Using device preset: ", g_scsi_settings.getDevicePresetName(id));
           }
 
-          imageReady = scsiDiskOpenHDDImage(id, fullname, id, lun, blk, type);
+          imageReady = scsiDiskOpenHDDImage(id, fullname, lun, blk, type);
           if(imageReady)
           {
             foundImage = true;
@@ -668,7 +668,7 @@ static void reinitSCSI()
       snprintf(raw_filename, sizeof(raw_filename), "RAW:0x%X:0x%X", start, end);
     }
     
-    success = scsiDiskOpenHDDImage(scsiId, raw_filename, scsiId, 0,
+    success = scsiDiskOpenHDDImage(scsiId, raw_filename, 0,
                                    g_hw_config.blocksize(), g_hw_config.device_type());
     if (success)
     {
@@ -699,7 +699,7 @@ static void reinitSCSI()
   #ifdef RAW_FALLBACK_ENABLE
       logmsg("No images found, enabling RAW fallback partition");
       g_scsi_settings.initDevice(RAW_FALLBACK_SCSI_ID, S2S_CFG_FIXED);
-      scsiDiskOpenHDDImage(RAW_FALLBACK_SCSI_ID, "RAW:0:0xFFFFFFFF", RAW_FALLBACK_SCSI_ID, 0,
+      scsiDiskOpenHDDImage(RAW_FALLBACK_SCSI_ID, "RAW:0:0xFFFFFFFF", 0,
                           RAW_FALLBACK_BLOCKSIZE);
   #else
       logmsg("No valid image files found!");

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1704,54 +1704,64 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
             diskEjectButtonUpdate(false);
         }
         if (scsiDev.resetFlag) break;
-
-        if (add_fake_headers)
+        if ((g_scsi_settings.getDevice(img.scsiId & 0x7)->vendorExtensions & VENDOR_EXTENSION_OPTICAL_PLEXTOR))
         {
-            // 12-byte data sector sync pattern
-            *buf++ = 0x00;
-            for (int i = 0; i < 10; i++)
+            if (sector_length > 0)
             {
-                *buf++ = 0xFF;
+                // User data
+                img.file.read(buf, sector_length);
+                buf += sector_length;
             }
-            *buf++ = 0x00;
-
-            // 4-byte data sector header
-            LBA2MSFBCD(lba + idx, buf, false);
-            buf += 3;
-            *buf++ = 0x01; // Mode 1
         }
-
-        if (sector_length > 0)
+        else 
         {
-            // User data
-            img.file.read(buf, sector_length);
-            buf += sector_length;
-        }
+            if (add_fake_headers)
+            {
+                // 12-byte data sector sync pattern
+                *buf++ = 0x00;
+                for (int i = 0; i < 10; i++)
+                {
+                    *buf++ = 0xFF;
+                }
+                *buf++ = 0x00;
 
-        if (add_fake_headers)
-        {
-            // 288 bytes of ECC
-            memset(buf, 0, 288);
-            buf += 288;
-        }
+                // 4-byte data sector header
+                LBA2MSFBCD(lba + idx, buf, false);
+                buf += 3;
+                *buf++ = 0x01; // Mode 1
+            }
 
-        if (field_q_subchannel)
-        {
-            // Formatted Q subchannel data
-            // Refer to table 354 in T10/1545-D MMC-4 Revision 5a
-            // and ECMA-130 22.3.3
-            *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
-            *buf++ = trackinfo.track_number;
-            *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
-            int32_t rel = (int32_t)(lba + idx) - (int32_t)trackinfo.data_start;
-            LBA2MSF(rel, buf, true); buf += 3;
-            *buf++ = 0;
-            LBA2MSF(lba + idx, buf, false); buf += 3;
-            *buf++ = 0; *buf++ = 0; // CRC (optional)
-            *buf++ = 0; *buf++ = 0; *buf++ = 0; // (pad)
-            *buf++ = 0; // No P subchannel
-        }
+            if (sector_length > 0)
+            {
+                // User data
+                img.file.read(buf, sector_length);
+                buf += sector_length;
+            }
 
+            if (add_fake_headers)
+            {
+                // 288 bytes of ECC
+                memset(buf, 0, 288);
+                buf += 288;
+            }
+
+            if (field_q_subchannel)
+            {
+                // Formatted Q subchannel data
+                // Refer to table 354 in T10/1545-D MMC-4 Revision 5a
+                // and ECMA-130 22.3.3
+                *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
+                *buf++ = trackinfo.track_number;
+                *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
+                int32_t rel = (int32_t)(lba + idx) - (int32_t)trackinfo.data_start;
+                LBA2MSF(rel, buf, true); buf += 3;
+                *buf++ = 0;
+                LBA2MSF(lba + idx, buf, false); buf += 3;
+                *buf++ = 0; *buf++ = 0; // CRC (optional)
+                *buf++ = 0; *buf++ = 0; *buf++ = 0; // (pad)
+                *buf++ = 0; // No P subchannel
+            }
+        }
         assert(buf == bufstart + result_length);
         scsiStartWrite(bufstart, result_length);
     }

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1244,7 +1244,7 @@ bool cdromSwitchNextImage(image_config_t &img, const char* next_filename)
     {
         logmsg("Switching to next CD-ROM image for ", target_idx, ": ", filename);
         img.file.close();
-        bool status = scsiDiskOpenHDDImage(target_idx, filename, target_idx, 0, 2048, S2S_CFG_OPTICAL);
+        bool status = scsiDiskOpenHDDImage(target_idx, filename, 0, 2048, S2S_CFG_OPTICAL);
 
         if (status)
         {
@@ -1532,7 +1532,7 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
                ", sector size ", (int) AUDIO_CD_SECTOR_LEN,
                ", data offset in file ", (int)offset);
     }
-    if (sector_type == SECTOR_TYPE_VENDOR_APPLE_300plus)
+    else if (sector_type == SECTOR_TYPE_VENDOR_APPLE_300plus)
     {
         trackinfo.sector_length = AUDIO_CD_SECTOR_LEN;
         trackinfo.track_mode = CUETrack_AUDIO;

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -106,7 +106,7 @@ void scsiDiskResetImages();
 // Close any files opened from SD card (prepare for remounting SD)
 void scsiDiskCloseSDCardImages();
 
-bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_id, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED);
+bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED);
 void scsiDiskLoadConfig(int target_idx);
 
 // Checks if a filename extension is appropriate for further processing as a disk image.


### PR DESCRIPTION
Fixed a bug where the 0xD8 command offset was being overwritten because of a missing else.
Skipped over parts of `doReadCD` when using the 0xD8 command.
Removed a redundant parameter from `scsiDiskOpenHDDImage`. `target_idx` and `scsi_id` were the same.