### PR TITLE
ZuluSCSI Blaster: Update SDIO_RP2350 to fix timeout bug

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -318,7 +318,7 @@ ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     ZuluI2S
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.1
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_BLASTER


### PR DESCRIPTION
The command timeout was too short, which caused problems on Sandisk cards.