### PR TITLE
CLEAR_ROM file was crashing the ZuluSCSI

### DIFF
--- a/src/ROMDrive.cpp
+++ b/src/ROMDrive.cpp
@@ -88,9 +88,8 @@ bool romDriveCheckPresent(romdrive_hdr_t *hdr)
 // Clear the drive metadata header
 bool romDriveClear()
 {
-    romdrive_hdr_t hdr = {0x0};
-
-    if (!platform_write_romdrive((const uint8_t*)&hdr, 0, PLATFORM_ROMDRIVE_PAGE_SIZE))
+    memset(scsiDev.data, 0, PLATFORM_ROMDRIVE_PAGE_SIZE);
+    if (!platform_write_romdrive(scsiDev.data, 0, PLATFORM_ROMDRIVE_PAGE_SIZE))
     {
         logmsg("-- Failed to clear ROM drive");
         return false;


### PR DESCRIPTION
Placing a CLEAR_ROM file on the root directory on the SD card to clear the ROM drive was crashing the ZuluSCSI. Best guess is it was trying to read beyond an SRAM boundary as there was a read overrun because the write buffer was smaller than the byte count to be written.

Creating a zeroed buffer the same size as the sector size of the flash corrects the issue.