### PR TITLE
Do not join SSID if SSID string is empty on start

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -843,7 +843,8 @@ static void reinitSCSI()
   if (scsiDiskCheckAnyNetworkDevicesConfigured())
   {
     platform_network_init(scsiDev.boardCfg.wifiMACAddress);
-    platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+    if (scsiDev.boardCfg.wifiSSID[0] != '\0')
+      platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
   }
 #endif // ZULUSCSI_NETWORK
 


### PR DESCRIPTION
Fixes an issue where the board would attempt to join a wifi AP on start even if there was no wifi ssid set in the zuluscsi.ini file.