### PR TITLE
Fix messaging around firmware files on SD Card and reset USB interface on init

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -49,6 +49,7 @@
 #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
 # include <SerialUSB.h>
 # include <class/cdc/cdc_device.h>
+# include <device/usbd.h>
 #endif
 
 #include <pico/multicore.h>
@@ -327,8 +328,10 @@ void platform_init()
     gpio_set_input_enabled(DIP_DBGLOG, true);
     gpio_set_input_enabled(DIP_TERM, true);
 #endif
-
+    // In case of a firmware update the USB connection fails and needs to be restarted
+    tud_disconnect();
     delay(10); // 10 ms delay to let pull-ups do their work
+    tud_connect();
     bool working_dip = true;
     bool dbglog = false;
     bool termination = false;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -810,11 +810,25 @@ static void check_for_unused_update_files()
     if (!file.isDir())
     {
       size_t filename_len = file.getName(filename, sizeof(filename));
-      if (strncasecmp(filename, "zuluscsi", sizeof("zuluscsi" - 1)) == 0 &&
+      if (strncasecmp(filename, "zuluscsi", sizeof("zuluscsi") - 1) == 0 &&
           strncasecmp(filename + filename_len - 4, ".bin", 4) == 0)
       {
-        bin_files_found = true;
-        logmsg("Firmware update file \"", filename, "\" does not contain the board model string \"", FIRMWARE_NAME_PREFIX, "\"");
+        if (strncasecmp(filename, FIRMWARE_NAME_PREFIX, sizeof(FIRMWARE_NAME_PREFIX) - 1) == 0)
+        {
+          if (file.isReadOnly())
+          {
+              logmsg("The firmware file ", filename, " is read-only, the ZuluSCSI will continue to update every power cycle with this SD card inserted");
+          }
+          else
+          {
+              logmsg("Found firmware file ", filename, " on the SD card, to update this ZuluSCSI with the file please power cycle the board");
+          }
+        }
+        else
+        {
+          bin_files_found = true;
+          logmsg("Firmware update file \"", filename, "\" does not contain the board model string \"", FIRMWARE_NAME_PREFIX, "\"");
+        }
       }
     }
   }


### PR DESCRIPTION
This properly report to the user if a firmware file is found on the SD card. If a correct firmware file is found to be read-only it reports that. If the ZuluSCSI is powered on without and SD card and then an SD card is inserted with proper firmware, the log reports that the board needs to be powered cycled to install the firmware.

The USB interface is restarted in the init cycle. This is because during a firmware update, the USB interface in Windows reports that the USB device failed. After the firmware update the serial console cannot be connected to. Restarting the USB interface solves this issue.