### PR TITLE
USB MSC Initiator: Fix write support and handling of IO errors

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
@@ -389,7 +389,7 @@ extern "C" int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset
                            uint8_t *buffer, uint32_t bufsize)
 {
   MSCScopedLock lock;
-  if (g_msc_initiator) return init_msc_read10_cb(lun, lba, offset, buffer, bufsize);
+  if (g_msc_initiator) return init_msc_write10_cb(lun, lba, offset, buffer, bufsize);
 
   bool rc = 0;
 

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -635,9 +635,10 @@ int scsiInitiatorRunCommand(int target_id,
                 break;
             }
 
-            if (scsiHostRead(bufIn, bufInLen) == 0)
+            uint32_t readCount = scsiHostRead(bufIn, bufInLen);
+            if (readCount != bufInLen)
             {
-                logmsg("scsiHostRead failed, tried to read ", (int)bufInLen, " bytes");
+                logmsg("scsiHostRead failed, tried to read ", (int)bufInLen, " bytes, got ", (int)readCount);
                 status = -2;
                 break;
             }
@@ -652,9 +653,10 @@ int scsiInitiatorRunCommand(int target_id,
                 break;
             }
 
-            if (scsiHostWrite(bufOut, bufOutLen) < bufOutLen)
+            uint32_t writeCount = scsiHostWrite(bufOut, bufOutLen);
+            if (writeCount != bufOutLen)
             {
-                logmsg("scsiHostWrite failed, was writing ", bytearray(bufOut, bufOutLen));
+                logmsg("scsiHostWrite failed, was writing ", bytearray(bufOut, bufOutLen), " return value ", (int)writeCount);
                 status = -2;
                 break;
             }

--- a/src/ZuluSCSI_msc_initiator.cpp
+++ b/src/ZuluSCSI_msc_initiator.cpp
@@ -578,6 +578,8 @@ int32_t init_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t 
         status = scsiInitiatorRunCommand(target_id, command, sizeof(command), NULL, 0, buffer, bufsize);
     }
 
+    g_msc_initiator_state.prefetch_sectorcount = 0; // Invalidate prefetch cache
+
     g_msc_initiator_state.status_reqcount++;
     g_msc_initiator_state.status_bytecount += sectorcount * sectorsize;
     LED_OFF();


### PR DESCRIPTION
Writing to discs with USB MSC Initiator mode did not work because wrong function was being called.

Aborted data transfers were not being reported as IO errors to host, which could cause corrupted data reads/writes.

(This pull request can be merged in either order with #521, there should be no conflicts.)