### PR TITLE
RP2040: Fix 10s delay before USB serial port became available on Windows

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
@@ -245,7 +245,16 @@ extern "C" uint8_t tud_msc_get_maxlun_cb(void)
   MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_get_maxlun_cb();
 
-  return g_MSC.lun_count; // number of LUNs supported
+  if (g_MSC.lun_count != 0)
+  {
+    return g_MSC.lun_count; // number of LUNs supported
+  }
+  else
+  {
+    // Returning 0 makes TU_VERIFY(maxlun); fail in tinyusb/src/class/msc/msc_device.c:378
+    // This stalls the endpoint and causes an unnecessary enumeration delay on Windows.
+    return 1;
+  }
 }
 
 // return writable status


### PR DESCRIPTION
Since commit 196dd9f69db, RP2040 ZuluSCSI_platform_msc.cpp function tud_msc_get_maxlun_cb() was returning 0 if MSC mode was not active. The USB descriptors still show MSC functionality so it is valid for the host to query the lun count.

This caused TU_VERIFY(maxlun); fail in tinyusb/src/class/msc/msc_device.c:378 which then stalled the endpoint.

The endpoint stall caused a delay before the CDC serial port part of the USB compound device was initialized.

Fixed by always returning at least 1 lun, and then reporting that lun as media not present.

![image](https://github.com/user-attachments/assets/e04accb1-43d3-465a-a678-becc6b182196)
