### PR TITLE
Respond to a non standard read subchannel CDB

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1934,7 +1934,9 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
 {
     uint8_t *buf = scsiDev.data;
 
-    if (parameter == 0x01)
+    // DOS for a game Screamer was requesting parameter list 0x00. This defined in the SCSI-2 spec
+    // but later as a reserved value in subsequent SCSI MMCs. Currently treating is as playback position request
+    if (parameter == 0x01 || parameter == 0x00)
     {
         uint8_t audiostatus;
         uint32_t lba = 0;
@@ -1956,7 +1958,7 @@ static void doReadSubchannel(bool time, bool subq, uint8_t parameter, uint8_t tr
             len = 12;
             *buf++ = 0;  // Subchannel data length (MSB)
             *buf++ = len; // Subchannel data length (LSB)
-            *buf++ = 0x01; // Subchannel data format
+            *buf++ = parameter; // Subchannel data format
             *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14);
             *buf++ = trackinfo.track_number;
             *buf++ = (lba >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.06.17"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "25.06.27"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR


### PR DESCRIPTION
In issue https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/583 the user reported a DOS game not working. It was using a read subchannel parameter list than is reserved in SCSI MMC standards. The fix that worked was to treat it as a CD current position parameter.