### PR TITLE
Initiator: recover from target holding BSY after command complete

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.h
@@ -51,5 +51,9 @@ bool scsiHostRequestWaiting();
 uint32_t scsiHostWrite(const uint8_t *data, uint32_t count);
 uint32_t scsiHostRead(uint8_t *data, uint32_t count);
 
+// Release bus signals and expect the target to do the same.
+// Cycles ACK in case target still holds BSY and REQ.
+void scsiHostWaitBusFree();
+
 // Release all bus signals
 void scsiHostPhyRelease();

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -613,8 +613,13 @@ int scsiInitiatorRunCommand(int target_id,
 
         if (phase == MESSAGE_IN)
         {
-            uint8_t dummy = 0;
-            scsiHostRead(&dummy, 1);
+            uint8_t msg = 0;
+            scsiHostRead(&msg, 1);
+
+            if (msg == MSG_COMMAND_COMPLETE)
+            {
+                break;
+            }
         }
         else if (phase == MESSAGE_OUT)
         {
@@ -670,7 +675,7 @@ int scsiInitiatorRunCommand(int target_id,
         }
     }
 
-    scsiHostPhyRelease();
+    scsiHostWaitBusFree();
 
     return status;
 }
@@ -1046,8 +1051,13 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
 
         if (phase == MESSAGE_IN)
         {
-            uint8_t dummy = 0;
-            scsiHostRead(&dummy, 1);
+            uint8_t msg = 0;
+            scsiHostRead(&msg, 1);
+
+            if (msg == MSG_COMMAND_COMPLETE)
+            {
+                break;
+            }
         }
         else if (phase == MESSAGE_OUT)
         {
@@ -1063,7 +1073,7 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
         }
     }
 
-    scsiHostPhyRelease();
+    scsiHostWaitBusFree();
 
     if (!g_initiator_transfer.all_ok)
     {


### PR DESCRIPTION
For some reason IBM H3171-S2 mishandles READ(6) command and returns to COMMAND phase (issue #519).

This commit adds a recovery logic if target is holding BSY after command is complete.
This might also be able to resolve similar cases with other drives.

Confirmed to fix the issue in SD card initiator mode.