### PR TITLE
Wide: Fix wrong DMA state after 6-byte SCSI command transfer

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
@@ -453,7 +453,7 @@ extern "C" void scsiRead(uint8_t* data, uint32_t count, int* parityError)
     if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY)) { parityError = NULL; }
 
     scsiStartRead(data, count, parityError);
-    scsiFinishRead(data, count, parityError);
+    scsiFinishRead(NULL, 0, parityError);
 }
 
 extern "C" void scsiStartRead(uint8_t* data, uint32_t count, int *parityError)

--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.h
@@ -75,6 +75,7 @@ uint8_t scsiReadByte(void);
 // Depending on platform support the start() function may block.
 // The start function can be called multiple times, it may internally
 // either combine transfers or block until previous transfer completes.
+// After final read, call scsiFinishRead() with data = NULL.
 void scsiStartWrite(const uint8_t* data, uint32_t count);
 void scsiFinishWrite();
 void scsiStartRead(uint8_t* data, uint32_t count, int *parityError);


### PR DESCRIPTION
On ZuluSCSI Wide, after a 6-byte SCSI command the card would sometimes crash with error
"ERROR: SCSI DMA was in state 4 when changing sync mode".

This was caused by an old bug in the synchronous wrapper around the asynchronous read code in RP2 scsiPhy.cpp. It ended the read by calling scsiFinishRead() with the data argument. An undocumented assumption in the API was that final call would be with NULL argument, like done in ZuluSCSI_disk.cpp.

In 8-bit SCSI accelerator code this made no difference, as the last buffer completed exactly the same time as the whole transfer. Because the 16-bit accelerator code uses second CPU core, there was a race condition where last buffer has already finished but the whole transfer has not.

Related issue: #629