### PR TITLE
DaynaPORT SCSI/Link support for ZuluSCSI Blaster

### DIFF
--- a/boards/zuluscsi_blaster.json
+++ b/boards/zuluscsi_blaster.json
@@ -9,7 +9,7 @@
         },
         "core": "earlephilhower",
         "cpu": "cortex-m33",
-        "extra_flags": "-DARDUINO_GENERIC_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 ",
+        "extra_flags": "-DARDUINO_GENERIC_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1",
         "f_cpu": "150000000L",
         "hwids": [
             [
@@ -22,7 +22,7 @@
             ]
         ],
         "mcu": "rp2350",
-        "variant": "generic_rp2350"
+        "variant": "rpipico2w"
     },
     "debug": {
         "jlink_device": "RP2350_0",

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Blaster.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Blaster.h
@@ -115,6 +115,12 @@
 #define DIP_DBGLOG      SWO_PIN
 #define DIP_TERM        SCSI_OUT_REQ
 
+// RM2 pins
+#define GPIO_RM2_ON   0
+#define GPIO_RM2_DATA 1
+#define GPIO_RM2_CS   2
+#define GPIO_RM2_CLK  4
+
 // Below are GPIO access definitions that are used from scsiPhy.cpp.
 
 // Write a single SCSI pin.
@@ -181,4 +187,3 @@
 // Read SCSI data bus
 #define SCSI_IN_DATA() \
     (~sio_hw->gpio_in & SCSI_IO_DATA_MASK) >> SCSI_IO_SHIFT
-

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -47,6 +47,8 @@ bool platform_network_supported()
 	/* from cores/rp2040/RP2040Support.h */
 #if !defined(PICO_CYW43_SUPPORTED)
 	return false;
+#elif defined(ZULUSCSI_BLASTER)
+	return true;
 #else
 	extern bool __isPicoW;
 	return __isPicoW;
@@ -173,6 +175,20 @@ int platform_network_send(uint8_t *buf, size_t len)
 		logmsg("cyw43_send_ethernet failed: ", ret);
 
 	return ret;
+}
+
+bool platform_network_iface_check()
+{
+	cyw43_deinit(&cyw43_state);
+	cyw43_init(&cyw43_state);
+	return 0 == cyw43_gpio_set(&cyw43_state, PICO_W_GPIO_LED_PIN, 1);
+}
+
+void platform_network_deinit()
+{
+	cyw43_init(&cyw43_state);
+	cyw43_gpio_set(&cyw43_state, PICO_W_GPIO_LED_PIN, 0);
+	cyw43_deinit(&cyw43_state);
 }
 
 static int platform_network_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result)

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.h
@@ -37,7 +37,10 @@ char * platform_network_wifi_ssid();
 char * platform_network_wifi_bssid();
 int platform_network_wifi_channel();
 int platform_network_send(uint8_t *buf, size_t len);
-
+// Test if the communication between the network device and the ZuluIDE works
+bool platform_network_iface_check();
+// Tears down the interface, mainly used to turn off the LED on the RM2 Pico 1W/2W
+void platform_network_deinit();
 # ifdef __cplusplus
 }
 # endif

--- a/lib/ZuluSCSI_platform_RP2MCU/audio_i2s.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/audio_i2s.h
@@ -26,8 +26,8 @@
 #define I2S_PIO_SM 0
 
 // audio subsystem DMA channels
-#define SOUND_DMA_CHA 6
-#define SOUND_DMA_CHB 7
+#define SOUND_DMA_CHA 10
+#define SOUND_DMA_CHB 11
 
 // size of the two audio sample buffers, in bytes
 // #define AUDIO_BUFFER_SIZE 8192 // reduce memory usage

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -645,6 +645,8 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
     case SPEED_GRADE_AUDIO_I2S:
         timings_index = 7;
         break;
+    case SPEED_GRADE_WIFI_RM2:
+        timings_index = 5;
 #elif defined(ZULUSCSI_MCU_RP23XX)
     case SPEED_GRADE_MAX:
     case SPEED_GRADE_A:

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,6 +144,7 @@ build_flags =
     -DRECLOCKING_SUPPORTED
 ; build flags mirroring the "framework-arduinopico#x.x.x-DaynaPORT" static library build
     -DPICO_CYW43_ARCH_POLL=1
+    -DCYW43_PIN_WL_DYNAMIC=1
 	-DCYW43_LWIP=0
 	-DCYW43_USE_OTP_MAC=0
 
@@ -312,7 +313,7 @@ build_flags =
 [env:ZuluSCSI_Blaster]
 extends = env:ZuluSCSI_RP2MCU
 board = zuluscsi_blaster
-program_flash_allocation = 589824
+program_flash_allocation = 786432
 linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
@@ -326,6 +327,10 @@ build_flags =
     -DENABLE_AUDIO_OUTPUT
     -DENABLE_AUDIO_OUTPUT_I2S
     -DSD_USE_RP2350_SDIO
+    -DZULUSCSI_NETWORK
+    -DZULUSCSI_DAYNAPORT
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    -DZULUSCSI_RM2
     -DROMDRIVE_OFFSET=${env:ZuluSCSI_Blaster.program_flash_allocation}
 ; Use the -Wl line below as a "build_flags" entry if you wish to make a map file
 ; to check memory locations of the compiled code.

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -781,11 +781,15 @@ static void reinitSCSI()
   scsiInit();
 
 #ifdef ZULUSCSI_NETWORK
-  if (scsiDiskCheckAnyNetworkDevicesConfigured())
+  if (scsiDiskCheckAnyNetworkDevicesConfigured() && platform_network_supported())
   {
     platform_network_init(scsiDev.boardCfg.wifiMACAddress);
     if (scsiDev.boardCfg.wifiSSID[0] != '\0')
       platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+  }
+  else
+  {
+    platform_network_deinit();
   }
 #endif // ZULUSCSI_NETWORK
 

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.04.10"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "25.04.24"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -48,6 +48,7 @@ const char * const speed_grade_strings[] =
     "A",
     "B",
     "C",
+    "WifiRM2"
 };
 
 // Helper function for case-insensitive string compare

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -21,6 +21,7 @@
 **/
 #pragma once
 
+// must be in the same order as speed_grade_strings[]  in ZuluSCSI_settings.cpp
 typedef enum
 {
     SPEED_GRADE_DEFAULT = 0,
@@ -31,7 +32,7 @@ typedef enum
     SPEED_GRADE_A,
     SPEED_GRADE_B,
     SPEED_GRADE_C,
-
+    SPEED_GRADE_WIFI_RM2
 } zuluscsi_speed_grade_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit enables support for Raspberry Pi's new RM2 Radio Module. The RM2 module contains the same Infineon transceiver ([CYW43439](https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-4-802.11n/cyw43439/)) as used in the Pico W and Pico 2W, and supports IEEE 802.11 b/g/n wireless LAN.

RM2 works with an audio compatible clock speed of around 155MHz. ZuluSCSI Blaster now initializes at ~155MHz. If no RM2 is detected, it then re-clocks to 200.5MHz.

* Switched the variant in the board `zuluscsi_blaster.json` file to be rpipico2w so the proper static libraries with wifi support get linked.

* Turn on the RM2 module's LED and the Pico 1W/2W LEDs (not the activity LED) early on at firmware initialization.

This indicates a couple of things to the user
 - The devices are setup in network mode
 - The communication interface between the ZuluSCSI and the wireless module is functional

The RM2 and Pico W LED turns off when either the network connection is attempted, in which case the LED goes through some blinking sequences, or there is no network device configured on a SCSI ID.