### PR TITLE
Create library.json with CUEParser dependency

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/library.json
+++ b/lib/ZuluSCSI_platform_RP2MCU/library.json
@@ -1,0 +1,14 @@
+{
+    "name": "ZuluSCSI_platform_RP2MCU",
+    "version": "1.0",
+    "repository": { "type": "git", "url": "git://github.com/ZulusCSI/ZuluSCSI-firmware" },
+    "authors": [{ "name": "Rabbit Hole Computing", "email": "support@zuluscsi.com" }],
+    "license": "GPL-3.0-or-later",
+    "homepage": "http://zuluscsi.com",
+    "frameworks": "*",
+    "platforms": "*",
+    "dependencies":
+    {
+        "CUEParser": "https://github.com/rabbitholecomputing/CUEParser"
+    }
+}


### PR DESCRIPTION
`lib/ZuluSCSI_platform_RP2MCU` was not compiling because of a dependency issue. The lib_ldf_mode could be changed to chain+, but this avoids needing to do that which would have add extra compile time.