### PR TITLE
Notify the user that an eject has occurred

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -60,6 +60,7 @@
 #include "ZuluSCSI_initiator.h"
 #include "ZuluSCSI_msc_initiator.h"
 #include "ZuluSCSI_msc.h"
+#include "ZuluSCSI_blink.h"
 #include "ROMDrive.h"
 
 SdFs SD;
@@ -72,77 +73,7 @@ bool g_sdcard_present;
 #define SD_SPEED_CLASS_WARN_BELOW 10
 #endif
 
-/************************************/
-/* Status reporting by blinking led */
-/************************************/
 
-#define BLINK_STATUS_OK 1
-#define BLINK_ERROR_NO_IMAGES  3
-#define BLINK_DIRECT_MODE      4
-#define BLINK_ERROR_NO_SD_CARD 5
-
-static uint16_t blink_count = 0;
-static uint32_t blink_start = 0;
-static uint32_t blink_delay = 0;
-static uint32_t blink_end_delay= 0;
-
-bool blink_poll()
-{
-    bool is_blinking = true;
-
-    if (blink_count == 0)
-    {
-        is_blinking = false;
-    }
-    else if (blink_count == 1 && ((uint32_t)(millis() - blink_start)) > blink_end_delay )
-    {
-        LED_OFF_OVERRIDE();
-        blink_count = 0;
-        is_blinking = false;
-    }
-    else if (blink_count > 1 && ((uint32_t)(millis() - blink_start)) > blink_delay)
-    {
-        if (1 & blink_count)
-            LED_ON_OVERRIDE();
-        else
-            LED_OFF_OVERRIDE();
-        blink_count--;
-        blink_start = millis();
-    }
-
-    if (!is_blinking)
-        platform_set_blink_status(false);
-    return is_blinking;
-}
-
-void blink_cancel()
-{
-    blink_count = 0;
-    platform_set_blink_status(false);
-}
-
-void blinkStatus(uint8_t times, uint32_t delay = 500, uint32_t end_delay = 1250)
-{
-    if (!blink_poll() && blink_count == 0)
-    {
-        blink_start = millis();
-        blink_count = 2 * times + 1;
-        blink_delay = delay / 2;
-        blink_end_delay =  end_delay;
-        platform_set_blink_status(true);
-        LED_OFF_OVERRIDE();
-    }
-}
-
-extern "C" void s2s_ledOn()
-{
-  LED_ON();
-}
-
-extern "C" void s2s_ledOff()
-{
-  LED_OFF();
-}
 
 /**************/
 /* Log saving */

--- a/src/ZuluSCSI_blink.cpp
+++ b/src/ZuluSCSI_blink.cpp
@@ -1,0 +1,88 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+/************************************/
+/* Status reporting by blinking led */
+/************************************/
+#include <ZuluSCSI_platform.h>
+#include "ZuluSCSI_blink.h"
+
+static uint32_t blink_count = 0;
+static uint32_t blink_start = 0;
+static uint32_t blink_delay = 0;
+static uint32_t blink_end_delay= 0;
+
+extern "C" void s2s_ledOn()
+{
+  LED_ON();
+}
+
+extern "C" void s2s_ledOff()
+{
+  LED_OFF();
+}
+bool blink_poll()
+{
+    bool is_blinking = true;
+
+    if (blink_count == 0)
+    {
+        is_blinking = false;
+    }
+    else if (blink_count == 1 && ((uint32_t)(millis() - blink_start)) > blink_end_delay )
+    {
+        LED_OFF_OVERRIDE();
+        blink_count = 0;
+        is_blinking = false;
+    }
+    else if (blink_count > 1 && ((uint32_t)(millis() - blink_start)) > blink_delay)
+    {
+        if (1 & blink_count)
+            LED_ON_OVERRIDE();
+        else
+            LED_OFF_OVERRIDE();
+        blink_count--;
+        blink_start = millis();
+    }
+
+    if (!is_blinking)
+        platform_set_blink_status(false);
+    return is_blinking;
+}
+
+void blink_cancel()
+{
+    blink_count = 0;
+    platform_set_blink_status(false);
+}
+
+void blinkStatus(uint32_t times, uint32_t delay, uint32_t end_delay)
+{
+    if (!blink_poll() && blink_count == 0)
+    {
+        blink_start = millis();
+        blink_count = 2 * times + 1;
+        blink_delay = delay / 2;
+        blink_end_delay =  end_delay;
+        platform_set_blink_status(true);
+        LED_OFF_OVERRIDE();
+    }
+}

