### PR TITLE
Automatically guess sectors/head settings from image size.

### DIFF
--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -319,8 +319,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     // setting set for all or specific devices
     cfgDev.deviceType = S2S_CFG_NOT_SET;
     cfgDev.deviceTypeModifier = 0;
-    cfgDev.sectorsPerTrack = 63;
-    cfgDev.headsPerCylinder = 255;
+    cfgDev.sectorsPerTrack = 0;
+    cfgDev.headsPerCylinder = 0;
     cfgDev.prefetchBytes = PREFETCH_BUFFER_SIZE;
     cfgDev.ejectButton = 0;
     cfgDev.vol = DEFAULT_VOLUME_LEVEL;


### PR DESCRIPTION
Only matters for hosts that check the geometry information. Main benefit is that this avoids the "affected by drive geometry" warnings by having a reasonable geometry to report.

Code based on [commit 233fd64159](https://github.com/ZuluIDE/ZuluIDE-firmware/commit/233fd64159a6e270f92ad5b1ac26cb6afa5675f4) by Morio in ZuluIDE repository.

Added new log message like this:

    [94ms] -- Opening /HD1.img for id:1 lun:0
    [95ms] ---- Configuring as disk drive drive
    [95ms] ---- Drive geometry from image size: SectorsPerTrack=32 HeadsPerCylinder=16 total sectors 131072 (divisible)
    [96ms] ---- Read prefetch enabled: 8192 bytes
