### PR TITLE
RP2MCU: Fix USB console not connecting

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -665,7 +665,7 @@ static bool usb_serial_connected()
     if (platform_msc_lock_get()) return connected; // Avoid re-entrant USB events
 #endif
 
-    if (last_check_time == 0 || (uint32_t)(millis() - last_check_time) > 1000)
+    if (last_check_time == 0 || (uint32_t)(millis() - last_check_time) > 50)
     {
         connected = bool(Serial);
         last_check_time = millis();


### PR DESCRIPTION
There was a regression caused by commit 7238526d551f0f3 which caused the USB console not to connect after the first SCSI request had been processed.

This seems to be related to the USB request timeout of 500 ms, where the polling interval was previously 1000 ms.

I didn't research deep enough to find why this works before the first SCSI request, nor why it doesn't work afterwards. The USB IRQ still seems to be called so it has something to do with the userspace processing of requests. Possibly the USB MSC support also affects it.

In any case, lowering the polling interval to 50 ms fixed the issue and gives just as good performance.

The performance difference with constant USB polling or connected USB is around 5-8%, and with 50 ms polling the effect of unconnected USB to SCSI performance is around 1-2%.