### PR TITLE
Enable physical eject buttons on ZuluSCSI V1.2 by default

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -829,6 +829,11 @@ uint8_t platform_get_buttons()
     return buttons_debounced;
 }
 
+bool platform_has_phy_eject_button()
+{
+    return g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2;
+}
+
 /***********************/
 /* Flash reprogramming */
 /***********************/

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -149,6 +149,9 @@ void SysTick_Handle_PreEmptively();
 bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE]);
 void platform_boot_to_main_firmware();
 
+// True if the board has a physical eject button
+bool platform_has_phy_eject_button();
+
 // Configuration customizations based on DIP switch settings
 // When DIPSW1 is on, Apple quirks are enabled by default.
 void platform_config_hook(S2S_TargetCfg *config);

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -199,6 +199,9 @@ const uint32_t platform_flash_sector_map[] =
 
 bool platform_firmware_erase(FsFile &file);
 bool platform_firmware_program(FsFile &file);
+
+bool platform_has_phy_eject_button(){return false};
+
 // SD card driver for SdFat
 
 // SDIO interface, ZuluSCSI v1.4

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1040,7 +1040,10 @@ uint8_t platform_get_buttons()
     return buttons_debounced;
 }
 
-
+bool platform_has_phy_eject_button()
+{
+    return false;
+}
 
 /************************************/
 /* ROM drive in extra flash space   */

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -176,7 +176,8 @@ bool platform_write_romdrive(const uint8_t *data, uint32_t start, uint32_t count
 extern const uint16_t g_scsi_parity_lookup[256];
 extern const uint16_t g_scsi_parity_check_lookup[512];
 
-
+// Returns true if the board has a physical eject button 
+bool platform_has_phy_eject_button();
 
 #ifdef __cplusplus
 }

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -558,3 +558,18 @@ const char *ZuluSCSISettings::getSpeedGradeString()
 {
     return speed_grade_strings[m_sys.speedGrade];
 }
+
+
+const bool ZuluSCSISettings::isEjectButtonSet()
+{
+    bool is_set = false;
+    for (uint8_t i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        if (m_dev[i].ejectButton != 0)
+        {
+            is_set = true;
+            break;
+        }
+    }
+    return is_set;
+}

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -163,6 +163,9 @@ public:
 
     const char* getSpeedGradeString();
 
+    // see if any SCSI devices have an eject button set
+    const bool isEjectButtonSet();
+
 protected:
     // Set default drive vendor / product info after the image file
     // is loaded and the device type is known.
@@ -175,14 +178,14 @@ protected:
     scsi_system_preset_t m_sysPreset;
     // The last preset is for the device specific under [SCSI] in the CONFIGFILE
     // The rest are for corresponding SCSI Ids e.g. [SCSI0] in the CONFIGFILE.
-    scsi_device_preset_t m_devPreset[8];
+    scsi_device_preset_t m_devPreset[S2S_MAX_TARGETS];
 
     // These are setting for host compatibility
     scsi_system_settings_t m_sys;
 
     // The last dev will be copied over the other dev scsi Id for device defaults.
     // It is set during when the system settings are initialized
-    scsi_device_settings_t m_dev[9];
+    scsi_device_settings_t m_dev[S2S_MAX_TARGETS+1];
 } ;
 
 


### PR DESCRIPTION
ZuluSCSI boards with a physical eject button will now assign the lowest SCSI ID that is a removable device to that physical button.