### PR TITLE
Fix ZuluSCSI v1.1plus firmware from not starting

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/scsi_accel_sync.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsi_accel_sync.cpp
@@ -471,7 +471,7 @@ void scsi_accel_sync_send(const uint8_t* data, uint32_t count, volatile int *res
     }
     else
     {
-        dbgmsg("No optimized routine for syncOffset=", syncOffset, " syndPeriod=", syncPeriod, ", using fallback");
+        dbgmsg("No optimized routine for syncOffset=", syncOffset, " syncPeriod=", syncPeriod, ", using fallback");
         while (count-- > 0)
         {
             while (TIMER_CNT(SCSI_SYNC_TIMER) > count + syncOffset && !*resetFlag);

--- a/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
@@ -56,10 +56,17 @@ bool SdioCard::begin(SdioConfig sdioConfig)
     nvic_irq_enable(SDIO_IRQn, 0, 0);
 
     g_sdio_error = sd_init();
+    static sd_error_enum last_error = SD_OK;
     if (g_sdio_error != SD_OK)
     {
-        // Don't spam the log when main program polls for card insertion.
-        dbgmsg("sd_init() failed: ", (int)g_sdio_error);
+        static uint32_t redisplay_error_start = millis();
+        // Don't spam the log when main program polls for card insertion, redisplay retry every 5 seconds.
+        if (last_error != g_sdio_error || (uint32_t)(millis() - redisplay_error_start) > 5000)
+        {
+            dbgmsg("sd_init() failed: ", (int)g_sdio_error);
+            last_error = g_sdio_error;
+            redisplay_error_start = millis();
+        }
         return false;
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,6 +101,7 @@ build_flags =
      -DPLATFORM_MASS_STORAGE
      -DSDFAT_NOARDUINO
      -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+     -DLOGBUFSIZE=8192
 
 ; ZuluSCSI settings shared among Raspberry Pi microcontroller like the RP2040 and RP2350
 [env:ZuluSCSI_RP2MCU]

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,8 +28,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "24.12.03"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "24.12.09"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR


### PR DESCRIPTION
The ZuluSCSI v1.1plus ran out of free SRAM and was overwriting some variables. The solution was to halve the logging buffer to 8K from 16k.

Also in debug mode the exact error number for the no SD card error was spamming the log. Now it only shows the error every five seconds when it is retrying or if the error number changes.