### PR TITLE
Adjust logic for supported vendor commands

### DIFF
--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -599,8 +599,15 @@ static void process_Command()
 	{
 		enter_Status(CONFLICT);
 	}
+	// Handle Toolbox commands, overriding other vendor commands if enabled
+	else if (scsiToolboxEnabled() && scsiToolboxCommand())
+	{
+		// already handled
+	}
 	// Handle odd device types first that may override basic read and
 	// write commands. Will fall-through to generic disk handling.
+	// Some device specific vendor commands are located here instead
+	// of in scsiVendorCommand()
 	else if (((cfg->deviceType == S2S_CFG_OPTICAL) && scsiCDRomCommand()) ||
 		((cfg->deviceType == S2S_CFG_SEQUENTIAL) && scsiTapeCommand()) ||
 #ifdef ZULUSCSI_NETWORK

--- a/lib/SCSI2SD/src/firmware/vendor.c
+++ b/lib/SCSI2SD/src/firmware/vendor.c
@@ -185,20 +185,6 @@ int scsiVendorCommand()
 
 void scsiVendorCommandSetLen(uint8_t command, uint8_t* command_length)
 {
-	if (scsiDev.target->cfg->deviceType == S2S_CFG_OPTICAL)
-	{
-		// Apple CD-ROM with CD audio over the SCSI bus
-		if (scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE && (command == 0xD8 || command == 0xD9))
-		{
-			*command_length =  12;
-		}
-		// Plextor CD-ROM vendor extensions 0xD8
-		if (unlikely(scsiDev.target->cfg->vendorExtensions & VENDOR_EXTENSION_OPTICAL_PLEXTOR) && command == 0xD8)
-		{
-			*command_length =  12;
-		}
-	}
-
 	if (scsiToolboxEnabled())
 	{
 		// Conflicts with Apple CD-ROM audio over SCSI bus and Plextor CD-ROM D8 extension
@@ -206,6 +192,19 @@ void scsiVendorCommandSetLen(uint8_t command, uint8_t* command_length)
 		if (0xD0 <= command && command <= 0xDA)
 		{
 			*command_length = 10;
+		}
+	}
+	else if (scsiDev.target->cfg->deviceType == S2S_CFG_OPTICAL)
+	{
+		// Apple CD-ROM with CD audio over the SCSI bus
+		if (scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE && (command == 0xD8 || command == 0xD9))
+		{
+			*command_length =  12;
+		}
+		// Plextor CD-ROM vendor extensions 0xD8
+		else if (unlikely(scsiDev.target->cfg->vendorExtensions & VENDOR_EXTENSION_OPTICAL_PLEXTOR) && command == 0xD8)
+		{
+			*command_length =  12;
 		}
 	}
 }

--- a/lib/SCSI2SD/src/firmware/vendor.c
+++ b/lib/SCSI2SD/src/firmware/vendor.c
@@ -171,10 +171,6 @@ int scsiVendorCommand()
 	  // XEBEC S1410 controller
 	  // Stub, return success
 	}   	
-	else if (scsiToolboxEnabled() && scsiToolboxCommand())
-	{
-		// already handled
-	}
 	else
 	{
 		commandHandled = 0;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -580,7 +580,7 @@ bool findHDDImages()
     }
   }
   // count the removable drives and drive with eject enabled
-  for (uint8_t id; id < S2S_MAX_TARGETS; id++)
+  for (uint8_t id = 0; id < S2S_MAX_TARGETS; id++)
   {
     const S2S_TargetCfg* cfg = s2s_getConfigByIndex(id);
     if (cfg  && (cfg->scsiId & S2S_CFG_TARGET_ENABLED ))


### PR DESCRIPTION
There isn't any functional change in this fix, just a rearrangement with if else statements to address this issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/432 Also a for loop wasn't initialized in `src/ZuluSCSI.cpp`, set the counter to 0.