### PR TITLE
Fix timings at 155.25MHz

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -364,7 +364,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_20 =
         {
             .delay0 = 2 - 1,
-            .delay1 = 4 - 1,
+            .delay1 = 5 - 1,
             .total_period_adjust = 0,
             .rdelay1 = 5 - 1,
             .rtotal_period_adjust = 0,
@@ -375,9 +375,9 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .scsi_10 =
         {
             .delay0 = 4 - 1,
-            .delay1 = 7 - 1,
+            .delay1 = 8 - 1,
             .total_period_adjust = 0,
-            .rdelay1 = 7 - 1,
+            .rdelay1 = 8 - 1,
             .rtotal_period_adjust = 0,
             .max_sync = 25,
 


### PR DESCRIPTION
On the Pico 2W timings were not correct for Sync 10 and 20, causing SCSI bus DMA timeouts. This occurred when timings were standardized among the ZuluSCSI lines.

Adjusted them manually on a Adaptec SCSI card till the timeouts stopped. Tested Sync 20, 10, and 5