### PR TITLE
Improve USB MSC initiator support

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
@@ -73,6 +73,8 @@ SECTIONS
         /* Put only non-timecritical code in flash
          * This includes e.g. floating point math routines.
          */
+        .pio/build/$project_name/src/ZuluSCSI_initiator.cpp.o(.text .text*)
+        .pio/build/$project_name/src/ZuluSCSI_msc_initiator.cpp.o(.text .text*)
         .pio/build/$project_name/src/ZuluSCSI_log.cpp.o(.text .text*)
         .pio/build/$project_name/src/ZuluSCSI_log_trace.cpp.o(.text .text*)
         .pio/build/$project_name/src/ZuluSCSI_settings.cpp.o(.text .text*)

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -691,7 +691,7 @@ bool scsiInitiatorReadCapacity(int target_id, uint32_t *sectorcount, uint32_t *s
     {
         uint8_t sense_key;
         scsiRequestSense(target_id, &sense_key);
-        logmsg("READ CAPACITY on target ", target_id, " failed, sense key ", sense_key);
+        scsiLogInitiatorCommandFailure("READ CAPACITY", target_id, status, sense_key);
         return false;
     }
     else
@@ -748,7 +748,7 @@ bool scsiStartStopUnit(int target_id, bool start)
     {
         uint8_t sense_key;
         scsiRequestSense(target_id, &sense_key);
-        dbgmsg("START STOP UNIT on target ", target_id, " failed, sense key ", sense_key);
+        scsiLogInitiatorCommandFailure("START STOP UNIT", target_id, status, sense_key);
     }
 
     return status == 0;
@@ -790,13 +790,13 @@ bool scsiTestUnitReady(int target_id)
             uint8_t sense_key;
             scsiRequestSense(target_id, &sense_key);
 
-            if (sense_key == 6)
+            if (sense_key == UNIT_ATTENTION)
             {
                 uint8_t inquiry[36];
                 dbgmsg("Target ", target_id, " reports UNIT_ATTENTION, running INQUIRY");
                 scsiInquiry(target_id, inquiry);
             }
-            else if (sense_key == 2)
+            else if (sense_key == NOT_READY)
             {
                 dbgmsg("Target ", target_id, " reports NOT_READY, running STARTSTOPUNIT");
                 scsiStartStopUnit(target_id, true);
@@ -957,7 +957,7 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
         uint8_t sense_key;
         scsiRequestSense(target_id, &sense_key);
 
-        logmsg("scsiInitiatorReadDataToFile: READ failed: ", status, " sense key ", sense_key);
+        scsiLogInitiatorCommandFailure("scsiInitiatorReadDataToFile command phase", target_id, status, sense_key);
         scsiHostPhyRelease();
         return false;
     }
@@ -1055,7 +1055,7 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
         }
         else
         {
-            logmsg("scsiInitiatorReadDataToFile: READ failed: ", status, " sense key ", sense_key);
+            scsiLogInitiatorCommandFailure("scsiInitiatorReadDataToFile data phase", target_id, status, sense_key);
             return false;
         }
     }

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -331,3 +331,31 @@ void scsiLogDataOut(const uint8_t *buf, uint32_t length)
 
     g_OutByteCount += length;
 }
+
+static const char *get_sense_key_name(uint8_t sense_key)
+{
+    switch (sense_key)
+    {
+        case RECOVERED_ERROR:              return "RECOVERED_ERROR";
+        case NOT_READY      :              return "NOT_READY";
+        case MEDIUM_ERROR   :              return "MEDIUM_ERROR";
+        case HARDWARE_ERROR :              return "HARDWARE_ERROR";
+        case ILLEGAL_REQUEST:              return "ILLEGAL_REQUEST";
+        case UNIT_ATTENTION :              return "UNIT_ATTENTION";
+        case DATA_PROTECT   :              return "DATA_PROTECT";
+        case BLANK_CHECK    :              return "BLANK_CHECK";
+        case VENDOR_SPECIFIC:              return "VENDOR_SPECIFIC";
+        case COPY_ABORTED   :              return "COPY_ABORTED";
+        case ABORTED_COMMAND:              return "ABORTED_COMMAND";
+        case EQUAL          :              return "EQUAL";
+        case VOLUME_OVERFLOW:              return "VOLUME_OVERFLOW";
+        case MISCOMPARE     :              return "MISCOMPARE";
+        case RESERVED       :              return "RESERVED";
+        default: return "UNKNOWN";
+    }
+}
+
+void scsiLogInitiatorCommandFailure(const char *command_text, int target_id, int status, uint8_t sense_key)
+{
+    logmsg("-- ", command_text, " on target ", target_id, " failed with status ", status, " and sense_key ", sense_key, " (", get_sense_key_name(sense_key), ")");
+}

