### PR TITLE
USB MSC initiator mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ LED indications in initiator mode:
 The firmware retries reads up to 5 times and attempts to skip any sectors that have problems.
 Any read errors are logged into `zululog.txt`.
 
+Alternatively, if SD card is not inserted, the SCSI drive will be available to PC through USB connection.
+The drive shows up as mass storage device (USB MSC).
+Currently this primarily supports SCSI harddrives, but basic read access is supported for CD-ROM and other SCSI devices.
+
 Depending on hardware setup, you may need to mount diode `D205` and jumper `JP201` to supply `TERMPWR` to the SCSI bus.
 This is necessary if the drives do not supply their own SCSI terminator power.
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -51,6 +51,10 @@ extern "C" {
 }
 #endif // ZULUSCSI_NETWORK
 
+#ifdef PLATFORM_MASS_STORAGE
+#include "ZuluSCSI_platform_msc.h"
+#endif
+
 #ifdef ENABLE_AUDIO_OUTPUT
 #  include "audio.h"
 #endif // ENABLE_AUDIO_OUTPUT
@@ -646,6 +650,11 @@ static void usb_log_poll()
 {
 #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
     static uint32_t logpos = 0;
+
+#ifdef PLATFORM_MASS_STORAGE
+    if (platform_msc_lock_get()) return; // Avoid re-entrant USB events
+#endif
+
     if (Serial.availableForWrite())
     {
         // Retrieve pointer to log start and determine number of bytes available.
@@ -670,6 +679,11 @@ static void usb_log_poll()
 static void usb_input_poll()
 {
     #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
+
+#ifdef PLATFORM_MASS_STORAGE
+    if (platform_msc_lock_get()) return; // Avoid re-entrant USB events
+#endif
+
     // Caputure reboot key sequence
     static bool mass_storage_reboot_keyed = false;
     static bool basic_reboot_keyed = false;

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
@@ -34,6 +34,9 @@
 #include <class/msc/msc.h>
 #include <class/msc/msc_device.h>
 
+#include <pico/mutex.h>
+extern mutex_t __usb_mutex;
+
 #if CFG_TUD_MSC_EP_BUFSIZE < SD_SECTOR_SIZE
   #error "CFG_TUD_MSC_EP_BUFSIZE is too small! It needs to be at least 512 (SD_SECTOR_SIZE)"
 #endif
@@ -43,6 +46,51 @@
 // external global SD variable
 extern SdFs SD;
 static bool unitReady = false;
+
+static bool g_msc_lock; // To block re-entrant calls
+static bool g_msc_usb_mutex_held;
+
+void platform_msc_lock_set(bool block)
+{
+  if (block)
+  {
+    if (g_msc_lock)
+    {
+      logmsg("Re-entrant MSC lock!");
+      assert(false);
+    }
+
+    g_msc_usb_mutex_held = mutex_try_enter(&__usb_mutex, NULL); // Blocks USB IRQ if not already blocked
+    g_msc_lock = true; // Blocks platform USB polling
+  }
+  else
+  {
+    if (!g_msc_lock)
+    {
+      logmsg("MSC lock released when not held!");
+      assert(false);
+    }
+
+    g_msc_lock = false;
+
+    if (g_msc_usb_mutex_held)
+    {
+      g_msc_usb_mutex_held = false;
+      mutex_exit(&__usb_mutex);
+    }
+  }
+}
+
+bool platform_msc_lock_get()
+{
+  return g_msc_lock;
+}
+
+struct MSCScopedLock {
+public:
+  MSCScopedLock() {  platform_msc_lock_set(true); }
+  ~MSCScopedLock() { platform_msc_lock_set(false); }
+};
 
 /* return true if USB presence detected / eligble to enter CR mode */
 bool platform_sense_msc() {
@@ -111,6 +159,7 @@ void __USBInstallMassStorage() { }
 extern "C" void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8],
                         uint8_t product_id[16], uint8_t product_rev[4]) {
 
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_inquiry_cb(lun, vendor_id, product_id, product_rev);
 
   const char vid[] = "ZuluSCSI";
@@ -124,7 +173,9 @@ extern "C" void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8],
 
 // max LUN supported
 // we only have the one SD card
-extern "C" uint8_t tud_msc_get_maxlun_cb(void) {
+extern "C" uint8_t tud_msc_get_maxlun_cb(void)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_get_maxlun_cb();
 
   return 1; // number of LUNs supported
@@ -135,6 +186,7 @@ extern "C" uint8_t tud_msc_get_maxlun_cb(void) {
 // otherwise this is not actually needed
 extern "C" bool tud_msc_is_writable_cb (uint8_t lun)
 {
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_is_writable_cb(lun);
 
   (void) lun;
@@ -144,6 +196,7 @@ extern "C" bool tud_msc_is_writable_cb (uint8_t lun)
 // see https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf pg 221
 extern "C" bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
 {
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_start_stop_cb(lun, power_condition, start, load_eject);
 
   if (load_eject)  {
@@ -159,7 +212,9 @@ extern "C" bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool
 }
 
 // return true if we are ready to service reads/writes
-extern "C" bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+extern "C" bool tud_msc_test_unit_ready_cb(uint8_t lun)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_test_unit_ready_cb(lun);
 
   return unitReady;
@@ -167,7 +222,9 @@ extern "C" bool tud_msc_test_unit_ready_cb(uint8_t lun) {
 
 // return size in blocks and block size
 extern "C" void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count,
-                         uint16_t *block_size) {
+                         uint16_t *block_size)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_capacity_cb(lun, block_count, block_size);
 
   *block_count = unitReady ? (SD.card()->sectorCount()) : 0;
@@ -177,7 +234,9 @@ extern "C" void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count,
 // Callback invoked when received an SCSI command not in built-in list (below) which have their own callbacks
 // - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE, READ10 and WRITE10
 extern "C" int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer,
-                        uint16_t bufsize) {
+                        uint16_t bufsize)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_scsi_cb(lun, scsi_cmd, buffer, bufsize);
 
   const void *response = NULL;
@@ -216,6 +275,7 @@ extern "C" int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void
 extern "C" int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, 
                             void* buffer, uint32_t bufsize)
 {
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_read10_cb(lun, lba, offset, buffer, bufsize);
 
   bool rc = SD.card()->readSectors(lba, (uint8_t*) buffer, bufsize/SD_SECTOR_SIZE);
@@ -230,7 +290,9 @@ extern "C" int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
 // Callback invoked when receive WRITE10 command.
 // Process data in buffer to disk's storage and return number of written bytes (must be multiple of block size)
 extern "C" int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
-                           uint8_t *buffer, uint32_t bufsize) {
+                           uint8_t *buffer, uint32_t bufsize)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_read10_cb(lun, lba, offset, buffer, bufsize);
 
   bool rc = SD.card()->writeSectors(lba, buffer, bufsize/SD_SECTOR_SIZE);
@@ -243,7 +305,9 @@ extern "C" int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset
 
 // Callback invoked when WRITE10 command is completed (status received and accepted by host).
 // used to flush any pending cache to storage
-extern "C" void tud_msc_write10_complete_cb(uint8_t lun) {
+extern "C" void tud_msc_write10_complete_cb(uint8_t lun)
+{
+  MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_write10_complete_cb(lun);
 }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.h
@@ -37,4 +37,10 @@ bool platform_run_msc();
 /* perform any cleanup tasks for the MSC-specific functionality */
 void platform_exit_msc();
 
+/* Block re-entrant msc poll calls.
+   This avoids starting another command handler while first one is running.
+   */
+void platform_msc_lock_set(bool block);
+bool platform_msc_lock_get();
+
 #endif

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -54,6 +54,9 @@
 #endif
 #define LOG_SAVE_INTERVAL_MS 1000
 
+// How often to check for SD card presence
+#define SDCARD_POLL_INTERVAL 5000
+
 // Watchdog timeout
 // Watchdog will first issue a bus reset and if that does not help, crashdump.
 #define WATCHDOG_BUS_RESET_TIMEOUT 15000

--- a/src/ZuluSCSI_initiator.h
+++ b/src/ZuluSCSI_initiator.h
@@ -34,6 +34,9 @@ void scsiInitiatorInit();
 
 void scsiInitiatorMainLoop();
 
+// Get the SCSI ID used by the initiator itself
+int scsiInitiatorGetOwnID();
+
 // Select target and execute SCSI command
 int scsiInitiatorRunCommand(int target_id,
                             const uint8_t *command, size_t cmdLen,

--- a/src/ZuluSCSI_msc_initiator.cpp
+++ b/src/ZuluSCSI_msc_initiator.cpp
@@ -1,0 +1,353 @@
+/* Initiator mode USB Mass Storage Class connection.
+ * This file binds platform-specific MSC routines to the initiator mode
+ * SCSI bus interface. The call structure is modeled after TinyUSB, but
+ * should be usable with other USB libraries.
+ *
+ * ZuluSCSI™ - Copyright (c) 2023 Rabbit Hole Computing™
+ *
+ * This file is licensed under the GPL version 3 or any later version. 
+ * It is derived from cdrom.c in SCSI2SD V6
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "ZuluSCSI_config.h"
+#include "ZuluSCSI_log.h"
+#include "ZuluSCSI_log_trace.h"
+#include "ZuluSCSI_initiator.h"
+#include <ZuluSCSI_platform.h>
+#include <minIni.h>
+#include "SdFat.h"
+
+bool g_msc_initiator;
+
+#ifndef PLATFORM_HAS_INITIATOR_MODE
+
+bool setup_msc_initiator() { return false; }
+void poll_msc_initiator() {}
+
+void init_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
+uint8_t init_msc_get_maxlun_cb(void) { return 0; }
+bool init_msc_is_writable_cb (uint8_t lun) { return false; }
+bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject) { return false; }
+bool init_msc_test_unit_ready_cb(uint8_t lun) { return false; }
+void init_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size) {}
+int32_t init_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, uint16_t bufsize) {return -1;}
+int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {return -1;}
+int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize) { return -1;}
+void init_msc_write10_complete_cb(uint8_t lun) {}
+
+#else
+
+// If there are multiple SCSI devices connected, they are mapped into LUNs for host.
+static struct {
+    int target_id;
+    uint32_t sectorsize;
+    uint32_t sectorcount;
+} g_msc_initiator_targets[NUM_SCSIID];
+static int g_msc_initiator_target_count;
+
+static void scan_targets()
+{
+    int initiator_id = scsiInitiatorGetOwnID();
+    uint8_t inquiry_data[36] = {0};
+    g_msc_initiator_target_count = 0;
+    for (int target_id = 0; target_id < NUM_SCSIID; target_id++)
+    {
+        if (target_id == initiator_id) continue;
+
+        if (scsiTestUnitReady(target_id))
+        {
+            uint32_t sectorcount, sectorsize;
+
+            bool inquiryok =
+                scsiStartStopUnit(target_id, true) &&
+                scsiInquiry(target_id, inquiry_data) &&
+                scsiInitiatorReadCapacity(target_id, &sectorcount, &sectorsize);
+
+            char vendor_id[9] = {0};
+            char product_id[17] = {0};
+            memcpy(vendor_id, &inquiry_data[8], 8);
+            memcpy(product_id, &inquiry_data[16], 16);
+
+            if (inquiryok)
+            {
+                logmsg("Found SCSI drive with ID ", target_id, ": ", vendor_id, " ", product_id);
+                g_msc_initiator_targets[g_msc_initiator_target_count].target_id = target_id;
+                g_msc_initiator_targets[g_msc_initiator_target_count].sectorcount = sectorcount;
+                g_msc_initiator_targets[g_msc_initiator_target_count].sectorsize = sectorsize;
+                g_msc_initiator_target_count++;
+            }
+            else
+            {
+                logmsg("Detected SCSI device with ID ", target_id, ", but failed to get inquiry response, skipping");
+            }
+        }
+    }
+}
+
+bool setup_msc_initiator()
+{
+    logmsg("SCSI Initiator: activating USB MSC mode");
+    g_msc_initiator = true;
+
+    scsiInitiatorInit();
+
+    // Scan for targets
+    scan_targets();
+
+    logmsg("SCSI Initiator: found " , g_msc_initiator_target_count, " SCSI drives");
+    return g_msc_initiator_target_count > 0;
+}
+
+void poll_msc_initiator()
+{
+    if (g_msc_initiator_target_count == 0)
+    {
+        // Scan for targets until we find one
+        scan_targets();
+    }
+}
+
+static int get_target(uint8_t lun)
+{
+    if (lun >= g_msc_initiator_target_count)
+    {
+        logmsg("Host requested access to non-existing lun ", (int)lun);
+        return 0;
+    }
+    else
+    {
+        return g_msc_initiator_targets[lun].target_id;
+    }
+}
+
+void init_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
+{
+    int target = get_target(lun);
+    uint8_t response[36] = {0};
+    bool status = scsiInquiry(target, response);
+    if (!status)
+    {
+        logmsg("SCSI Inquiry to target ", target, " failed");
+    }
+
+    memcpy(vendor_id, &response[8], 8);
+    memcpy(product_id, &response[16], 16);
+    memcpy(product_rev, &response[32], 4);
+}
+
+uint8_t init_msc_get_maxlun_cb(void)
+{
+    return g_msc_initiator_target_count;
+}
+
+bool init_msc_is_writable_cb (uint8_t lun)
+{
+    int target = get_target(lun);
+    uint8_t command[6] = {0x1A, 0x08, 0, 0, 4, 0}; // MODE SENSE(6)
+    uint8_t response[4] = {0};
+    scsiInitiatorRunCommand(target, command, 6, response, 4, NULL, 0);
+    return (response[2] & 0x80) == 0; // Check write protected bit
+}
+
+bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
+{
+    int target = get_target(lun);
+    uint8_t command[6] = {0x1B, 0x1, 0, 0, 0, 0};
+    uint8_t response[4] = {0};
+    
+    if (start)
+    {
+        command[4] |= 1; // Start
+        command[1] = 0;  // Immediate
+    }
+
+    if (load_eject)
+    {
+        command[4] |= 2;
+    }
+
+    command[4] |= power_condition << 4;
+
+    int status = scsiInitiatorRunCommand(target,
+                                         command, sizeof(command),
+                                         response, sizeof(response),
+                                         NULL, 0);
+
+    if (status == 2)
+    {
+        uint8_t sense_key;
+        scsiRequestSense(target, &sense_key);
+        logmsg("START STOP UNIT on target ", target, " failed, sense key ", sense_key);
+    }
+
+    return status == 0;
+}
+
+bool init_msc_test_unit_ready_cb(uint8_t lun)
+{
+    return scsiTestUnitReady(get_target(lun));
+}
+
+void init_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size)
+{
+    uint32_t sectorcount = 0;
+    uint32_t sectorsize = 0;
+    scsiInitiatorReadCapacity(get_target(lun), &sectorcount, &sectorsize);
+    *block_count = sectorcount;
+    *block_size = sectorsize;
+}
+
+int32_t init_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, uint16_t bufsize)
+{
+    // NOTE: the TinyUSB API around free-form commands is not very good,
+    // this function could need improvement.
+    
+    // Figure out command length
+    static const uint8_t CmdGroupBytes[8] = {6, 10, 10, 6, 16, 12, 6, 6}; // From SCSI2SD
+    int cmdlen = CmdGroupBytes[scsi_cmd[0] >> 5];
+
+    int target = get_target(lun);
+    int status = scsiInitiatorRunCommand(target,
+                                         scsi_cmd, cmdlen,
+                                         NULL, 0,
+                                         (const uint8_t*)buffer, bufsize);
+
+    return status;
+}
+
+int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize)
+{
+    int status = -1;
+
+    int target_id = get_target(lun);
+    int sectorsize = g_msc_initiator_targets[lun].sectorsize;
+    uint32_t start_sector = lba;
+    uint32_t sectorcount = bufsize / sectorsize;
+
+    if (sectorcount == 0)
+    {
+        // Not enough buffer left for a full sector
+        return 0;
+    }
+
+    // Read6 command supports 21 bit LBA - max of 0x1FFFFF
+    // ref: https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf pg 134
+    if (start_sector < 0x1FFFFF && sectorcount <= 256)
+    {
+        // Use READ6 command for compatibility with old SCSI1 drives
+        uint8_t command[6] = {0x08,
+            (uint8_t)(start_sector >> 16),
+            (uint8_t)(start_sector >> 8),
+            (uint8_t)start_sector,
+            (uint8_t)sectorcount,
+            0x00
+        };
+
+        status = scsiInitiatorRunCommand(target_id, command, sizeof(command), (uint8_t*)buffer, bufsize, NULL, 0);
+    }
+    else
+    {
+        // Use READ10 command for larger number of blocks
+        uint8_t command[10] = {0x28, 0x00,
+            (uint8_t)(start_sector >> 24), (uint8_t)(start_sector >> 16),
+            (uint8_t)(start_sector >> 8), (uint8_t)start_sector,
+            0x00,
+            (uint8_t)(sectorcount >> 8), (uint8_t)(sectorcount),
+            0x00
+        };
+
+        status = scsiInitiatorRunCommand(target_id, command, sizeof(command), (uint8_t*)buffer, bufsize, NULL, 0);
+    }
+
+
+    if (status != 0)
+    {
+        uint8_t sense_key;
+        scsiRequestSense(target_id, &sense_key);
+
+        logmsg("SCSI Initiator read failed: ", status, " sense key ", sense_key);
+        return -1;
+    }
+
+    return sectorcount * sectorsize;
+}
+
+int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize)
+{
+    int status = -1;
+
+    int target_id = get_target(lun);
+    int sectorsize = g_msc_initiator_targets[lun].sectorsize;
+    uint32_t start_sector = lba;
+    uint32_t sectorcount = bufsize / sectorsize;
+
+    if (sectorcount == 0)
+    {
+        // Not a complete sector
+        return 0;
+    }
+
+    // Write6 command supports 21 bit LBA - max of 0x1FFFFF
+    if (start_sector < 0x1FFFFF && sectorcount <= 256)
+    {
+        // Use WRITE6 command for compatibility with old SCSI1 drives
+        uint8_t command[6] = {0x0A,
+            (uint8_t)(start_sector >> 16),
+            (uint8_t)(start_sector >> 8),
+            (uint8_t)start_sector,
+            (uint8_t)sectorcount,
+            0x00
+        };
+
+        status = scsiInitiatorRunCommand(target_id, command, sizeof(command), NULL, 0, buffer, bufsize);
+    }
+    else
+    {
+        // Use READ10 command for larger number of blocks
+        uint8_t command[10] = {0x2A, 0x00,
+            (uint8_t)(start_sector >> 24), (uint8_t)(start_sector >> 16),
+            (uint8_t)(start_sector >> 8), (uint8_t)start_sector,
+            0x00,
+            (uint8_t)(sectorcount >> 8), (uint8_t)(sectorcount),
+            0x00
+        };
+
+        status = scsiInitiatorRunCommand(target_id, command, sizeof(command), NULL, 0, buffer, bufsize);
+    }
+
+
+    if (status != 0)
+    {
+        uint8_t sense_key;
+        scsiRequestSense(target_id, &sense_key);
+
+        logmsg("SCSI Initiator write failed: ", status, " sense key ", sense_key);
+        return -1;
+    }
+
+    return sectorcount * sectorsize;
+}
+
+void init_msc_write10_complete_cb(uint8_t lun)
+{
+    (void)lun;
+}
+
+
+#endif

--- a/src/ZuluSCSI_msc_initiator.cpp
+++ b/src/ZuluSCSI_msc_initiator.cpp
@@ -138,6 +138,8 @@ static int get_target(uint8_t lun)
 
 void init_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
 {
+    LED_ON();
+
     int target = get_target(lun);
     uint8_t response[36] = {0};
     bool status = scsiInquiry(target, response);
@@ -149,6 +151,8 @@ void init_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[1
     memcpy(vendor_id, &response[8], 8);
     memcpy(product_id, &response[16], 16);
     memcpy(product_rev, &response[32], 4);
+
+    LED_OFF();
 }
 
 uint8_t init_msc_get_maxlun_cb(void)
@@ -167,6 +171,8 @@ bool init_msc_is_writable_cb (uint8_t lun)
 
 bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
 {
+    LED_ON();
+
     int target = get_target(lun);
     uint8_t command[6] = {0x1B, 0x1, 0, 0, 0, 0};
     uint8_t response[4] = {0};
@@ -195,6 +201,8 @@ bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bo
         scsiRequestSense(target, &sense_key);
         logmsg("START STOP UNIT on target ", target, " failed, sense key ", sense_key);
     }
+
+    LED_OFF();
 
     return status == 0;
 }
@@ -233,6 +241,8 @@ int32_t init_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, 
 
 int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize)
 {
+    LED_ON();
+
     int status = -1;
 
     int target_id = get_target(lun);
@@ -275,6 +285,7 @@ int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf
         status = scsiInitiatorRunCommand(target_id, command, sizeof(command), (uint8_t*)buffer, bufsize, NULL, 0);
     }
 
+    LED_OFF();
 
     if (status != 0)
     {
@@ -302,6 +313,8 @@ int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t 
         // Not a complete sector
         return 0;
     }
+
+    LED_ON();
 
     // Write6 command supports 21 bit LBA - max of 0x1FFFFF
     if (start_sector < 0x1FFFFF && sectorcount <= 256)
@@ -331,6 +344,7 @@ int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t 
         status = scsiInitiatorRunCommand(target_id, command, sizeof(command), NULL, 0, buffer, bufsize);
     }
 
+    LED_OFF();
 
     if (status != 0)
     {

--- a/src/ZuluSCSI_msc_initiator.h
+++ b/src/ZuluSCSI_msc_initiator.h
@@ -1,0 +1,46 @@
+/* Initiator mode USB Mass Storage Class connection.
+ * This file binds platform-specific MSC routines to the initiator mode
+ * SCSI bus interface. The call structure is modeled after TinyUSB, but
+ * should be usable with other USB libraries.
+ *
+ * ZuluSCSI™ - Copyright (c) 2023 Rabbit Hole Computing™
+ *
+ * This file is licensed under the GPL version 3 or any later version. 
+ * It is derived from cdrom.c in SCSI2SD V6
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <stdint.h>
+
+// When true, initiator MSC mode is enabled.
+extern bool g_msc_initiator;
+bool setup_msc_initiator();
+void poll_msc_initiator();
+
+void init_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]);
+uint8_t init_msc_get_maxlun_cb(void);
+bool init_msc_is_writable_cb (uint8_t lun);
+bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject);
+bool init_msc_test_unit_ready_cb(uint8_t lun);
+void init_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size);
+int32_t init_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, uint16_t bufsize);
+int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize);
+void init_msc_write10_complete_cb(uint8_t lun);
+
+

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -44,6 +44,7 @@
 #InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
 #InitiatorMaxRetry = 5 #  number of retries on failed reads 0-255, default is 5
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
+#InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
 
 #EnableCDAudio = 0 # 1: Enable CD audio - an external I2S DAC on the v1.2 is required
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -45,6 +45,7 @@
 #InitiatorMaxRetry = 5 #  number of retries on failed reads 0-255, default is 5
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
 #InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
+#InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
 
 #EnableCDAudio = 0 # 1: Enable CD audio - an external I2S DAC on the v1.2 is required
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -44,8 +44,10 @@
 #InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
 #InitiatorMaxRetry = 5 #  number of retries on failed reads 0-255, default is 5
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
+
 #InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
+#InitiatorMSCStatusInterval = 5000 # Periodically report access status to log
 
 #EnableCDAudio = 0 # 1: Enable CD audio - an external I2S DAC on the v1.2 is required
 


### PR DESCRIPTION
This allows connected SCSI drives to be visible to PC as USB mass storage devices.

Performance is limited by USB full-speed connection. Read access achieves about 800 kB/s.