### PR TITLE
CD-ROM: Support PREGAP in .cue files

### DIFF
--- a/lib/CUEParser/src/CUEParser.cpp
+++ b/lib/CUEParser/src/CUEParser.cpp
@@ -90,6 +90,8 @@ const CUETrackInfo *CUEParser::next_track()
         }
         else if (strncasecmp(m_parse_pos, "PREGAP ", 7) == 0)
         {
+            // Unstored pregap, which offsets the data start on CD but does not
+            // affect the offset in data file.
             const char *time_str = skip_space(m_parse_pos + 7);
             m_track_info.unstored_pregap_length = parse_time(time_str);
         }
@@ -104,11 +106,13 @@ const CUETrackInfo *CUEParser::next_track()
 
             if (index == 0)
             {
+                // Stored pregap that is present both on CD and in data file
                 m_track_info.track_start = time;
                 got_pause = true;
             }
             else if (index == 1)
             {
+                // Data content of the track
                 m_track_info.data_start = time;
                 got_data = true;
             }
@@ -120,6 +124,7 @@ const CUETrackInfo *CUEParser::next_track()
     if (got_data && !got_pause)
     {
         m_track_info.track_start = m_track_info.data_start;
+        m_track_info.data_start += m_track_info.unstored_pregap_length;
     }
 
     if (got_track && got_data)

--- a/lib/CUEParser/src/CUEParser.h
+++ b/lib/CUEParser/src/CUEParser.h
@@ -53,7 +53,7 @@ struct CUETrackInfo
     // Source file name and file type, and offset to start of track data in bytes.
     char filename[CUE_MAX_FILENAME+1];
     CUEFileMode file_mode;
-    uint64_t file_offset; // corresponds to track_start below
+    uint64_t file_offset; // corresponds to data_start below
 
     // Track number and mode in CD format
     int track_number;
@@ -70,6 +70,7 @@ struct CUETrackInfo
     uint32_t data_start;
 
     // LBA for the beginning of the track, which will be INDEX 00 if that is present.
+    // If there is unstored PREGAP, it's added between track_start and data_start.
     // Otherwise this will be INDEX 01 matching data_start above.
     uint32_t track_start;
 };

--- a/lib/CUEParser/test/Makefile
+++ b/lib/CUEParser/test/Makefile
@@ -4,4 +4,4 @@ all: CUEParser_test
 	./CUEParser_test
 
 CUEParser_test: CUEParser_test.cpp ../src/CUEParser.cpp
-	g++ -Wall -Wextra -o $@ -I ../src $^
+	g++ -Wall -Wextra -g -ggdb -o $@ -I ../src $^

--- a/src/ImageBackingStore.cpp
+++ b/src/ImageBackingStore.cpp
@@ -183,7 +183,7 @@ bool ImageBackingStore::close()
 
 uint64_t ImageBackingStore::size()
 {
-    if (m_iscontiguous && m_blockdev)
+    if (m_iscontiguous && m_blockdev && m_israw)
     {
         return (uint64_t)(m_endsector - m_bgnsector + 1) * SD_SECTOR_SIZE;
     }

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -271,7 +271,7 @@ static uint32_t getLeadOutLBA(const CUETrackInfo* lasttrack)
         image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
         uint32_t lastTrackBlocks = (img.file.size() - lasttrack->file_offset)
                 / lasttrack->sector_length;
-        return lasttrack->track_start + lastTrackBlocks;
+        return lasttrack->data_start + lastTrackBlocks;
     }
     else
     {
@@ -1500,7 +1500,7 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
     }
     else
     {
-        offset = trackinfo.file_offset + trackinfo.sector_length * (lba - trackinfo.track_start);
+        offset = trackinfo.file_offset + trackinfo.sector_length * (lba - trackinfo.data_start);
         dbgmsg("------ Read CD: ", (int)length, " sectors starting at ", (int)lba,
             ", track number ", trackinfo.track_number, ", sector size ", (int)trackinfo.sector_length,
             ", main channel ", main_channel, ", sub channel ", sub_channel,


### PR DESCRIPTION
Previously `PREGAP` specifier in .cue files was ignored.
This pull request adds support for it.

Also includes fix for incorrect image length if sector size is not divisible by 512. Previously for CD files in 2352 sector format the reported data length could be one sector too short.

Tests done:
* The .cue file provided in #422 with `readcd -fulltoc` and `cdrdao read-cd` now produces identical results as with real Lite-On CD drive and CD-R burned from the same files.
* `beos-5.0.3-professional-gobe.cue` with `cdrdao read-cd` gives identical .bin and .cue as the input data (this was working already previously, tested against to check for any regressions).

Fixes #422.