### PR TITLE
Fix "Seek to .. failed" error with prefetch close to end of drive.

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2015,7 +2015,8 @@ void scsiDiskStartRead(uint32_t lba, uint32_t blocks)
         }
 #endif
 
-        if (!img.file.seek((uint64_t)(transfer.lba + transfer.currentBlock) * bytesPerSector))
+        if (transfer.currentBlock < transfer.blocks &&
+            !img.file.seek((uint64_t)(transfer.lba + transfer.currentBlock) * bytesPerSector))
         {
             logmsg("Seek to ", transfer.lba, " failed for SCSI ID", (int)scsiDev.target->targetId);
             scsiDev.status = CHECK_CONDITION;


### PR DESCRIPTION
When a read to the last sector of the drive image was fully satisfied from prefetch buffer, a seek error was mistakenly reported.

Related issue: #621