### PR TITLE
Log SpeedGrade at firmware initialization

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -122,11 +122,8 @@ uint8_t platform_get_buttons();
 // Return system clock in Hz
 uint32_t platform_sys_clock_in_hz();
 
-// Attempt to reclock the MCU - unsupported
-inline zuluscsi_reclock_status_t platform_reclock(zuluscsi_speed_grade_t speed_grade){return ZULUSCSI_RECLOCK_NOT_SUPPORTED;}
-
-// match string to speed grade - unsupported
-inline zuluscsi_speed_grade_t platform_string_to_speed_grade(const char *speed_grade_str, size_t length){return SPEED_GRADE_DEFAULT;}
+// Return whether device supports reclocking the MCU
+inline bool platform_reclock_supported(){return false;}
 
 // Returns true if reboot was for mass storage - unsupported
 inline bool platform_rebooted_into_mass_storage() {return false;}

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -113,16 +113,11 @@ uint8_t platform_get_buttons();
 
 uint32_t platform_sys_clock_in_hz();
 
-// Attempt to reclock the MCU - unsupported
-inline zuluscsi_reclock_status_t platform_reclock(zuluscsi_speed_grade_t speed_grade){return ZULUSCSI_RECLOCK_NOT_SUPPORTED;}
-
-// match string to speed grade - unsupported
-inline zuluscsi_speed_grade_t platform_string_to_speed_grade(const char *speed_grade_str, size_t length){return SPEED_GRADE_DEFAULT;}
+// Return whether device supports reclocking the MCU
+inline bool platform_reclock_supported(){return false;}
 
 // Returns true if reboot was for mass storage - unsupported
 inline bool platform_rebooted_into_mass_storage() {return false;}
-
-
 
 // Reinitialize SD card connection and save log from interrupt context.
 // This can be used in crash handlers.

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -27,6 +27,7 @@
 #include <Arduino.h>
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform_network.h"
+#include <ZuluSCSI_settings.h>
 
 #ifdef ZULUSCSI_PICO
 // ZuluSCSI Pico carrier board variant
@@ -131,11 +132,13 @@ uint8_t platform_get_buttons();
 
 uint32_t platform_sys_clock_in_hz();
 
-// Attempt to reclock the MCU
-zuluscsi_reclock_status_t platform_reclock(zuluscsi_speed_grade_t speed_grade);
+// Return whether device supports reclocking the MCU
+inline bool platform_reclock_supported(){return true;}
 
-// convert string to speed grade
-zuluscsi_speed_grade_t platform_string_to_speed_grade(const char *speed_grade_str, size_t length);
+#ifdef RECLOCKING_SUPPORTED
+// reclock the MCU
+bool platform_reclock(zuluscsi_speed_grade_t speed_grade);
+#endif
 
 // Returns true if reboot was for mass storage
 bool platform_rebooted_into_mass_storage();
@@ -151,8 +154,8 @@ void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 #define PLATFORM_FLASH_TOTAL_SIZE (1024 * 1024)
 #define PLATFORM_FLASH_PAGE_SIZE 4096
 bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE]);
-void platform_boot_to_main_firmware();
 #endif
+void platform_boot_to_main_firmware();
 
 // ROM drive in the unused external flash area
 #ifndef RP2040_DISABLE_ROMDRIVE

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
@@ -72,7 +72,7 @@ bool CustomTimings::set_timings_from_file()
 
     char speed_grade_str[10];
     ini_gets(settings_section, "extends_speed_grade", "Default", speed_grade_str, sizeof(speed_grade_str), CUSTOM_TIMINGS_FILE);
-    zuluscsi_speed_grade_t speed_grade =  platform_string_to_speed_grade(speed_grade_str, sizeof(speed_grade_str));
+    zuluscsi_speed_grade_t speed_grade =  g_scsi_settings.stringToSpeedGrade(speed_grade_str, sizeof(speed_grade_str));
     set_timings(speed_grade);
 
     int32_t number_setting = ini_getl(settings_section, "boot_with_sync_value", 0, CUSTOM_TIMINGS_FILE);

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.h
@@ -22,10 +22,9 @@
 
 #define CUSTOM_TIMINGS_FILE "zuluscsi_timings.ini"
 
