### PR TITLE
Add debug message suppression by SCSI ID

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1,6 +1,6 @@
 /*  
  *  ZuluSCSI™
- *  Copyright (c) 2022-2023 Rabbit Hole Computing™
+ *  Copyright (c) 2022-2024 Rabbit Hole Computing™
  * 
  * This project is based on BlueSCSI:
  *
@@ -692,7 +692,24 @@ static void reinitSCSI()
     g_log_debug = true;
   }
 #endif
+  if (g_log_debug)
+  {
+    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", 0xFF, CONFIGFILE) & 0xFF;
+    if (g_scsi_log_mask == 0)
+    {
+      dbgmsg("DebugLogMask set to 0x00, this will silence all debug messages when a SCSI ID has been selected");
+    }
+    else if (g_scsi_log_mask != 0xFF)
+    {
+      dbgmsg("DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
+    }
 
+    g_log_ignore_busy_free = ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE);
+    if (g_log_ignore_busy_free)
+    {
+      dbgmsg("DebugIgnoreBusyFree enabled, BUS_FREE/BUS_BUSY messages suppressed");
+    }
+  }
 #ifdef PLATFORM_HAS_INITIATOR_MODE
   if (platform_is_initiator_mode_enabled())
   {

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "24.06.04"
+#define FW_VER_NUM      "24.06.12"
 #define FW_VER_SUFFIX   "devel"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 #define INQUIRY_NAME  PLATFORM_NAME " v" ZULU_FW_VERSION

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -1,6 +1,7 @@
 /** 
- * ZuluSCSI™ - Copyright (c) 2022 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2022-2024 Rabbit Hole Computing™
  * Copyright (c) 2023 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2024 Eric Helgeson <erichelgeson@gmail.com>
  * 
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
  * 
@@ -30,6 +31,8 @@
 const char *g_log_firmwareversion = ZULU_FW_VERSION " " __DATE__ " " __TIME__;
 
 bool g_log_debug = false;
+bool g_log_ignore_busy_free = false;
+uint8_t g_scsi_log_mask = 0xFF;
 
 // This memory buffer can be read by debugger and is also saved to zululog.txt
 #define LOGBUFMASK (LOGBUFSIZE - 1)

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -130,11 +130,11 @@ static void printNewPhase(int phase, bool initiator = false)
     switch(phase)
     {
         case BUS_FREE:
-            dbgmsg("-- BUS_FREE");
+            if (!g_log_ignore_busy_free) dbgmsg("-- BUS_FREE");
             break;
         
         case BUS_BUSY:
-            dbgmsg("-- BUS_BUSY");
+            if (!g_log_ignore_busy_free) dbgmsg("-- BUS_BUSY");
             break;
         
         case ARBITRATION:

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -7,6 +7,8 @@
 #System="Mac"
 
 #Debug = 0   # Same effect as DIPSW2, enables verbose log messages
+#DebugLogMask = 255 # A bit mask for SCSI IDs 0-7, filters only matching SCSI ID debug messages
+#DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9


### PR DESCRIPTION
Loosely based on commit: https://github.com/BlueSCSI/BlueSCSI-v2/commit/27906736962ffbb52da9b5aa8473fefa86a5b231

Setting the `DebugLogMask` SCSI ID bit mask filters debug messages that are emitted when devices in the mask are selected. It does not filter out debug messages emitted outside of a device selection. The BUS_BUSY and BUS_FREE messages are still logged, which can make the log noisy.

To remove BUS_BUSY and BUS_FREE messages a `DebugIgnoreBusyFree` flag can be set in the `zuluscsi.ini` file.

This commit also removes the WiFi outbound cache to free up SRAM so this code can run on a DaynaPORT build.