### PR TITLE
Simplify toolbox inquiry name

### DIFF
--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,14 +27,14 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.06.27"
+#define FW_VER_NUM      "25.07.01"
 #define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR
 #define FIRMWARE_NAME_PREFIX DEF_STRINGFY(BUILD_ENV)
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
-#define INQUIRY_NAME  PLATFORM_NAME " v" ZULU_FW_VERSION
+#define INQUIRY_NAME  "ZuluSCSI"
 #define TOOLBOX_API 0
 
 // Configuration and log file paths


### PR DESCRIPTION
For issue https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/603 Set the inquiry name to a fixed width "ZuluSCSI" with the toolbox version byte after it so matching it with toolbox software is easier.