### PR TITLE
Fix unaligned buffer access in 16 bit parity calc

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -41,6 +41,10 @@
 #include "custom_timings.h"
 #include <ZuluSCSI_settings.h>
 
+#ifdef ZULUSCSI_MCU_RP23XX
+# include <hardware/structs/scb.h>
+#endif
+
 #ifdef SD_USE_RP2350_SDIO
 #include <sdio_rp2350.h>
 #else
@@ -761,7 +765,10 @@ void show_hardfault(uint32_t *sp)
     logmsg("R1: ", sp[1]);
     logmsg("R2: ", sp[2]);
     logmsg("R3: ", sp[3]);
-
+#ifdef ZULUSCSI_MCU_RP23XX
+    logmsg("CFSR: ", (uint32_t)scb_hw->cfsr);
+    logmsg("BFAR: ", (uint32_t)scb_hw->bfar);
+#endif
     uint32_t *p = (uint32_t*)((uint32_t)sp & ~3);
 
     for (int i = 0; i < 8; i++)

--- a/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
@@ -279,7 +279,8 @@ static uint32_t *scsi_generate_parity_16bit(uint8_t *src, uint32_t count, uint32
     // From measurements this takes approx 23 µs per 1024 bytes at 150 MHz
     // This gives 1.2 clock cycles per instruction, and throughput of 44 MB/s.
     asm(R"(
-            ldm %[src]!, {r0, r2}    // Load source words
+            ldr r0, [%[src]], #4   // Load source words
+            ldr r2, [%[src]], #4
             subs %[cnt], %[cnt], #7  // Make sure count goes <= 0 when there is less than 8 left
             mov r4, #0x02040000      // Load multiplication constant for bit shuffling
             ble 2f                   // Skip loop if count is too low

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "25.08.19"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "25.08.26"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR


### PR DESCRIPTION
It was found when using a different sector sizes that the 16 bit parity calculation was crashing. Adding the CFSR and BFAR registers for the RP2350 to the crash log helped track down the issue.

The cause was an unaligned buffer access, switching from the assembly command ldm to two ldrs allows for the src buffer to be unaligned in the case of using a sector size that causes unaligned data.