### PR TITLE
Fix initiator mode failing to image Yamaha CRW2100S (#504)

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -241,10 +241,16 @@ void scsiInitiatorMainLoop()
     {
         // Scan for SCSI drives one at a time
         g_initiator_state.target_id = (g_initiator_state.target_id + 1) % 8;
+        g_initiator_state.sectorsize = 0;
+        g_initiator_state.sectorcount = 0;
         g_initiator_state.sectors_done = 0;
         g_initiator_state.retrycount = 0;
+        g_initiator_state.failposition = 0;
         g_initiator_state.max_sector_per_transfer = 512;
+        g_initiator_state.ansi_version = 0;
         g_initiator_state.bad_sector_count = 0;
+        g_initiator_state.device_type = SCSI_DEVICE_TYPE_DIRECT_ACCESS;
+        g_initiator_state.removable = false;
         g_initiator_state.eject_when_done = false;
 
         if (!(g_initiator_state.drives_imaged & (1 << g_initiator_state.target_id)))

--- a/src/ZuluSCSI_initiator.h
+++ b/src/ZuluSCSI_initiator.h
@@ -48,7 +48,7 @@ int scsiInitiatorRunCommand(int target_id,
 bool scsiInitiatorReadCapacity(int target_id, uint32_t *sectorcount, uint32_t *sectorsize);
 
 // Execute REQUEST SENSE command to get more information about error status
-bool scsiRequestSense(int target_id, uint8_t *sense_key);
+bool scsiRequestSense(int target_id, uint8_t *sense_key, uint8_t *sense_asc = nullptr, uint8_t *sense_ascq = nullptr);
 
 // Execute UNIT START STOP command to load/unload media
 bool scsiStartStopUnit(int target_id, bool start);

--- a/src/ZuluSCSI_initiator.h
+++ b/src/ZuluSCSI_initiator.h
@@ -38,11 +38,13 @@ void scsiInitiatorMainLoop();
 int scsiInitiatorGetOwnID();
 
 // Select target and execute SCSI command
+// If timeout is specified, it overrides the default watchdog timeout.
 int scsiInitiatorRunCommand(int target_id,
                             const uint8_t *command, size_t cmdLen,
                             uint8_t *bufIn, size_t bufInLen,
                             const uint8_t *bufOut, size_t bufOutLen,
-                            bool returnDataPhase = false);
+                            bool returnDataPhase = false,
+                            uint32_t timeout = 0);
 
 // Execute READ CAPACITY command
 bool scsiInitiatorReadCapacity(int target_id, uint32_t *sectorcount, uint32_t *sectorsize);


### PR DESCRIPTION
Fix initiator mode failing to image Yamaha CRW2100S (#504)
Several fixes were necessary:

* Longer timeout for start command (can take up to 30 seconds, previous timeout 15 seconds, new timeout 60 seconds)
* Run STOP command after START reports NOT_READY. Otherwise the drive never becomes ready.
* Reinitialize state variables between images so that failure on one CD disc does not affect imaging of next discs.

Tested against previously working SCSI harddrive.
Awaiting testing from @dlundqvist with the failing CD drive.