### PR TITLE
Backup ROM image before a changing flash layout

### DIFF
--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.07.15"
-#define FW_VER_SUFFIX   "dev"
+#define FW_VER_NUM      "25.08.05"
+#define FW_VER_SUFFIX   "trans"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,7 @@
 
 // Use variables for version number
 #define FW_VER_NUM      "25.08.05"
-#define FW_VER_SUFFIX   "trans"
+#define FW_VER_SUFFIX   "release"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -122,6 +122,107 @@ bool scsiDiskActivateRomDrive()
         return false;
     }
 
+    logmsg("==== Transitional firmware: backing up ROM drive ====");
+    logmsg("==== Offset for ROM drive placement will be changed in next firmware release ====");
+    // Backing up rom drive in transitional firmware
+    const uint32_t new_firmware_size_limit = 1273856;
+    // Reverse maxsize to flash_size
+    uint32_t flash_size = maxsize + PLATFORM_ROMDRIVE_PAGE_SIZE + ROMDRIVE_OFFSET;
+    uint32_t maxsize_post_transistion = flash_size - PLATFORM_ROMDRIVE_PAGE_SIZE - new_firmware_size_limit;
+    if (hdr.imagesize > maxsize_post_transistion)
+    {
+        logmsg("!!!! ROM image will not fit in the next firmware release !!!!");
+        logmsg("---- ROM image size is ",(int)(hdr.imagesize/1024),"kB, new firmware only allocates ", (int)(maxsize_post_transistion/1024),"kB");
+    }
+    char filename[32] = {0};
+    bool found_type = true;
+    filename[0] = '/';
+    switch (hdr.drivetype)
+    {
+        case S2S_CFG_TYPE::S2S_CFG_FIXED:
+            memcpy(filename + 1, "HD", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_FLOPPY_14MB:
+            memcpy(filename + 1, "FD", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_MO:
+            memcpy(filename + 1, "MO", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_OPTICAL:
+            memcpy(filename + 1, "CD", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_REMOVABLE:
+            memcpy(filename + 1, "RE", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_SEQUENTIAL:
+            memcpy(filename + 1, "TP", 2);
+            break;
+        case S2S_CFG_TYPE::S2S_CFG_ZIP100:
+            memcpy(filename + 1, "ZP", 2);
+            break;
+        default:
+            found_type = false;
+    }
+
+    if (!found_type)
+    {
+        logmsg("---- Unable to create backup of ROM image, ROM image type not recognized");
+    }
+    else
+    {
+        filename[3] = '0' + hdr.scsi_id;
+        filename[4] = '_';
+        int blocksize_str_len = sprintf(&filename[5], "%lu", hdr.blocksize);
+        if (blocksize_str_len < 0)
+        {
+            logmsg("---- Unable to create backup of ROM image, can not convert blocksize to string");
+        }
+        else
+        {
+            memcpy(&filename[5 + blocksize_str_len], ".rom_bkup", sizeof(".rom_bkup"));
+            if (SD.exists(filename))
+            {
+                logmsg("---- Unable to create backup of ROM image, backup already created: \"", filename, "\"");
+            }
+            else
+            {
+                FsFile rom_back_up = SD.open(filename, O_CREAT | O_TRUNC | O_WRONLY);
+                if (!rom_back_up.isOpen())
+                {
+                    logmsg("---- Unable to create backup of ROM image, could not open: \"", filename, "\"");
+                }
+                else
+                {
+                    bool flip_led = true;
+                    uint32_t start_delay = millis();
+                    for(uint32_t i = 0; i < hdr.imagesize; i += hdr.blocksize)
+                    {
+                        if (flip_led)
+                            LED_ON();
+                        else
+                            LED_OFF();
+
+                        if ((uint32_t)(millis() - start_delay) > 100)
+                        {
+                            flip_led = !flip_led;
+                            start_delay = millis();
+                        }
+
+                        uint32_t count = hdr.blocksize;
+                        // In case the rom drive image size is not divisible by the blocksize, read to the end of image size
+                        if (i +  hdr.blocksize > hdr.imagesize)
+                            count = hdr.imagesize % hdr.blocksize;
+                        romDriveRead(scsiDev.data, i, count);
+                        rom_back_up.write(scsiDev.data, count);
+                    }
+                    LED_OFF();
+                    rom_back_up.close();
+                    logmsg("---- Created backup of ROM image: \"", filename, "\"");
+                }
+            }
+        }
+    }
+
     if (ini_getbool("SCSI", "DisableROMDrive", 0, CONFIGFILE))
     {
         logmsg("---- ROM drive disabled in ini file, not enabling");
@@ -648,7 +749,7 @@ bool scsiDiskFilenameValid(const char* name)
     if (extension)
     {
         const char *ignore_exts[] = {
-            ".rom_loaded", ".cue", ".txt", ".rtf", ".md", ".nfo", ".pdf", ".doc", 
+            ".rom_loaded", ".rom_bkup", ".cue", ".txt", ".rtf", ".md", ".nfo", ".pdf", ".doc", 
 	    ".ini", ".mid", ".midi", ".aiff", ".mp3", ".m4a",
             NULL
         };


### PR DESCRIPTION
This build will backup a ROM image and warn the user if the backed up ROM image will no longer fit in flash after transitioning to a new flash layout in the upcoming firmware update.

The backed up filename extension is `.rom_bkup` and can be renamed to `.rom` to reprogram the flash in the upcoming firmware update with the same scsi id, block size and total file size as the original programmed flash rom.