### PR TITLE
Fix >64 kB writes when using non-power-of-2 sector sizes.

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1839,6 +1839,17 @@ void diskDataOut()
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     uint32_t blockcount = (transfer.blocks - transfer.currentBlock);
     uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+
+    // If we are using non-power-of-two sector size, wrapping around
+    // the buffer edge doesn't work out. Instead limit the transfer
+    // to a smaller section and re-enter diskDataOut().
+    uint32_t blocksPerBuffer = sizeof(scsiDev.data) / bytesPerSector;
+    if (blockcount > blocksPerBuffer &&
+        blocksPerBuffer * bytesPerSector != sizeof(scsiDev.data))
+    {
+        blockcount = blocksPerBuffer;
+    }
+
     g_disk_transfer.buffer = scsiDev.data;
     g_disk_transfer.bytes_scsi = blockcount * bytesPerSector;
     g_disk_transfer.bytes_sd = 0;


### PR DESCRIPTION
By default the access wraps around the 64 kB transfer buffer so that SD card can be written in one continuous burst. But for non-divisible sector sizes wrapping around would split the sector.

This commit affects only devices configured for non-power-of-2 sector size, and splits the transfer to max. 64 kB sections.