### PR TITLE
ZuluSCSI Wide: Fixes for firmware and ROM drive flashing

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -258,10 +258,15 @@ static pin_setup_state_t read_setup_ack_pin()
 
 // Allows execution on Core1 via function pointers. Each function can take
 // no parameters and should return nothing, operating via side-effects only.
+mutex g_core1_mutex;
+__attribute__((section(".time_critical.core1_handler")))
 static void core1_handler() {
     while (1) {
         void (*function)() = (void (*)()) multicore_fifo_pop_blocking();
+
+        mutex_enter_blocking(&g_core1_mutex);
         (*function)();
+        mutex_exit(&g_core1_mutex);
     }
 }
 
@@ -519,6 +524,7 @@ void platform_late_init()
 #endif
 
     dbgmsg("Starting Core1 dispatcher");
+    mutex_init(&g_core1_mutex);
     multicore_launch_core1(core1_handler);
 
     if (!g_scsi_initiator)
@@ -1204,10 +1210,20 @@ bool platform_write_romdrive(const uint8_t *data, uint32_t start, uint32_t count
     assert(start < platform_get_romdrive_maxsize());
     assert((count % PLATFORM_ROMDRIVE_PAGE_SIZE) == 0);
 
+    // XIP is disabled during flashing so interrupts and
+    // core1 handlers must be blocked.
+    mutex_enter_blocking(&g_core1_mutex);
     uint32_t saved_irq = save_and_disable_interrupts();
+
     flash_range_erase(start + ROMDRIVE_OFFSET, count);
     flash_range_program(start + ROMDRIVE_OFFSET, data, count);
+
+#ifdef ZULUSCSI_MCU_RP23XX
+    set_flash_clock();
+#endif
+
     restore_interrupts(saved_irq);
+    mutex_exit(&g_core1_mutex);
     return true;
 }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/program_flash.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/program_flash.cpp
@@ -86,13 +86,15 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
     // Avoid any mbed timer interrupts triggering during the flashing.
     uint32_t saved_irq = save_and_disable_interrupts();
 
+#ifndef ZULUSCSI_MCU_RP23XX
     // For some reason any code executed after flashing crashes
-    // unless we disable the XIP cache.
+    // unless we disable the XIP cache on RP2040.
     // Not sure why this happens, as flash_range_program() is flushing
     // the cache correctly.
     // The cache is now enabled from bootloader start until it starts
     // flashing, and again after reset to main firmware.
     xip_ctrl_hw->ctrl = 0;
+#endif
 
     flash_range_erase(offset, PLATFORM_FLASH_PAGE_SIZE);
     flash_range_program(offset, buffer, PLATFORM_FLASH_PAGE_SIZE);


### PR DESCRIPTION
Two fixes related to flash writing on ZuluSCSI Wide:

* SD card bootloader was slow
* ROM drive loading crashed (regression after authenticity check was added / old bug uncovered)