### PR TITLE
Fix initiator serial connect delay

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.cpp
@@ -437,5 +437,4 @@ extern "C" void tud_msc_write10_complete_cb(uint8_t lun)
   MSCScopedLock lock;
   if (g_msc_initiator) return init_msc_write10_complete_cb(lun);
 }
-
 #endif

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_msc.h
@@ -24,7 +24,7 @@
 
 // private constants/enums
 #define SD_SECTOR_SIZE 512
-
+#define MSC_INIT_DELAY 300
 /* return true if USB presence detected / eligble to enter CR mode */
 bool platform_sense_msc();
 

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -23,7 +23,6 @@
 /*
  * Main program for initiator mode.
  */
-
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_log.h"
 #include "ZuluSCSI_log_trace.h"
@@ -226,6 +225,13 @@ void scsiInitiatorMainLoop()
     {
         if (!g_sdcard_present || ini_getbool("SCSI", "InitiatorMSC", false, CONFIGFILE))
         {
+            // This delay allows the USB serial console to connect immediately to the host
+            // It also decreases the delay in callback processing of MSC commands
+            int32_t msc_init_delay = ini_getl("SCSI", "InitiatorMSCInitDelay", MSC_INIT_DELAY, CONFIGFILE);
+            if (msc_init_delay != MSC_INIT_DELAY)
+                logmsg("Initiator init delay set in ", CONFIGFILE ," to ", (int)msc_init_delay, " milliseconds");
+            delay(msc_init_delay);
+
             logmsg("Entering USB MSC initiator mode");
             platform_enter_msc();
             setup_msc_initiator();

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -49,6 +49,7 @@
 #InitiatorMSCReadOnly = 0 # Prevent writing to the drive through USB MSC
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
 #InitiatorMSCStatusInterval = 5000 # Periodically report access status to log
+#InitiatorMSCInitDelay = 300 # In milliseconds, gives time for USB serial to configure itself
 
 #EnableCDAudio = 0 # 1: Enable CD audio - an external I2S DAC on the v1.2 is required
 #MaxVolume = 100 # Set the percentage of the volume from 1 to 100 (default)


### PR DESCRIPTION
There was a 16 seconds delay for the USB serial console from the startup of the board and initial opening of the serial port to actual being able to transfer data over the serial USB line.
The fix is to wait a few hundred milliseconds before activating the MSC callbacks. This puts the TinyUSB serial connection in a state where it will immediately connect to the host and decreases the initial time for the MSC to start responding to the hosts MSC commands.