### PR TITLE
Fix onboard eject button on SD card reinsert

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1230,6 +1230,7 @@ extern "C" void zuluscsi_main_loop(void)
         print_sd_info();
         reinitSCSI();
         init_logfile();
+        init_eject_button();
         blinkStatus(BLINK_STATUS_OK);
       }
       else if (!g_romdrive_active)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1195,7 +1195,7 @@ static void diskEjectAction(uint8_t buttonId)
             if (img.deviceType == S2S_CFG_OPTICAL)
             {
                 found = true;
-                logmsg("Eject button ", (int)buttonId, " pressed, passing to CD drive SCSI", (int)i);
+                logmsg("Eject button ", (int)buttonId, " pressed, passing to CD drive SCSI ID: ", (int)i);
                 cdromPerformEject(img);
             }
             else if (img.deviceType == S2S_CFG_ZIP100 
@@ -1205,7 +1205,7 @@ static void diskEjectAction(uint8_t buttonId)
                     || img.deviceType == S2S_CFG_SEQUENTIAL)
             {
                 found = true;
-                logmsg("Eject button ", (int)buttonId, " pressed, passing to SCSI device", (int)i);
+                logmsg("Eject button ", (int)buttonId, " pressed, passing to device SCSI ID: ", (int)i);
                 doPerformEject(img);
             }
         }


### PR DESCRIPTION
For boards with built-in eject buttons that default to the first removable device when no device is assigned an eject button in `zuluscsi.ini`, the eject button auto assignment is lost after ejecting the SD card and reinserting.

Reinitializing the eject button's auto assignment after the SD card has been reinserted fixes the issue.

Also cleaned up the log messaging when an eject button is pressed.