### PR TITLE
Fix Read Defect Data response

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2400,7 +2400,7 @@ int scsiDiskCommand()
             scsiDev.cdb[8];
 
         scsiDev.data[0] = 0;
-        scsiDev.data[1] = scsiDev.cdb[1];
+        scsiDev.data[1] = scsiDev.cdb[2];
         scsiDev.data[2] = 0;
         scsiDev.data[3] = 0;
         scsiDev.dataLen = 4;


### PR DESCRIPTION
Information found from SCSI 2 Spec 9.2.8
The second byte of the Read Defect Data defect list should come from the third byte of the Read Defect Data command. The defect list's second byte, which is Reserved, Plist, Glist, Defect List Format was coming from the second byte of the command, which is LUN, Reserved, and is incorrect.

This is an attempt to address issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/634

Although it didn't fix the users particular issue, it still fixes a bug.