### PR TITLE
Upgrade to latest Pico-SDK and Arduino-Pico

### DIFF
--- a/boards/rpipico.json
+++ b/boards/rpipico.json
@@ -4,7 +4,7 @@
             "earlephilhower": {
                 "boot2_source": "boot2_w25q080_2_padded_checksum.S",
                 "usb_vid": "0x2E8A",
-                "usb_pid": "0x000A"
+                "usb_pid": "0x10D7"
             }
         },
         "core": "earlephilhower",
@@ -18,7 +18,7 @@
             ],
             [
                 "0x2E8A",
-                "0x000A"
+                "0x10D7"
             ]
         ],
         "mcu": "rp2040",

--- a/boards/rpipico2.json
+++ b/boards/rpipico2.json
@@ -4,7 +4,7 @@
             "earlephilhower": {
                 "boot2_source": "none.S",
                 "usb_vid": "0x2E8A",
-                "usb_pid": "0x000F"
+                "usb_pid": "0x10D7"
             }
         },
         "core": "earlephilhower",
@@ -18,7 +18,7 @@
             ],
             [
                 "0x2E8A",
-                "0x000F"
+                "0x10D7"
             ]
         ],
         "mcu": "rp2350",

--- a/boards/rpipico2w.json
+++ b/boards/rpipico2w.json
@@ -4,7 +4,7 @@
             "earlephilhower": {
                 "boot2_source": "none.S",
                 "usb_vid": "0x2E8A",
-                "usb_pid": "0xF00F"
+                "usb_pid": "0x10D7"
             }
         },
         "core": "earlephilhower",
@@ -18,7 +18,7 @@
             ],
             [
                 "0x2E8A",
-                "0xF00F"
+                "0x10D7"
             ]
         ],
         "mcu": "rp2350",

--- a/boards/rpipicow.json
+++ b/boards/rpipicow.json
@@ -4,7 +4,7 @@
             "earlephilhower": {
                 "boot2_source": "boot2_w25q080_2_padded_checksum.S",
                 "usb_vid": "0x2E8A",
-                "usb_pid": "0xF00A"
+                "usb_pid": "0x10D7"
             }
         },
         "core": "earlephilhower",
@@ -18,7 +18,7 @@
             ],
             [
                 "0x2E8A",
-                "0xF00A"
+                "0x10D7"
             ]
         ],
         "mcu": "rp2040",

--- a/boards/zuluscsi_rp2040.json
+++ b/boards/zuluscsi_rp2040.json
@@ -4,7 +4,7 @@
         "earlephilhower": {
           "boot2_source": "boot2_w25q080_2_padded_checksum.S",
           "usb_vid": "0x2E8A",
-          "usb_pid": "0xF00A"
+          "usb_pid": "0x10D7"
         }
       },
       "core": "earlephilhower",
@@ -18,7 +18,7 @@
         ],
         [
           "0x2E8A",
-          "0xF00A"
+          "0x10D7"
         ]
       ],
       "mcu": "rp2040",

--- a/boards/zuluscsi_wide.json
+++ b/boards/zuluscsi_wide.json
@@ -4,7 +4,7 @@
             "earlephilhower": {
                 "boot2_source": "none.S",
                 "usb_vid": "0x2E8A",
-                "usb_pid": "0xF00F"
+                "usb_pid": "0x10D7"
             }
         },
         "core": "earlephilhower",
@@ -18,7 +18,7 @@
             ],
             [
                 "0x2E8A",
-                "0xF00F"
+                "0x10D7"
             ]
         ],
         "mcu": "rp2350",

--- a/platformio.ini
+++ b/platformio.ini
@@ -108,9 +108,9 @@ build_flags =
 ; Note: getting the code to break on main, check the comments in the rp2040-template.ld or rp23xx-template.ld
 ;       They should instruct you on the changes needed to move code out of SRAM and back to flash
 [env:ZuluSCSI_RP2MCU]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6af38e26547c56cebdbfa4ab564eb361f7d27d4f
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6164ed92d83c1241a1d84ad848158d7b0fb486e3
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.6.0-DaynaPORT
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.7.0-DaynaPORT
 extra_scripts =
     src/build_bootloader.py
     src/process-linker-script.py


### PR DESCRIPTION
Version 2.2.0 of the Pico-SDK came out along with version 4.7.0 of the Arduino-Pico package, by Earle F. Philhower, that links to the Pico-SDK. These were customized and respun so DaynaPORT and MSC modes can be used.

Also upgraded to the latest version of the RaspberryPi platformIO framework by Maximilian Gerhardt.

Finally updated to USB Product ID to the one assigned to Rabbit Hole Computing by the Raspberry Pi on all ZuluSCSI RP2MCU sub targets.