### PR TITLE
RP2MCU: Ensure that SCSI phase is properly reset between requests

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
@@ -56,6 +56,7 @@ extern "C" bool scsiStatusBSY()
 /* SCSI selection logic */
 /************************/
 
+static SCSI_PHASE g_scsi_phase;
 volatile uint8_t g_scsi_sts_selection;
 volatile uint8_t g_scsi_ctrl_bsy;
 
@@ -63,6 +64,8 @@ void scsi_bsy_deassert_interrupt()
 {
     if (SCSI_IN(SEL) && !SCSI_IN(BSY))
     {
+        g_scsi_phase = BUS_BUSY;
+
         // Check if any of the targets we simulate is selected
         uint8_t sel_bits = SCSI_IN_DATA();
         int sel_id = -1;
@@ -171,6 +174,8 @@ extern "C" void scsiPhyReset(void)
     SCSI_RELEASE_OUTPUTS();
     g_scsi_sts_selection = 0;
     g_scsi_ctrl_bsy = 0;
+    g_scsi_phase = BUS_FREE;
+
 
     scsi_accel_rp2040_init();
 
@@ -189,8 +194,6 @@ extern "C" void scsiPhyReset(void)
 /************************/
 /* SCSI bus phase logic */
 /************************/
-
-static SCSI_PHASE g_scsi_phase;
 
 extern "C" void scsiEnterPhase(int phase)
 {


### PR DESCRIPTION
Previously for SCSI-1 hosts the SCSI phase signals might not be updated when a new request starts, especially if the previous one had failed.