### PR TITLE
Switch activity LED blinking from delay to polling

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -44,6 +44,7 @@ static bool g_enable_apple_quirks = false;
 bool g_direct_mode = false;
 ZuluSCSIVersion_t g_zuluscsi_version = ZSVersion_unknown;
 bool g_moved_select_in = false;
+static bool g_led_blinking = false;
 // hw_config.cpp c functions
 #include "platform_hw_config.h"
 
@@ -457,6 +458,28 @@ void platform_post_sd_card_init()
         audio_setup();
     }
     #endif
+}
+
+void platform_write_led(bool state)
+{
+    if (g_led_blinking) return;
+    if (state)
+        gpio_bit_reset(LED_PORT, LED_PINS);
+    else
+        gpio_bit_set(LED_PORT, LED_PINS);
+}
+
+void platform_set_blink_status(bool status)
+{
+    g_led_blinking = status;
+}
+
+void platform_write_led_override(bool state)
+{
+    if (state)
+        gpio_bit_reset(LED_PORT, LED_PINS);
+    else
+        gpio_bit_set(LED_PORT, LED_PINS);
 }
 
 void platform_disable_led(void)

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -84,6 +84,15 @@ void platform_late_init();
 // Initialization after the SD Card has been found
 void platform_post_sd_card_init();
 
+// Write the status LED
+void platform_write_led(bool state);
+#define LED_ON()  platform_write_led(true)
+#define LED_OFF() platform_write_led(false)
+void platform_set_blink_status(bool status);
+void platform_write_led_override(bool state);
+#define LED_ON_OVERRIDE()  platform_write_led_override(true)
+#define LED_OFF_OVERRIDE()  platform_write_led_override(false)
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -84,11 +84,13 @@ void platform_late_init();
 // Initialization after the SD Card has been found
 void platform_post_sd_card_init();
 
-// Write the status LED
+// Set the status LED only if it is not in a blinking routine
 void platform_write_led(bool state);
 #define LED_ON()  platform_write_led(true)
 #define LED_OFF() platform_write_led(false)
+// Used by the blinking routine
 void platform_set_blink_status(bool status);
+// LED override will set the status LED regardless of the blinking routine
 void platform_write_led_override(bool state);
 #define LED_ON_OVERRIDE()  platform_write_led_override(true)
 #define LED_OFF_OVERRIDE()  platform_write_led_override(false)

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_v1_0_gpio.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_v1_0_gpio.h
@@ -146,8 +146,6 @@
 #define LED_I_PIN    GPIO_PIN_4
 #define LED_E_PIN    GPIO_PIN_5
 #define LED_PINS     (LED_I_PIN | LED_E_PIN)
-#define LED_ON()     gpio_bit_reset(LED_PORT, LED_PINS)
-#define LED_OFF()    gpio_bit_set(LED_PORT, LED_PINS)
 
 // Ejection buttons are available on expansion header J303.
 // PE5 = channel 1, PE6 = channel 2

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_v1_1_gpio.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_v1_1_gpio.h
@@ -292,8 +292,6 @@
 #define LED_I_PIN    GPIO_PIN_4
 #define LED_E_PIN    GPIO_PIN_5
 #define LED_PINS     (LED_I_PIN | LED_E_PIN)
-#define LED_ON()     gpio_bit_reset(LED_PORT, LED_PINS)
-#define LED_OFF()    gpio_bit_set(LED_PORT, LED_PINS)
 #define LED_EJECT_PORT  GPIOA
 #define LED_EJECT_PIN   GPIO_PIN_1
 #define LED_EJECT_ON()  gpio_bit_reset(LED_EJECT_PORT, LED_EJECT_PIN)

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -39,6 +39,7 @@ extern "C" {
 
 const char *g_platform_name = PLATFORM_NAME;
 static bool g_enable_apple_quirks = false;
+static bool g_led_blinking = false;
 
 /*************************/
 /* Timing functions      */
@@ -300,6 +301,29 @@ void platform_late_init()
 }
 
 void platform_post_sd_card_init() {}
