### PR TITLE
Allow user to invert Status LED via zuluscsi.ini

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <audio.h>
 #include <ZuluSCSI_audio.h>
+#include <ZuluSCSI_settings.h>
 
 extern SdFs SD;
 extern bool g_rawdrive_active;
@@ -464,6 +465,10 @@ void platform_post_sd_card_init()
 void platform_write_led(bool state)
 {
     if (g_led_blinking) return;
+
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
+
     if (state)
         gpio_bit_reset(LED_PORT, LED_PINS);
     else
@@ -477,6 +482,9 @@ void platform_set_blink_status(bool status)
 
 void platform_write_led_override(bool state)
 {
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
+
     if (state)
         gpio_bit_reset(LED_PORT, LED_PINS);
     else

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -33,6 +33,7 @@
 #include <scsi.h>
 #include <assert.h>
 #include "usb_serial.h"
+#include <ZuluSCSI_settings.h>
 
 extern bool g_rawdrive_active;
 
@@ -306,6 +307,10 @@ void platform_post_sd_card_init() {}
 void platform_write_led(bool state)
 {
     if (g_led_blinking) return;
+
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
+
     if (state)
         gpio_bit_reset(LED_PORT, LED_PINS);
     else
@@ -319,6 +324,9 @@ void platform_set_blink_status(bool status)
 
 void platform_write_led_override(bool state)
 {
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
+
     if (state)
         gpio_bit_reset(LED_PORT, LED_PINS);
     else

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -38,6 +38,7 @@
 #include <hardware/sync.h>
 #include "scsi_accel_target.h"
 #include "custom_timings.h"
+#include <ZuluSCSI_settings.h>
 
 #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
 # include <SerialUSB.h>
@@ -516,6 +517,8 @@ void platform_write_led(bool state)
 {
     if (g_led_blinking) return;
 
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
     gpio_put(LED_PIN, state);
 }
 
@@ -526,6 +529,8 @@ void platform_set_blink_status(bool status)
 
 void platform_write_led_override(bool state)
 {
+    if (g_scsi_settings.getSystem()->invertStatusLed)
+        state = !state;
     gpio_put(LED_PIN, state);
 
 }

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -299,7 +299,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgSys.enableCDAudio = false;
     cfgSys.enableUSBMassStorage = false;
     cfgSys.usbMassStorageWaitPeriod = 1000;
-    
+    cfgSys.invertStatusLed = false;
+
     // setting set for all or specific devices
     cfgDev.deviceType = S2S_CFG_NOT_SET;
     cfgDev.deviceTypeModifier = 0;
@@ -395,7 +396,9 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
 
     cfgSys.enableUSBMassStorage = ini_getbool("SCSI", "EnableUSBMassStorage", cfgSys.enableUSBMassStorage, CONFIGFILE);
     cfgSys.usbMassStorageWaitPeriod = ini_getl("SCSI", "USBMassStorageWaitPeriod", cfgSys.usbMassStorageWaitPeriod, CONFIGFILE);
-    
+
+    cfgSys.invertStatusLed = ini_getbool("SCSI", "InvertStatusLED", cfgSys.invertStatusLed, CONFIGFILE);
+
     return &cfgSys;
 }
 

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -67,6 +67,9 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
     bool enableCDAudio;
     bool enableUSBMassStorage;
     uint16_t usbMassStorageWaitPeriod;
+
+    bool invertStatusLed;
+
 } scsi_system_settings_t;
 
 // This struct should only have new setting added to the end

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -13,6 +13,7 @@
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9
+#InvertStatusLED = 0 #  0: LED on when device is active, 1: Inverted LED activity
 #DisableStatusLED = 1 # 0: Use status LED, 1: Disable status LED
 #EnableToolbox = 1 # Enable Toolbox API. Disabled by default for compatibility reasons.
 


### PR DESCRIPTION
The `InvertStatusLED = 1` setting under the `[SCSI]` section will invert the LED, so the default state will be on and when there is device activity it will blink off.

This was a request from issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/493