### PR TITLE
Fix scsiLogDataOut logging commands

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
@@ -453,6 +453,7 @@ extern "C" void scsiRead(uint8_t* data, uint32_t count, int* parityError)
 
     scsiStartRead(data, count, parityError);
     scsiFinishRead(NULL, 0, parityError);
+    scsiLogDataOut(data, count);
 }
 
 extern "C" void scsiStartRead(uint8_t* data, uint32_t count, int *parityError)
@@ -491,7 +492,8 @@ extern "C" void scsiFinishRead(uint8_t* data, uint32_t count, int *parityError)
     if (!(scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY)) { parityError = NULL; }
     scsi_accel_rp2040_finishRead(data, count, parityError, &scsiDev.resetFlag);
 #endif
-    scsiLogDataOut(data, count);
+    if (data != NULL)
+        scsiLogDataOut(data, count);
 }
 
 extern "C" bool scsiIsReadFinished(const uint8_t *data)


### PR DESCRIPTION
Commit: https://github.com/ZuluSCSI/ZuluSCSI-firmware/commit/7ab702172375f86b02ad37435abc194fc737bc8d broke logging SCSI commands and would log SCSI OUT reads that were null.

This fix is to not call scsiLogDataOut in scsiFinishRead when called with NULL buffer. And in scsiRead after a scsiFinishRead is called with a NULL buffer call scsiLogDataOut so the COMMAND and/or OUT log message will be captured.