### PR TITLE
Correctly report read-only images as write protected to host.

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2355,7 +2355,7 @@ int scsiDiskCommand()
 
         scsiDev.phase = DATA_IN;
     }
-    else if (img.file.isRom())
+    else if (!img.file.isWritable())
     {
         // Special handling for ROM drive to make SCSI2SD code report it as read-only
         blockDev.state |= DISK_WP;


### PR DESCRIPTION
Previously MODE SENSE didn't report the write protected bit even if the image file was set to read-only. Any write requests would then fail with error.

After this commit the drive will appear write protected to the host.