### PR TITLE
RP2MCU: Improve write performance in SYNC-20 mode

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -46,10 +46,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 3 - 1,
+            .delay1 = 4 - 1,
             .total_period_adjust = -1,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 0,
             .max_sync = 12,
         },
 
@@ -59,7 +59,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
             .delay1 = 7 - 1,
             .total_period_adjust = -1,
             .rdelay1 = 6,
-            .rtotal_period_adjust = -1,
+            .rtotal_period_adjust = 0,
             .max_sync = 25,
         },
 
@@ -69,7 +69,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
             .delay1 = 15 - 1,
             .total_period_adjust = -1,
             .rdelay1 = 15 - 1,
-            .rtotal_period_adjust = -1,
+            .rtotal_period_adjust = 0,
             .max_sync = 50,
         },
 
@@ -108,10 +108,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 3 - 1,
+            .delay1 = 4 - 1,
             .total_period_adjust = -1,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 1,
             .max_sync = 12,
         },
 
@@ -170,10 +170,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 3 - 1,
+            .delay1 = 4 - 1,
             .total_period_adjust = -1,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 1,
             .max_sync = 12,
         },
 
@@ -183,7 +183,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
             .delay1 = 7 - 1,
             .total_period_adjust = -1,
             .rdelay1 = 7 - 1,
-            .rtotal_period_adjust = -1,
+            .rtotal_period_adjust = 0,
             .max_sync = 25,
         },
 
@@ -193,7 +193,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
             .delay1 = 15 - 1,
             .total_period_adjust = -1,
             .rdelay1 = 15 - 1,
-            .rtotal_period_adjust = -1,
+            .rtotal_period_adjust = 0,
             .max_sync = 50,
         },
 
@@ -235,10 +235,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 2 - 1,
-            .delay1 = 3 - 1,
+            .delay1 = 4 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 1,
             .max_sync = 12,
 
         },
@@ -300,10 +300,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 5 - 1,
+            .delay1 = 7 - 1,
             .total_period_adjust = 1,
-            .rdelay1 = 5 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 7 - 1,
+            .rtotal_period_adjust = 0,
             .max_sync = 12,
 
         },
@@ -363,10 +363,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 2 - 1,
-            .delay1 = 3 - 1,
+            .delay1 = 4 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 0,
             .max_sync = 12,
 
         },
@@ -431,10 +431,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 4 - 1,
+            .delay1 = 5 - 1,
             .total_period_adjust = -1,
-            .rdelay1 = 3 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 5 - 1,
+            .rtotal_period_adjust = 1,
             .max_sync = 12,
         },
 
@@ -495,11 +495,11 @@ static zuluscsi_timings_t  predefined_timings[]  = {
 
         .scsi_20 =
         {
-            .delay0 = 3 - 1,
-            .delay1 = 4 - 1,
-            .total_period_adjust = 1,
-            .rdelay1 = 5 - 1,
-            .rtotal_period_adjust = -1,
+            .delay0 = 2 - 1,
+            .delay1 = 5 - 1,
+            .total_period_adjust = 0,
+            .rdelay1 = 7 - 1,
+            .rtotal_period_adjust = 1,
             .max_sync = 12,
 
         },
@@ -563,10 +563,10 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 3 - 1,
-            .delay1 = 5 - 1,
+            .delay1 = 7 - 1,
             .total_period_adjust = 1,
-            .rdelay1 = 5 - 1,
-            .rtotal_period_adjust = -1,
+            .rdelay1 = 7 - 1,
+            .rtotal_period_adjust = 0,
             .max_sync = 12,
 
         },

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
@@ -74,7 +74,7 @@ typedef struct
     {
         uint8_t delay0;
         uint8_t delay1;
-        uint8_t rtotal_period_adjust;
+        int8_t rtotal_period_adjust;
         uint8_t rdelay1;
         int16_t total_period_adjust;
         uint8_t max_sync;
@@ -84,7 +84,7 @@ typedef struct
     {
         uint8_t delay0;
         uint8_t delay1;
-        uint8_t rtotal_period_adjust;
+        int8_t rtotal_period_adjust;
         uint8_t rdelay1;
         int16_t total_period_adjust;
         uint8_t max_sync;
@@ -94,7 +94,7 @@ typedef struct
     {
         uint8_t delay0;
         uint8_t delay1;
-        uint8_t rtotal_period_adjust;
+        int8_t rtotal_period_adjust;
         uint8_t rdelay1;
         int16_t total_period_adjust;
         uint8_t max_sync;


### PR DESCRIPTION
Improves performance especially for ZuluSCSI Blaster, up to 50% write speed improvement to around 16 MB/s.

Also adjusted the ZuluSCSI Blaster SCSI-20 timings for better signal quality (more even 0/1 ratio for REQ pulses).

Affects all RP2xxx targets but there isn't significant performance improvement for RP2040 at default 125 MHz.
Tested on ZuluSCSI Blaster and RP2040 at various clock rates.