### PR TITLE
Blaster: Update SDIO_RP2350 with some reliability fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -319,7 +319,7 @@ ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     ZuluI2S
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.1
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_BLASTER


### PR DESCRIPTION
- Fix occasional command timeout errors
- Recover from read error during prefetch seek

Quite rare, but hit these during some testing.