### PR TITLE
Initiator configuration options

### DIFF
--- a/src/ZuluSCSI_initiator.h
+++ b/src/ZuluSCSI_initiator.h
@@ -46,6 +46,11 @@ int scsiInitiatorRunCommand(int target_id,
                             bool returnDataPhase = false,
                             uint32_t timeout = 30000);
 
+// Detect support of read10 commands.
+// Returns true if supported.
+// Return value can be overridden by .ini file, in which case test is not done.
+bool scsiInitiatorTestSupportsRead10(int target_id, uint32_t sectorsize);
+
 // Execute READ CAPACITY command
 bool scsiInitiatorReadCapacity(int target_id, uint32_t *sectorcount, uint32_t *sectorsize);
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -48,6 +48,7 @@
 #InitiatorUseRead10 = 0 # 0: Always use READ6 command, 1: Always use READ10 command, not set: Autodetect READ10 support
 
 #InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
+#InitiatorMSCReadOnly = 0 # Prevent writing to the drive through USB MSC
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
 #InitiatorMSCStatusInterval = 5000 # Periodically report access status to log
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -45,6 +45,7 @@
 #InitiatorID = 7 # SCSI ID, 0-7, when the device is in initiator mode, default is 7
 #InitiatorMaxRetry = 5 #  number of retries on failed reads 0-255, default is 5
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
+#InitiatorUseRead10 = 0 # 0: Always use READ6 command, 1: Always use READ10 command, not set: Autodetect READ10 support
 
 #InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode


### PR DESCRIPTION
Adds two new .ini configuration options for initiator mode:

* `InitiatorMSCReadOnly`: Prevents writes to the drive through USB MSC mode
* `InitiatorUseRead10`: Forces usage of either READ6 (setting 0) or READ10 (setting 1) SCSI command. If config option is not specified, the support is autodetected.
 
The autodetection is added to resolve the #519 problems without having to do any configuration. The config option is provided in case we find some drive which totally freaks out on unknown commands, instead of gracefully returning error status.

@aperezbios I have tested this with the drives I have, but they all support READ10 command.
If you still have `Apple Quantum ProDrive 80S` and time to test it with initiator mode, that could be a good idea before merging this pull request.