### PR TITLE
Do not open and write to a log file in raw mode

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -34,6 +34,7 @@
 #include <ZuluSCSI_audio.h>
 
 extern SdFs SD;
+extern bool g_rawdrive_active;
 
 extern "C" {
 
@@ -544,6 +545,8 @@ void platform_log(const char *s)
 
 void platform_emergency_log_save()
 {
+    if (g_rawdrive_active)
+        return;
 #ifdef ZULUSCSI_HARDWARE_CONFIG
     if (g_hw_config.is_active())
         return;

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -32,6 +32,8 @@
 #include <assert.h>
 #include "usb_serial.h"
 
+extern bool g_rawdrive_active;
+
 extern "C" {
 
 const char *g_platform_name = PLATFORM_NAME;
@@ -348,6 +350,9 @@ void platform_log(const char *s)
 
 void platform_emergency_log_save()
 {
+    if (g_rawdrive_active)
+        return;
+
     platform_set_sd_callback(NULL, NULL);
 
     SD.begin(SD_CONFIG_CRASH);

--- a/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2040/ZuluSCSI_platform.cpp
@@ -54,6 +54,8 @@ extern "C" {
 #  include "audio.h"
 #endif // ENABLE_AUDIO_OUTPUT
 
+extern bool g_rawdrive_active;
+
 extern "C" {
 
 const char *g_platform_name = PLATFORM_NAME;
@@ -406,6 +408,8 @@ extern uint32_t __StackTop;
 
 void platform_emergency_log_save()
 {
+    if (g_rawdrive_active)
+        return;
     platform_set_sd_callback(NULL, NULL);
     SD.begin(SD_CONFIG_CRASH);
     FsFile crashfile = SD.open(CRASHFILE, O_WRONLY | O_CREAT | O_TRUNC);

--- a/src/ImageBackingStore.h
+++ b/src/ImageBackingStore.h
@@ -68,11 +68,14 @@ public:
     // Can the image be written?
     bool isWritable();
 
+    // Is this in Raw mode? by passing the file system
+    bool isRaw();
+
     // Is this internal ROM drive in microcontroller flash?
     bool isRom();
 
-    // Is this backed by raw passthrough
-    bool isRaw();
+    // Is this a contigious block on the SD card? Allowing less overhead
+    bool isContiguous();
 
     // Close the image so that .isOpen() will return false.
     bool close();
@@ -103,6 +106,7 @@ public:
     size_t getFilename(char* buf, size_t buflen);
 
 protected:
+    bool m_iscontiguous;
     bool m_israw;
     bool m_isrom;
     bool m_isreadonly_attr;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -62,6 +62,7 @@
 
 SdFs SD;
 FsFile g_logfile;
+bool g_rawdrive_active;
 static bool g_romdrive_active;
 static bool g_sdcard_present;
 
@@ -138,6 +139,9 @@ void init_logfile()
   if (g_hw_config.is_active())
     return;
 #endif
+
+  if (g_rawdrive_active)
+    return;
 
   static bool first_open_after_boot = true;
 

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 #include <ZuluSCSI_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "24.07.17"
+#define FW_VER_NUM      "24.07.22"
 #define FW_VER_SUFFIX   "devel"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 #define INQUIRY_NAME  PLATFORM_NAME " v" ZULU_FW_VERSION


### PR DESCRIPTION
This fix stops the opening of both the `zululog.txt` and `zuluerr.txt` when the drive is in raw mode.

It also renames a variable and function israw to iscontiguous as it aligns with it actual meaning and adds israw to denote SD card is accessed via raw mode

It also fixes an unrelated issue where a for loop variable wasn't being initialized.