### PR TITLE
Fix ordering of speed grades

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -267,24 +267,13 @@ static zuluscsi_timings_t  predefined_timings[]  = {
             .total_delay_adjust = 1,
             .max_sync = 50,
         },
-#ifdef ZULUSCSI_PICO_2
         .sdio =
         {
             .clk_div_1mhz = 30, // set by trail and error
-            .clk_div_pio = 6, // SDIO at 41.7MHz
-            .delay0 = 4 - 1, // subtract one for the instruction delay
-            .delay1 = 2 - 1  // clk_div_pio - delay0 and subtract one for the instruction delay
-        }
-#else
-        .sdio =
-        {
-            .clk_div_1mhz = 50, // = 250MHz clk / clk_div_pio
             .clk_div_pio = 5, // SDIO at 50MHz
             .delay0 = 4 - 1, // subtract one for the instruction delay
             .delay1 = 1 - 1  // clk_div_pio - delay0 and subtract one for the instruction delay
         }
-
-#endif
     },
 };
     zuluscsi_timings_t  current_timings;

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -43,10 +43,10 @@ const char * const speed_grade_strings[7] =
     "Default",
     "TurboMax",
     "Custom",
+    "Audio",
     "TurboA",
     "TurboB",
     "TurboC",
-    "Audio"
 };
 
 // Helper function for case-insensitive string compare


### PR DESCRIPTION
The order of the speed grade text and enum didn't match so speed grade, so e.g. TurboA wasn't matching the enum SPEED_GRADE_A, etc.

Also set the 1MHz div for SDIO from 50 to 30 for the 250MHz system clock, as this seems to make some SD cards work with the Pico 2.