--- a/src/ZuluSCSI_blink.h
+++ b/src/ZuluSCSI_blink.h
@@ -1,0 +1,30 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+#include <stdint.h>
+
+#define BLINK_STATUS_OK 1
+#define BLINK_ERROR_NO_IMAGES  3
+#define BLINK_DIRECT_MODE      4
+#define BLINK_ERROR_NO_SD_CARD 5
+
+bool blink_poll();
+void blink_cancel();
+void blinkStatus(uint32_t times, uint32_t delay = 500, uint32_t end_delay = 1250);

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -33,6 +33,7 @@
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform.h"
 #include "ZuluSCSI_settings.h"
+#include "ZuluSCSI_blink.h"
 #include <CUEParser.h>
 #include <assert.h>
 #include <minIni.h>
@@ -1267,6 +1268,8 @@ void cdromPerformEject(image_config_t &img)
 #endif
     if (!img.ejected)
     {
+        blink_cancel();
+        blinkStatus(g_scsi_settings.getDevice(target)->ejectBlinkTimes, g_scsi_settings.getDevice(target)->ejectBlinkPeriod);
         dbgmsg("------ CDROM open tray on ID ", (int)target);
         img.ejected = true;
         img.cdrom_events = 3; // Media removal

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -31,6 +31,7 @@
 #include "ZuluSCSI_log.h"
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_settings.h"
+#include "ZuluSCSI_blink.h"
 #ifdef ENABLE_AUDIO_OUTPUT
 #  include "ZuluSCSI_audio.h"
 #endif
@@ -778,6 +779,8 @@ static void doPerformEject(image_config_t &img)
     uint8_t target = img.scsiId & 7;
     if (!img.ejected)
     {
+        blink_cancel();
+        blinkStatus(g_scsi_settings.getDevice(target)->ejectBlinkTimes, g_scsi_settings.getDevice(target)->ejectBlinkPeriod);;
         dbgmsg("------ Device open tray on ID ", (int)target);
         img.ejected = true;
         switchNextImage(img); // Switch media for next time

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -232,6 +232,8 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
     cfg.headsPerCylinder = ini_getl(section, "HeadsPerCylinder", cfg.headsPerCylinder, CONFIGFILE);
     cfg.prefetchBytes = ini_getl(section, "PrefetchBytes", cfg.prefetchBytes, CONFIGFILE);
     cfg.ejectButton = ini_getl(section, "EjectButton", cfg.ejectButton, CONFIGFILE);
+    cfg.ejectBlinkTimes = ini_getl(section, "EjectBlinkTimes", cfg.ejectBlinkTimes, CONFIGFILE);
+    cfg.ejectBlinkPeriod = ini_getl(section, "EjectBlinkPeriod", cfg.ejectBlinkPeriod, CONFIGFILE);
 
     cfg.vol = ini_getl(section, "CDAVolume", cfg.vol, CONFIGFILE) & 0xFF;
 
@@ -325,6 +327,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgDev.headsPerCylinder = 0;
     cfgDev.prefetchBytes = PREFETCH_BUFFER_SIZE;
     cfgDev.ejectButton = 0;
+    cfgDev.ejectBlinkTimes = 20;
+    cfgDev.ejectBlinkPeriod = 50;
     cfgDev.vol = DEFAULT_VOLUME_LEVEL;
     
     cfgDev.nameFromImage = false;

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -110,6 +110,8 @@ typedef struct __attribute__((__packed__)) scsi_device_settings_t
     uint8_t deviceType;
     uint8_t deviceTypeModifier;
     uint8_t ejectButton;
+    uint32_t ejectBlinkTimes;
+    uint32_t ejectBlinkPeriod;
     bool nameFromImage;
     bool rightAlignStrings;
     bool reinsertOnInquiry;

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -74,6 +74,11 @@
 #ReinsertCDOnInquiry = 1 # Reinsert any ejected CD-ROM image on Inquiry command
 #ReinsertAfterEject = 1 # Reinsert next CD image after eject, if multiple images configured.
 #EjectButton = 0 # Enable eject by button 1 or 2, or set 0 to disable
+
+# The default values of 20 and 50 give a visible and audible (with optional buzzer) eject notification
+#EjectBlinkTimes = 20 # the number of times to blink the LED
+#EjectBlinkPeriod = 50 # the period in milliseconds for each blink
+
 #CDAVolume = 63 # Change CD Audio default volume. Maximum 255.
 #DisableMacSanityCheck = 0 # Disable sanity warnings for Mac disk drives. Default is 0 - enable checks
 #BlockSize = 0 # Set the drive's blocksize, defaults to 2048 for CDs and 512 for all other drives


### PR DESCRIPTION
As requested by issue https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/447

This change will blink the LED and buzz the optional piezo speaker a visible and audible signal for about a second when the device registers an eject. It is configurable via 'zuluscsi.ini' using `EjectBlinkTimes`
`EjectBlinkPeriod`
under `[SCSI]` or per device under `[SCSIx]` where x is the SCSI device ID.

```
EjectBlinkTimes = 20
EjectBlinkPeriod = 50
```
are the default values and a good starting point for customization.