### PR TITLE
Switch to Arduino-Pico library v4.5.4

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -110,7 +110,7 @@ build_flags =
 [env:ZuluSCSI_RP2MCU]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#39b90392af50585e429941bd2561a91949a2ba46
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.3.0-DaynaPORT
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.5.4-DaynaPORT
 extra_scripts =
     src/build_bootloader.py
     src/process-linker-script.py


### PR DESCRIPTION
Using a custom spin of the Arduino-Pico library v4.5.4 that in turn uses a custom spin of the pico-sdk v2.1.2 develop branch. The customization allows DayanPORT emulation and proper USB mass storage class device enumeration.

See the following repos for more information:
- https://github.com/rabbitholecomputing/arduino-pico/tree/v4.5.4-DaynaPORT
- https://github.com/rabbitholecomputing/pico-sdk/tree/v2.1.2dev-smaller-cyw43-spi-pio