### PR TITLE
Fix reboot logic

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -918,7 +918,6 @@ static void usb_input_poll()
                 {
                     logmsg("Rebooting", mass_storage_reboot_keyed ? " into mass storage": "");
                     g_rebooting = true;
-                    watchdog_reboot(0, 0, 2000);
                 }
                 break;
             case '\n':

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -68,7 +68,7 @@ FsFile g_logfile;
 bool g_rawdrive_active;
 static bool g_romdrive_active;
 bool g_sdcard_present;
-bool g_rebooting=false;
+bool g_rebooting = false;
 #ifndef SD_SPEED_CLASS_WARN_BELOW
 #define SD_SPEED_CLASS_WARN_BELOW 10
 #endif
@@ -947,7 +947,7 @@ static void firmware_update()
       root.remove(name);
       root.close();
       logmsg("Update extracted from package, rebooting MCU");
-      platform_reset_mcu(2000);
+      g_rebooting = true;
     }
     else
     {
@@ -1211,13 +1211,14 @@ extern "C" void zuluscsi_main_loop(void)
   // While timer for reboot is going, attempt to close SD images
   if (g_rebooting)
   {
-    while (scsiIsWriteFinished(NULL) && scsiIsReadFinished(NULL))
+    while (!scsiIsWriteFinished(NULL) || !scsiIsReadFinished(NULL))
     {
       platform_reset_watchdog();
     }
     scsiDiskCloseSDCardImages();
     save_logfile();
     g_logfile.close();
+    platform_reset_mcu(1000);
     while(1)
     {
       platform_poll();
@@ -1271,7 +1272,7 @@ extern "C" void zuluscsi_main_loop(void)
         platform_reset_watchdog();
         platform_poll();
       }
-    } while (!g_sdcard_present && !g_romdrive_active && !is_initiator);
+    } while (!g_sdcard_present && !g_romdrive_active && !is_initiator && !g_rebooting);
   }
 }
 


### PR DESCRIPTION
There was an error waiting for SCSI operations to finish. This fixes that logic and doesn't send the reset request until all the SCSI images are closed.