--- a/src/ZuluSCSI_log_trace.h
+++ b/src/ZuluSCSI_log_trace.h
@@ -31,3 +31,4 @@ void scsiLogPhaseChange(int new_phase);
 void scsiLogInitiatorPhaseChange(int new_phase);
 void scsiLogDataIn(const uint8_t *buf, uint32_t length);
 void scsiLogDataOut(const uint8_t *buf, uint32_t length);
+void scsiLogInitiatorCommandFailure(const char *command_text, int target_id, int status, uint8_t sense_key);

--- a/src/ZuluSCSI_msc_initiator.cpp
+++ b/src/ZuluSCSI_msc_initiator.cpp
@@ -494,8 +494,19 @@ int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf
         uint8_t sense_key;
         scsiRequestSense(target_id, &sense_key);
 
-        logmsg("SCSI Initiator read failed: ", status, " sense key ", sense_key);
-        return -1;
+        if (sense_key == RECOVERED_ERROR)
+        {
+            dbgmsg("SCSI Initiator read: RECOVERED_ERROR at ", (int)orig_lba);
+        }
+        else if (sense_key == UNIT_ATTENTION)
+        {
+            dbgmsg("SCSI Initiator read: UNIT_ATTENTION");
+        }
+        else
+        {
+            logmsg("SCSI Initiator read failed: ", status, " sense key ", sense_key);
+            return -1;
+        }
     }
 
     if (lba + total_sectorcount <= g_msc_initiator_targets[lun].sectorcount)
@@ -576,8 +587,19 @@ int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t 
         uint8_t sense_key;
         scsiRequestSense(target_id, &sense_key);
 
-        logmsg("SCSI Initiator write failed: ", status, " sense key ", sense_key);
-        return -1;
+        if (sense_key == RECOVERED_ERROR)
+        {
+            dbgmsg("SCSI Initiator write: RECOVERED_ERROR at ", (int)start_sector);
+        }
+        else if (sense_key == UNIT_ATTENTION)
+        {
+            dbgmsg("SCSI Initiator write: UNIT_ATTENTION");
+        }
+        else
+        {
+            logmsg("SCSI Initiator write failed: ", status, " sense key ", sense_key);
+            return -1;
+        }
     }
 
     return sectorcount * sectorsize;

--- a/src/ZuluSCSI_msc_initiator.cpp
+++ b/src/ZuluSCSI_msc_initiator.cpp
@@ -330,7 +330,7 @@ bool init_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bo
     {
         uint8_t sense_key;
         scsiRequestSense(target, &sense_key);
-        logmsg("START STOP UNIT on target ", target, " failed, sense key ", sense_key);
+        scsiLogInitiatorCommandFailure("START STOP UNIT", target, status, sense_key);
     }
 
     LED_OFF();
@@ -504,7 +504,7 @@ int32_t init_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void* buf
         }
         else
         {
-            logmsg("SCSI Initiator read failed: ", status, " sense key ", sense_key);
+            scsiLogInitiatorCommandFailure("SCSI Initiator read", target_id, status, sense_key);
             return -1;
         }
     }
@@ -597,7 +597,7 @@ int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t 
         }
         else
         {
-            logmsg("SCSI Initiator write failed: ", status, " sense key ", sense_key);
+            scsiLogInitiatorCommandFailure("SCSI Initiator write", target_id, status, sense_key);
             return -1;
         }
     }


### PR DESCRIPTION
Made the USB MSC initiator mode more robust.

Tested against ST-296N drive that has a large amount of bad blocks with ddrescue.
Reading is slow because of a lot of medium errors reported by the drive, but is able to correctly handle the error statuses and transfer progresses.