### PR TITLE
RP2350: Fix crash when loading ROM drive

### DIFF
--- a/src/ROMDrive.cpp
+++ b/src/ROMDrive.cpp
@@ -131,8 +131,11 @@ bool scsiDiskProgramRomDrive(const char *filename, int scsi_id, int blocksize, S
     hdr.blocksize = blocksize;
     hdr.drivetype = type;
 
+    memset(scsiDev.data, 0, PLATFORM_ROMDRIVE_PAGE_SIZE);
+    memcpy(scsiDev.data, &hdr, sizeof(hdr));
+
     // Program the drive metadata header
-    if (!platform_write_romdrive((const uint8_t*)&hdr, 0, PLATFORM_ROMDRIVE_PAGE_SIZE))
+    if (!platform_write_romdrive(scsiDev.data, 0, PLATFORM_ROMDRIVE_PAGE_SIZE))
     {
         logmsg("---- Failed to program ROM drive header");
         file.close();


### PR DESCRIPTION
Previously there was a read past the end of romdrive_hdr_t. For some reason this didn't crash on RP2040, but on RP2350 it crashes.

Fixed by using scsiDev buffer instead.