+
+void platform_write_led(bool state)
+{
+    if (g_led_blinking) return;
+    if (state)
+        gpio_bit_reset(LED_PORT, LED_PINS);
+    else
+        gpio_bit_set(LED_PORT, LED_PINS);
+}
+
+void platform_set_blink_status(bool status)
+{
+    g_led_blinking = status;
+}
+
+void platform_write_led_override(bool state)
+{
+    if (state)
+        gpio_bit_reset(LED_PORT, LED_PINS);
+    else
+        gpio_bit_set(LED_PORT, LED_PINS);
+}
+
 
 void platform_disable_led(void)
 {   

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -76,6 +76,15 @@ void platform_post_sd_card_init();
 // Hooks
 void platform_end_of_loop_hook(void);
 
+// Write the status LED
+void platform_write_led(bool state);
+#define LED_ON()  platform_write_led(true)
+#define LED_OFF() platform_write_led(false)
+void platform_set_blink_status(bool status);
+void platform_write_led_override(bool state);
+#define LED_ON_OVERRIDE()  platform_write_led_override(true)
+#define LED_OFF_OVERRIDE()  platform_write_led_override(false)
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -76,11 +76,13 @@ void platform_post_sd_card_init();
 // Hooks
 void platform_end_of_loop_hook(void);
 
-// Write the status LED
+// Set the status LED only if it is not in a blinking routine
 void platform_write_led(bool state);
 #define LED_ON()  platform_write_led(true)
 #define LED_OFF() platform_write_led(false)
+// Used by the blinking routine
 void platform_set_blink_status(bool status);
+// LED override will set the status LED regardless of the blinking routine
 void platform_write_led_override(bool state);
 #define LED_ON_OVERRIDE()  platform_write_led_override(true)
 #define LED_OFF_OVERRIDE()  platform_write_led_override(false)

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_v1_4_gpio.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_v1_4_gpio.h
@@ -170,8 +170,6 @@
 #define LED_I_PIN    GPIO_PIN_4
 #define LED_E_PIN    GPIO_PIN_5
 #define LED_PINS     (LED_I_PIN | LED_E_PIN)
-#define LED_ON()     gpio_bit_reset(LED_PORT, LED_PINS)
-#define LED_OFF()    gpio_bit_set(LED_PORT, LED_PINS)
 
 // User LEDs
 #define USER_LED_PORT       GPIOC

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -63,6 +63,7 @@ const char *g_platform_name = PLATFORM_NAME;
 static bool g_scsi_initiator = false;
 static uint32_t g_flash_chip_size = 0;
 static bool g_uart_initialized = false;
+static bool g_led_blinking = false;
 /***************/
 /* GPIO init   */
 /***************/
@@ -485,6 +486,24 @@ void platform_post_sd_card_init() {}
 bool platform_is_initiator_mode_enabled()
 {
     return g_scsi_initiator;
+}
+
+void platform_write_led(bool state)
+{
+    if (g_led_blinking) return;
+
+    gpio_put(LED_PIN, state);
+}
+
+void platform_set_blink_status(bool status)
+{
+    g_led_blinking = status;
+}
+
+void platform_write_led_override(bool state)
+{
+    gpio_put(LED_PIN, state);
+
 }
 
 void platform_disable_led(void)

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -90,11 +90,13 @@ void platform_late_init();
 // Initialization after the SD Card has been found
 void platform_post_sd_card_init();
 
-// Write the status LED
+// Set the status LED only if it is not in a blinking routine
 void platform_write_led(bool state);
 #define LED_ON()  platform_write_led(true)
 #define LED_OFF() platform_write_led(false)
+// Used by the blinking routine
 void platform_set_blink_status(bool status);
+// LED override will set the status LED regardless of the blinking routine
 void platform_write_led_override(bool state);
 #define LED_ON_OVERRIDE()  platform_write_led_override(true)
 #define LED_OFF_OVERRIDE()  platform_write_led_override(false)

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -90,6 +90,15 @@ void platform_late_init();
 // Initialization after the SD Card has been found
 void platform_post_sd_card_init();
 
+// Write the status LED
+void platform_write_led(bool state);
+#define LED_ON()  platform_write_led(true)
+#define LED_OFF() platform_write_led(false)
+void platform_set_blink_status(bool status);
+void platform_write_led_override(bool state);
+#define LED_ON_OVERRIDE()  platform_write_led_override(true)
+#define LED_OFF_OVERRIDE()  platform_write_led_override(false)
+
 // Disable the status LED
 void platform_disable_led(void);
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_BS2.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_BS2.h
@@ -60,8 +60,6 @@
 
 // Status LED pins
 #define LED_PIN      25
-#define LED_ON()     sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()    sio_hw->gpio_clr = 1 << LED_PIN
 
 // SD card pins in SDIO mode
 #define SDIO_CLK 10

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Pico.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Pico.h
@@ -71,9 +71,6 @@
 
 // Status LED pins
 #define LED_PIN      16
-#define LED_ON()    sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()   sio_hw->gpio_clr = 1 << LED_PIN
-
 
 // SD card pins in SDIO mode
 #define SDIO_CLK 10

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Pico_2.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Pico_2.h
@@ -71,9 +71,6 @@
 
 // Status LED pins
 #define LED_PIN      16
-#define LED_ON()    sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()   sio_hw->gpio_clr = 1 << LED_PIN
-
 
 // SD card pins in SDIO mode
 #define SDIO_CLK 10

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_RP2040.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_RP2040.h
@@ -71,8 +71,6 @@
 
 // Status LED pins
 #define LED_PIN      25
-#define LED_ON()     sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()    sio_hw->gpio_clr = 1 << LED_PIN
 
 // SD card pins in SDIO mode
 #define SDIO_CLK 18

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_RP2350A.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_RP2350A.h
@@ -71,8 +71,6 @@
 
 // Status LED pins
 #define LED_PIN      25
-#define LED_ON()     sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()    sio_hw->gpio_clr = 1 << LED_PIN
 
 // SD card pins in SDIO mode
 #define SDIO_CLK 18


### PR DESCRIPTION
The purpose behind this change is to stop having USB console logging be jittery because of blinking function when there is no SD card inserted. This was due to the blinking function being delay based. Switched the blink function to polling and checks when blinking should occur with deadlines.