### PR TITLE
Fix reported sector size for the Read Capacity command

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,8 +1,8 @@
 ; PlatformIO Project Configuration File https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-;default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus, ZuluSCSI_RP2040, ZuluSCSI_RP2040_Audio, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT, ZuluSCSI_Blaster
-default_envs = ZuluSCSI_RP2040
+default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus, ZuluSCSI_RP2040, ZuluSCSI_RP2040_Audio, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT, ZuluSCSI_Blaster
+
 [env]
 build_flags =
     -DBUILD_ENV=$PIOENV

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,8 +1,8 @@
 ; PlatformIO Project Configuration File https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus, ZuluSCSI_RP2040, ZuluSCSI_RP2040_Audio, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT, ZuluSCSI_Blaster
-
+;default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus, ZuluSCSI_RP2040, ZuluSCSI_RP2040_Audio, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT, ZuluSCSI_Blaster
+default_envs = ZuluSCSI_RP2040
 [env]
 build_flags =
     -DBUILD_ENV=$PIOENV

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.04.01"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "25.04.08"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1560,6 +1560,9 @@ static void doReadCapacity()
         scsiDev.data[7] = bytesPerSector;
         scsiDev.dataLen = 8;
         scsiDev.phase = DATA_IN;
+
+        // \todo get rid of me
+        dbgmsg("doReadCapacity - disk.cpp highest block: ", highestBlock, " bytes per sector: ", bytesPerSector);
     }
     else
     {
@@ -1629,7 +1632,6 @@ int doTestUnitReady()
 static void doSeek(uint32_t lba)
 {
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
-    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
     uint32_t capacity = img.get_capacity_lba();
 
     if (lba >= capacity)


### PR DESCRIPTION
ISOs with a custom sector to size were not reporting correctly when the Read Capacity SCSI command was being executed.
This was reported in this issue https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/545

This fixes the regression causing the issue.

Another issue has been found where the capacity of a single bin/cue file don't seem to report the same capacity as same images loaded into a virtual drive.