### PR TITLE
Reset on eject button in initiator mode

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -759,10 +759,11 @@ void platform_reset_watchdog()
     usb_log_poll();
 }
 
-void platform_reset_mcu()
+void platform_reset_mcu(uint32_t reset_in_ms)
 {
     // reset in 2 sec ( 1 / (40KHz / 32) * 2500 == 2sec)
-    fwdgt_config(2500, FWDGT_PSC_DIV32);
+    uint32_t cycles = reset_in_ms * 160 / 128;
+    fwdgt_config(cycles, FWDGT_PSC_DIV32);
     fwdgt_enable();
 
 }

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -105,7 +105,7 @@ uint8_t platform_no_sd_card_on_init_error_code();
 void platform_reset_watchdog();
 
 // Reset MCU after a certain amount of time
-void platform_reset_mcu();
+void platform_reset_mcu(uint32_t reset_in_ms);
 
 // Poll function that is called every few milliseconds.
 // The SD card is free to access during this time, and pauses up to

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.cpp
@@ -550,10 +550,10 @@ void platform_reset_watchdog()
     g_watchdog_timeout = WATCHDOG_CRASH_TIMEOUT;
 }
 
-void platform_reset_mcu()
+void platform_reset_mcu(uint32_t reset_in_ms)
 {
     // reset in 2 sec ( 1 / (32KHz / 32) * 2000 == 2sec)
-    fwdgt_config(2000, FWDGT_PSC_DIV32);
+    fwdgt_config(reset_in_ms, FWDGT_PSC_DIV32);
     fwdgt_enable();
 
 }

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -97,7 +97,7 @@ uint8_t platform_no_sd_card_on_init_error_code();
 void platform_reset_watchdog();
 
 // Reset MCU
-void platform_reset_mcu();
+void platform_reset_mcu(uint32_t reset_in_ms);
 
 // Poll function that is called every few milliseconds.
 // The SD card is free to access during this time, and pauses up to

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1086,9 +1086,9 @@ void platform_poll()
 #endif // ENABLE_AUDIO_OUTPUT_SPDIF
 }
 
-void platform_reset_mcu()
+void platform_reset_mcu(uint32_t reset_in_ms)
 {
-    watchdog_reboot(0, 0, 2000);
+    watchdog_reboot(0, 0, reset_in_ms);
 }
 
 uint8_t platform_get_buttons()

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -118,7 +118,7 @@ bool platform_is_initiator_mode_enabled();
 void platform_reset_watchdog();
 
 // Reset MCU
-void platform_reset_mcu();
+void platform_reset_mcu(uint32_t reset_in_ms);
 
 
 // Poll function that is called every few milliseconds.

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -920,7 +920,7 @@ static void firmware_update()
       root.remove(name);
       root.close();
       logmsg("Update extracted from package, rebooting MCU");
-      platform_reset_mcu();
+      platform_reset_mcu(2000);
     }
     else
     {

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1146,7 +1146,8 @@ extern "C" void zuluscsi_main_loop(void)
 
   platform_reset_watchdog();
   platform_poll();
-  diskEjectButtonUpdate(true);
+  if (!is_initiator)
+    diskEjectButtonUpdate(true);
   blink_poll();
 
 #ifdef ZULUSCSI_NETWORK


### PR DESCRIPTION
Because initiator mode on wide boards does not recover well upon bus disconnect, the device mode wide board it makes it difficult to test boards. The wide boards have a built in eject button. 

To make testing easier, this commit enables the eject button to function as a soft reset button, the initiator's init function is rerun and the initiator main loop is paused. The LED pulsates to indicate the board is paused. Hitting the eject button again, starts the initiator main loop again.

This avoids the serial console sometimes freezing and waiting for the ZuluSCSI to completely reset in the original commit that hard reset the MCU.