-extern "C"
-{
-    #include "timings_RP2MCU.h"
-}
+
+#include "timings_RP2MCU.h"
+
 
 class CustomTimings
 {

--- a/lib/ZuluSCSI_platform_RP2MCU/scsi2sd_timings.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsi2sd_timings.c
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 #include "timings.h"
-#include "ZuluSCSI_platform.h"
 #if defined(ZULUSCSI_MCU_RP23XX)
 uint8_t g_max_sync_20_period = 18;
 uint8_t g_max_sync_10_period = 25;

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
@@ -20,9 +20,17 @@
 **/
 #ifndef ZULUSCSI_TIMINGS_RP2MCU_H
 #define ZULUSCSI_TIMINGS_RP2MCU_H
+
+#include <ZuluSCSI_settings.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
-#include <ZuluSCSI_config.h>
+
 
 typedef struct
 {
@@ -105,4 +113,9 @@ extern  zuluscsi_timings_t *g_zuluscsi_timings;
 
 // Sets timings to the speed_grade, returns false on SPEED_GRADE_DEFAULT and SPEED_GRADE_CUSTOM
 bool set_timings(zuluscsi_speed_grade_t speed_grade);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // ZULUSCSI_TIMINGS_RP2MCU_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -136,6 +136,7 @@ build_flags =
     -DPICO_FLASH_SPI_CLKDIV=2
     -DPLATFORM_MASS_STORAGE
     -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+    -DRECLOCKING_SUPPORTED
 ; build flags mirroring the "framework-arduinopico#x.x.x-DaynaPORT" static library build
     -DPICO_CYW43_ARCH_POLL=1
 	-DCYW43_LWIP=0

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -24,7 +24,6 @@
 // Other settings can be set by ini file at runtime.
 
 #pragma once
-
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
@@ -136,22 +135,3 @@
 // Settings for rebooting
 #define REBOOT_INTO_MASS_STORAGE_MAGIC_NUM 0x5eeded
 
-// Reclocking return status
-typedef enum
-{
-    ZULUSCSI_RECLOCK_SUCCESS,
-    ZULUSCSI_RECLOCK_CUSTOM,
-    ZULUSCSI_RECLOCK_NOT_SUPPORTED,
-    ZULUSCSI_RECLOCK_FAILED
-} zuluscsi_reclock_status_t;
-
-typedef enum
-{
-    SPEED_GRADE_DEFAULT,
-    SPEED_GRADE_MAX,
-    SPEED_GRADE_CUSTOM,
-    SPEED_GRADE_A,
-    SPEED_GRADE_B,
-    SPEED_GRADE_C,
-    SPEED_GRADE_AUDIO,
-} zuluscsi_speed_grade_t;

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -20,10 +20,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 #pragma once
+
+typedef enum
+{
+    SPEED_GRADE_DEFAULT = 0,
+    SPEED_GRADE_MAX,
+    SPEED_GRADE_CUSTOM,
+    SPEED_GRADE_AUDIO,
+    SPEED_GRADE_A,
+    SPEED_GRADE_B,
+    SPEED_GRADE_C,
+
+} zuluscsi_speed_grade_t;
+
 #ifdef __cplusplus
 
 #include <stdint.h>
+#include <stddef.h>
 #include <scsi2sd.h>
+
 
 // Index 8 is the system defaults
 // Index 0-7 represent device settings
@@ -70,6 +85,8 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
     bool usbMassStoragePresentImages;
     
     bool invertStatusLed;
+
+    uint8_t speedGrade; // memory allocation for zuluscsi_speed_grade_t enum
 
 } scsi_system_settings_t;
 
@@ -136,6 +153,11 @@ public:
     // return the device preset name
     const char* getDevicePresetName(uint8_t scsiId);
 
+    // convert string to speed grade
+    zuluscsi_speed_grade_t stringToSpeedGrade(const char *speed_grade_str, size_t length);
+
+    const char* getSpeedGradeString();
+
 protected:
     // Set default drive vendor / product info after the image file
     // is loaded and the device type is known.
@@ -157,6 +179,8 @@ protected:
     // It is set during when the system settings are initialized
     scsi_device_settings_t m_dev[9];
 } ;
+
+
 
 extern ZuluSCSISettings g_scsi_settings;
 #endif // __cplusplus


### PR DESCRIPTION
Reports speed grade to user log and uses the g_scsi_setting to store the speed grade.