### PR TITLE
Blaster: Fix SYNC-5 synchronous mode timings

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -256,13 +256,13 @@ static zuluscsi_timings_t  predefined_timings[]  = {
 
         .scsi_5 =
         {
-            .delay0 = 10 - 1,
-            .delay1 = 15, // should be 18 - 1 but max currently is 15
+            .delay0 = 5 - 1,
+            .delay1 = 8 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 15,
+            .rdelay1 = 8 - 1,
             .rtotal_period_adjust = 0,
             .max_sync = 50,
-
+            .clkdiv = 2,
         },
 
         .sdio =
@@ -320,12 +320,13 @@ static zuluscsi_timings_t  predefined_timings[]  = {
 
         .scsi_5 =
         {
-            .delay0 = 15, // maxed out should be 16
-            .delay1 = 15, // maxed out should be 30
+            .delay0 = 8 - 1,
+            .delay1 = 12 - 1,
             .total_period_adjust = 1,
-            .rdelay1 = 15,
+            .rdelay1 = 12 - 1,
             .rtotal_period_adjust = 1,
             .max_sync = 50,
+            .clkdiv = 2,
         },
         .sdio =
         {
@@ -384,13 +385,13 @@ static zuluscsi_timings_t  predefined_timings[]  = {
 
         .scsi_5 =
         {
-            .delay0 = 10 - 1,
-            .delay1 = 15, // should be 18 - 1 but max currently is 15
+            .delay0 = 5 - 1,
+            .delay1 = 8 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 15,
+            .rdelay1 = 8 - 1,
             .rtotal_period_adjust = 0,
             .max_sync = 50,
-
+            .clkdiv = 2,
         },
 
         .sdio =
@@ -451,12 +452,12 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_5 =
         {
             .delay0 = 4 - 1,
-            .delay1 = 10 - 1,
+            .delay1 = 8 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 10 - 1,
+            .rdelay1 = 8 - 1,
             .rtotal_period_adjust = 0,
             .max_sync = 50,
-
+            .clkdiv = 2,
         },
 
         .sdio =
@@ -518,12 +519,12 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_5 =
         {
             .delay0 = 5 - 1,
-            .delay1 = 11 - 1,
+            .delay1 = 10 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 11 - 1,
+            .rdelay1 = 10 - 1,
             .rtotal_period_adjust = 0,
             .max_sync = 50,
-
+            .clkdiv = 2,
         },
 
         .sdio =
@@ -583,12 +584,13 @@ static zuluscsi_timings_t  predefined_timings[]  = {
 
         .scsi_5 =
         {
-            .delay0 = 15, // maxed out should be 16
-            .delay1 = 15, // maxed out should be 30
+            .delay0 = 8 - 1,
+            .delay1 = 12 - 1,
             .total_period_adjust = 1,
-            .rdelay1 = 15,
+            .rdelay1 = 12 -1,
             .rtotal_period_adjust = 1,
             .max_sync = 50,
+            .clkdiv = 2,
         },
         .sdio =
         {

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
@@ -98,6 +98,7 @@ typedef struct
         uint8_t rdelay1;
         int16_t total_period_adjust;
         uint8_t max_sync;
+        uint8_t clkdiv;
     } scsi_5;
 
 


### PR DESCRIPTION
With the faster 150+ MHz system clock rates, the 0-15 delay range wasn't enough to meet the slowest synchronous mode timing.

Implemented support for using the state machine clock divider to achieve the slower timing values.

Related issues: #556, #572.