### PR TITLE
Fix ImgDir section parsing

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -762,7 +762,7 @@ static void scsiDiskSetConfig(int target_idx)
     scsiDiskSetImageConfig(target_idx);
 
     char section[6] = "SCSI0";
-    section[4] += scsiEncodeID(target_idx);
+    section[4] = scsiEncodeID(target_idx);
     char tmp[32];
 
     ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);


### PR DESCRIPTION
Found in this issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/644
With the upgrade to 16bit SCSI IDs a `+=` wasn't changed to a `=`. Making that change should enable ImgDir to work as expected.