### PR TITLE
SCSI: fix mac vendor page

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -560,7 +560,6 @@ static void doModeSense(
 	idx += modeSenseCDCapabilitiesPage(pc, idx, pageCode, &pageFound);
 
 	if ((scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE) &&
-	    (idx + sizeof(AppleVendorPage) <= allocLength) &&
 		(pageCode == 0x30 || pageCode == 0x3F))
 	{
 		pageFound = 1;


### PR DESCRIPTION
Merge in downstream commit https://github.com/BlueSCSI/BlueSCSI-v2/commit/6c8a264b00866e892e5bcea86be3b12ac5afbbf8

Quoting from that commit: "In SCSI2SD 4.1.1 circa 2015 c09e15b there was a bug introduced that incorrectly checked the allocation length of the Apple Vendor page. This worked as it was silently truncating the response. But did cause the vendor string to always be sent even if Apple Quirks was disabled."