### PR TITLE
Move SD card errors for no SD card to debug mode

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -23,6 +23,7 @@
 #include "gd32f20x_sdio.h"
 #include "gd32f20x_fmc.h"
 #include "gd32f20x_fwdgt.h"
+#include "gd32_sdio_sdcard.h"
 #include "ZuluSCSI_log.h"
 #include "ZuluSCSI_config.h"
 #include "usbd_conf.h"
@@ -488,6 +489,10 @@ void platform_disable_led(void)
     logmsg("Disabling status LED");
 }
 
+uint8_t platform_no_sd_card_on_init_error_code()
+{
+    return 0x80 | SD_CMD_RESP_TIMEOUT;
+}
 /*****************************************/
 /* Supply voltage monitor                */
 /*****************************************/

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -98,6 +98,9 @@ void platform_write_led_override(bool state);
 // Disable the status LED
 void platform_disable_led(void);
 
+// Specific error code tied to the MCU when the SD card is not detected
+uint8_t platform_no_sd_card_on_init_error_code();
+
 // Setup soft watchdog
 void platform_reset_watchdog();
 

--- a/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/sd_card_sdio.cpp
@@ -44,7 +44,7 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    dbgmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
     return false;
 }
 

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -23,6 +23,7 @@
 #include "gd32f4xx_sdio.h"
 #include "gd32f4xx_fmc.h"
 #include "gd32f4xx_fwdgt.h"
+#include "gd32_sdio_sdcard.h"
 #include "ZuluSCSI_log.h"
 #include "ZuluSCSI_config.h"
 #include "usb_hs.h"
@@ -329,6 +330,11 @@ void platform_disable_led(void)
 {   
     gpio_mode_set(LED_PORT, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, LED_PINS);
     logmsg("Disabling status LED");
+}
+
+uint8_t platform_no_sd_card_on_init_error_code()
+{
+    return 0x80 | SD_CMD_RESP_TIMEOUT;
 }
 
 /*****************************************/

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -90,6 +90,9 @@ void platform_write_led_override(bool state);
 // Disable the status LED
 void platform_disable_led(void);
 
+// Specific error code tied to the MCU when the SD card is not detected
+uint8_t platform_no_sd_card_on_init_error_code();
+
 // Setup soft watchdog
 void platform_reset_watchdog();
 

--- a/lib/ZuluSCSI_platform_GD32F450/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/sd_card_sdio.cpp
@@ -46,7 +46,7 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    dbgmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
     return false;
 }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -22,6 +22,7 @@
 #include "ZuluSCSI_platform.h"
 #include "ZuluSCSI_log.h"
 #include <SdFat.h>
+#include <sdio.h>
 #include <scsi.h>
 #include <assert.h>
 #include <hardware/gpio.h>
@@ -534,6 +535,11 @@ void platform_disable_led(void)
     //        pin      function       pup   pdown  out    state fast
     gpio_conf(LED_PIN, GPIO_FUNC_SIO, false,false, false, false, false);
     logmsg("Disabling status LED");
+}
+
+uint8_t platform_no_sd_card_on_init_error_code()
+{
+    return SDIO_ERR_RESPONSE_TIMEOUT;
 }
 
 /*****************************************/

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -104,6 +104,9 @@ void platform_write_led_override(bool state);
 // Disable the status LED
 void platform_disable_led(void);
 
+// Specific error code tied to the MCU when the SD card is not detected
+uint8_t platform_no_sd_card_on_init_error_code();
+
 // Query whether initiator mode is enabled on targets with PLATFORM_HAS_INITIATOR_MODE
 bool platform_is_initiator_mode_enabled();
 

--- a/lib/ZuluSCSI_platform_RP2MCU/sd_card_sdio.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/sd_card_sdio.cpp
@@ -47,7 +47,7 @@ static uint32_t g_sdio_sector_count;
 static bool logSDError(int line)
 {
     g_sdio_error_line = line;
-    logmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
+    dbgmsg("SDIO SD card error on line ", line, ", error code ", (int)g_sdio_error);
     return false;
 }
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -958,12 +958,24 @@ static void firmware_update()
 // Which is pretty much everything after platform_init and and platform_late_init
 static void zuluscsi_setup_sd_card(bool wait_for_card = true)
 {
-
   g_sdcard_present = mountSDCard();
 
   if(!g_sdcard_present)
   {
-    logmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
+    if (SD.sdErrorCode() == platform_no_sd_card_on_init_error_code())
+    {
+  #ifdef PLATFORM_HAS_INITIATOR_MODE
+      if (platform_is_initiator_mode_enabled())
+      {
+        logmsg("No SD card detected, imaging to SD card not possible");
+      }
+      else
+  #endif
+      {
+        logmsg("No SD card detected, please check SD card slot to make sure it is in correctly");
+      }
+    }
+    dbgmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
            " sdErrorData: ", (int)SD.sdErrorData());
 
     if (romDriveCheckPresent())


### PR DESCRIPTION
Moved raw error messages when there is no SD card to debug mode. Provide a simple log message when there is no sd card at boot for both initiator mode and standard device operation.