### PR TITLE
Enable wide support for device mode

### DIFF
--- a/lib/ZuluSCSI_UI_RP2MCU/BrowseScreen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/BrowseScreen.cpp
@@ -119,21 +119,20 @@ void BrowseScreen::draw()
   _display->setCursor(0,0);             
   _display->print(F("Browser"));
 
-  _iconX = 92; // Inital offset from right (leave space for the SCSI ID)
-  
+   _iconX = _display->width();
+
   DeviceMap &map = g_devices[_scsiId];
+
+  _display->setTextSize(2);
+  printNumberFromTheRight(_scsiId, 6, 0);
+  _display->setTextSize(1);
 
   const uint8_t *deviceIcon = getIconForType(map.DeviceType, true);
   drawIconFromRight(deviceIcon, 6, 0);
 
   _display->drawLine(0,10,_iconX+11,10, 1);
 
-  _display->setTextSize(2);             
-  _display->setCursor(112,0);       
-  _display->print(_scsiId);           
-  _display->setTextSize(1);            
-
-  _display->setCursor(0,36);             
+  _display->setCursor(0,36);
   _display->print(F("Path: "));     
 
   _display->setCursor(0,22);             
@@ -189,7 +188,7 @@ void BrowseScreen::shortUserPress()
   if (!goBackADirectory())
   {
     resetScrollerDelay();
-    changeScreen(SCREEN_MAIN, -1);
+    changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
   }
 }
 

--- a/lib/ZuluSCSI_UI_RP2MCU/BrowseScreenFlat.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/BrowseScreenFlat.cpp
@@ -180,19 +180,18 @@ void BrowseScreenFlat::draw()
   _display->setCursor(0,0);             
   _display->print(F("Flat Browser"));
 
-  _iconX = 92;
+  _iconX = _display->width();
   
   DeviceMap &map = g_devices[_scsiId];
+
+  _display->setTextSize(2);
+  printNumberFromTheRight(_scsiId, 6, 0);
+  _display->setTextSize(1);
 
   const uint8_t *deviceIcon = getIconForType((S2S_CFG_TYPE)map.DeviceType, true);
   drawIconFromRight(deviceIcon, 6, 0);
 
- _display->drawLine(0,10,_iconX+11,10, 1);       
-
-   _display->setTextSize(2);             
-  _display->setCursor(112,0);       
-  _display->print(_scsiId);           
-  _display->setTextSize(1);            
+  _display->drawLine(0,10,_iconX+11,10, 1);
 
   _display->setCursor(0,36);             
   _display->print(F("Path: "));     
@@ -224,7 +223,7 @@ void BrowseScreenFlat::shortRotaryPress()
 void BrowseScreenFlat::shortUserPress()
 {
   resetScrollerDelay();
-  changeScreen(SCREEN_MAIN, -1);
+  changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void BrowseScreenFlat::shortEjectPress()
@@ -313,8 +312,11 @@ void BrowseScreenFlat::getCurrentFilename()
     {
       char pre[4];
       strcpy(pre, typeToShortString(_deviceMap->DeviceType));
-      pre[2] = '0' + _scsiId;
-      pre[3] = 0;
+      if (_scsiId >= 0 && _scsiId <= 9)
+        pre[2] = '0' + _scsiId;
+      else if (_scsiId >= 10  && _scsiId <= 15)
+        pre[2] = 'A' + (_scsiId - 10);
+      pre[3] = '\0';
       SDNavPrefixFileByIndex.GetFileByIndex(pre, _currentObjectIndex, _currentObjectName, MAX_PATH_LEN, _currentObjectSize);
     } 
     case BROWSE_METHOD_NOT_BROWSABLE:

--- a/lib/ZuluSCSI_UI_RP2MCU/BrowseTypeScreen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/BrowseTypeScreen.cpp
@@ -29,6 +29,7 @@
 #include "control_global.h"
 
 #define MAX_LINES 5
+#define NO_DEVICE_SELECTED -1
 
 void BrowseTypeScreen::init(int index)
 {
@@ -69,7 +70,7 @@ void BrowseTypeScreen::draw()
 
 void BrowseTypeScreen::shortUserPress()
 {
-  changeScreen(SCREEN_MAIN, -1);
+  changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void BrowseTypeScreen::shortEjectPress()
@@ -102,7 +103,7 @@ void BrowseTypeScreen::shortRotaryPress()
 
 void BrowseTypeScreen::rotaryChange(int direction)
 {
-  if (_selectedDevice == -1) // there aren't any, so just return (it would have been set to something other than -1 if there were)
+  if (_selectedDevice == NO_DEVICE_SELECTED) // there aren't any, so just return (it would have been set to something other than -1 if there were)
   {
     return;
   }
@@ -129,7 +130,7 @@ void BrowseTypeScreen::rotaryChange(int direction)
   else // dir -1
   {
     _selectedDevice--;
-    if (_selectedDevice == -1)
+    if (_selectedDevice == NO_DEVICE_SELECTED)
     {
       _selectedDevice++;
     }

--- a/lib/ZuluSCSI_UI_RP2MCU/CopyScreen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/CopyScreen.cpp
@@ -52,24 +52,24 @@ void CopyScreen::draw()
   _display->setCursor(0,0);             
   _display->print(_bannerText);
   
-  _iconX = 92;
-  if (DeviceType != 255)
-  {
-    const uint8_t *deviceIcon = getIconForType((S2S_CFG_TYPE)DeviceType, true);
-    
-    drawIconFromRight(deviceIcon, 6, 0);
-  }
+  _iconX = _display->width();
 
-  if (_scsiId != 255)
+
+  if (_scsiId != SCREEN_ID_OTHER)
   {
-    _display->setTextSize(2);             
-    _display->setCursor(112,0);       
-    _display->print(_scsiId);           
-    _display->setTextSize(1);      
+    _display->setTextSize(2);
+    printNumberFromTheRight(_scsiId, 6, 0);
+    _display->setTextSize(1);
   }
   else
   {
     _iconX += 16;
+  }
+
+  if (DeviceType != 255)
+  {
+    const uint8_t *deviceIcon = getIconForType((S2S_CFG_TYPE)DeviceType, true);
+    drawIconFromRight(deviceIcon, 6, 0);
   }
 
   _display->drawLine(0,10,_iconX+11,10, 1);
@@ -198,7 +198,7 @@ void CopyScreen::setShowInfoText(bool showInfoText)
 
 void CopyScreen::shortUserPress()
 {
-  // changeScreen(SCREEN_MAIN, -1);
+  // changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 #endif

--- a/lib/ZuluSCSI_UI_RP2MCU/InfoPage2Screen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/InfoPage2Screen.cpp
@@ -47,10 +47,14 @@ void InfoPage2Screen::draw()
   _display->setCursor(0,0);             
   _display->print(F("Info (2/3)"));
   
-  _iconX = 92;
+  _iconX = _display->width();
 
   DeviceMap &map = g_devices[_scsiId];
-  
+
+  _display->setTextSize(2);
+  printNumberFromTheRight(_scsiId, 6, 0);
+  _display->setTextSize(1);
+
   const uint8_t *deviceIcon = getIconForType(map.DeviceType, true);
   drawIconFromRight(deviceIcon, 6, 0);
 
@@ -64,11 +68,6 @@ void InfoPage2Screen::draw()
     }
 
     _display->drawLine(0,10,_iconX+11,10, 1);
-
-  _display->setTextSize(2);             
-  _display->setCursor(112,0);       
-  _display->print(_scsiId);           
-  _display->setTextSize(1);             
 
   _display->setCursor(0,22);             
   _display->print(F("Vendor:"));
@@ -89,7 +88,7 @@ void InfoPage2Screen::draw()
 
 void InfoPage2Screen::shortUserPress()
 {
-  changeScreen(SCREEN_MAIN, -1);
+  changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void InfoPage2Screen::rotaryChange(int direction)

--- a/lib/ZuluSCSI_UI_RP2MCU/InfoPage3Screen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/InfoPage3Screen.cpp
@@ -36,10 +36,14 @@ void InfoPage3Screen::draw()
   _display->setCursor(0,0);             
   _display->print(F("Info (3/3)"));
   
-  _iconX = 92;
+  _iconX = _display->width();
 
   DeviceMap &map = g_devices[_scsiId];
-  
+
+  _display->setTextSize(2);
+  printNumberFromTheRight(_scsiId, 6, 0);
+  _display->setTextSize(1);
+
   const uint8_t *deviceIcon = getIconForType(map.DeviceType, true);
   drawIconFromRight(deviceIcon, 6, 0);
 
@@ -54,10 +58,6 @@ void InfoPage3Screen::draw()
 
     _display->drawLine(0,10,_iconX+11,10, 1);
 
-  _display->setTextSize(2);             
-  _display->setCursor(112,0);       
-  _display->print(_scsiId);           
-  _display->setTextSize(1);             
 
   _display->setCursor(0,22);             
   _display->print(F("LBA:"));
@@ -82,7 +82,7 @@ void InfoPage3Screen::draw()
 
 void InfoPage3Screen::shortUserPress()
 {
-  changeScreen(SCREEN_MAIN, -1);
+  changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void InfoPage3Screen::rotaryChange(int direction)

--- a/lib/ZuluSCSI_UI_RP2MCU/InfoScreen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/InfoScreen.cpp
@@ -47,9 +47,14 @@ void InfoScreen::draw()
   _display->setCursor(0,0);             
   _display->print(F("Info (1/3)"));
   
-  _iconX = 92;
+  _iconX = _display->width();
 
   DeviceMap &map = g_devices[_scsiId];
+
+  _display->setTextSize(2);
+  printNumberFromTheRight(_scsiId, 6, 0);
+  _display->setTextSize(1);
+
 
   const uint8_t *deviceIcon = getIconForType(map.DeviceType, true);
   drawIconFromRight(deviceIcon, 6, 0);
@@ -65,10 +70,6 @@ void InfoScreen::draw()
 
     _display->drawLine(0,10,_iconX+11,10, 1);
 
-  _display->setTextSize(2);             
-  _display->setCursor(112,0);       
-  _display->print(_scsiId);           
-  _display->setTextSize(1);   
 
   _display->setCursor(0,22);             
   _display->print(F("File: "));
@@ -91,7 +92,7 @@ void InfoScreen::draw()
 
 void InfoScreen::shortUserPress()
 {
-  changeScreen(SCREEN_MAIN, -1);
+  changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void InfoScreen::rotaryChange(int direction)

--- a/lib/ZuluSCSI_UI_RP2MCU/Screen.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/Screen.cpp
@@ -206,13 +206,28 @@ void Screen::resetScrollerDelay()
 void Screen::printCenteredText(const char *text, int y)
 {
    int16_t lx = 0, ly = 0;
-   Size toDispSize;;
+   Size toDispSize;
   
    _display->getTextBounds(text, 0 ,0, &lx, &ly, &toDispSize.width, &toDispSize.height);
     int x = 64 - (toDispSize.width/2);
 
   _display->setCursor(x, y);
   _display->print(text);
+}
+
+void Screen::printNumberFromTheRight(int number, int extraSpace, int y)
+{
+  int16_t lx = 0, ly = 0;
+  Size toDispSize;
+
+  char number_text[13];
+  itoa(number, number_text, 10);
+  _display->getTextBounds(number_text, 0 ,0, &lx, &ly, &toDispSize.width, &toDispSize.height);
+  _iconX -= toDispSize.width;
+  _display->setCursor(_iconX, y);
+  _display->print(number_text);
+  _iconX -= 14;
+  _iconX -= extraSpace;
 }
 
 void Screen::drawIconFromRight(const uint8_t *icon, int extraSpace, int y)

--- a/lib/ZuluSCSI_UI_RP2MCU/Screen.h
+++ b/lib/ZuluSCSI_UI_RP2MCU/Screen.h
@@ -28,14 +28,17 @@
 #include "scrolling_text.h"
 
 #define MAX_SCOLLERS 4
-#define INDEX_UNINITIALIZED -100
+#define SCREEN_ID_UNINITIALIZED -100
+#define SCREEN_ID_OTHER 255
+#define SCREEN_ID_NO_PREVIOUS -1
+
 class Screen
 {
 protected:
     Adafruit_SSD1306 *_display;
     
 public:
-    Screen(Adafruit_SSD1306 *display) : _display(display), _init_index(INDEX_UNINITIALIZED) {}
+    Screen(Adafruit_SSD1306 *display) : _display(display), _init_index(SCREEN_ID_UNINITIALIZED) {}
     
     void virtual init(int index); // Called when switched to the screen
 	void virtual tick(); // Called on ever main loop cycle
@@ -90,6 +93,8 @@ protected:
 	void makeTimeStr(int seconds, char *buffer) ;
 
 	void printCenteredText(const char *text, int y);
+
+	void printNumberFromTheRight(int number, int extraSpace, int y);
 
 	FsFile createFile();
 	void saveScreenShot();

--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -120,7 +120,7 @@ static DeviceMap static_g_devices[S2S_MAX_TARGETS];
 
 Screen *g_activeScreen;
 
-int g_previousIndex = -1;
+int g_previousIndex = SCREEN_ID_NO_PREVIOUS;
 
 SYSTEM_MODE g_systemMode = SYSTEM_NORMAL;
 
@@ -215,7 +215,7 @@ static bool splashScreenPoll()
         if (g_uiStart == ZULUSCSI_UI_START_SPLASH_VERSION && (uint32_t)(millis() - g_uiStartTime) > 1500)
         {
             _splashScreen->setBannerText(systemModeToString(g_systemMode));
-            changeScreen(SCREEN_SPLASH, -1);
+            changeScreen(SCREEN_SPLASH, SCREEN_ID_NO_PREVIOUS);
             g_uiStart = ZULUSCSI_UI_START_SPLASH_SYS_MODE;
             g_uiStartTime = millis();
         }
@@ -228,21 +228,21 @@ static bool splashScreenPoll()
                 switch(g_systemMode)
                 {
                     case SYSTEM_NORMAL:
-                        changeScreen(SCREEN_MAIN, -1);
+                        changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
                         g_activeScreen->tick();
                         break;
 
                     case SYSTEM_INITIATOR:
                         _messageBox->setBlockingMode(true);
                         _messageBox->setText("-- Warning --", "MSC Mode not", "supported yet");
-                        changeScreen(MESSAGE_BOX, -1);
+                        changeScreen(MESSAGE_BOX, SCREEN_ID_NO_PREVIOUS);
                         g_activeScreen->tick();
                         break;
                 }
             }
             else if(g_systemMode == SYSTEM_NORMAL)
             {
-                changeScreen(SCREEN_MAIN, -1);
+                changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
                 g_activeScreen->tick();
             }
 
@@ -290,7 +290,7 @@ bool loadImageDeferred(uint8_t id, const char* next_filename, SCREEN_TYPE return
     _messageBox->setReturnScreen(returnScreen);
     _messageBox->setReturnConditionPendingLoadComplete();
         
-    if (strlen(next_filename) > (MAX_PATH_LEN-1))
+    if (strlen(next_filename) > (MAX_PATH_LEN - 1))
     {
         _messageBox->setText("-- Warning --", "Filepath", "too long...");
         changeScreen(MESSAGE_BOX, returnIndex);
@@ -538,7 +538,7 @@ void startInitiator(uint8_t initiatorId)
             deviceMap->InitiatorDriveStatus = i == initiatorId ? INITIATOR_DRIVE_HOST : INITIATOR_DRIVE_UNKNOWN;
         }
     }
-    deferredChangeScreen(SCREEN_INITIATOR_MAIN, -1);
+    deferredChangeScreen(SCREEN_INITIATOR_MAIN, SCREEN_ID_NO_PREVIOUS);
 }
 
 void initUIDisplay()
@@ -585,7 +585,7 @@ void initUIPostSDInit(bool sd_card_present)
         }
 
         _splashScreen->setBannerText(g_log_short_firmwareversion);
-        changeScreen(SCREEN_SPLASH, -1);
+        changeScreen(SCREEN_SPLASH, SCREEN_ID_NO_PREVIOUS);
         g_activeScreen->tick();
         g_uiStart = ZULUSCSI_UI_START_SPLASH_VERSION;
         g_uiStartTime = millis();
@@ -647,14 +647,14 @@ void stateChange()
     switch(g_systemMode)
     {
         case SYSTEM_NORMAL:
-            changeScreen(SCREEN_MAIN, -1);
+            changeScreen(SCREEN_MAIN, SCREEN_ID_NO_PREVIOUS);
             g_activeScreen->tick();
             break;
             
         case SYSTEM_INITIATOR:
             _messageBox->setBlockingMode(true);
             _messageBox->setText("-- Warning --", "MSC Mode not", "supported yet");
-            changeScreen(MESSAGE_BOX, -1);
+            changeScreen(MESSAGE_BOX, SCREEN_ID_NO_PREVIOUS);
             g_activeScreen->tick();
             break;
     }
@@ -1010,7 +1010,7 @@ extern "C" void mscMode()
     }
     mscModeMessageDisplayed = true;
     _messageBox->setText("-- Info --", "MSC Mode", "Enabled");
-    changeScreen(MESSAGE_BOX, -1);
+    changeScreen(MESSAGE_BOX, SCREEN_ID_NO_PREVIOUS);
     _messageBox->tick(); // During boot, there is no loop, so manually trigger the tick, to draw the screen
 }
 
@@ -1115,7 +1115,7 @@ void UICreateInit(uint64_t blockCount, uint32_t blockSize, const char *filename)
     _copyScreen->setShowInfoText(true);
     _copyScreen->setInfoText(filename);
     _copyScreen->setShowRetriesAndErrors(false);
-    overrideSplashScreenLoad(SCREEN_COPY, 255);
+    overrideSplashScreenLoad(SCREEN_COPY, SCREEN_ID_OTHER);
 }
 
 void UICreateProgress(uint32_t blockTime, uint32_t blockCopied) 
@@ -1163,7 +1163,7 @@ void UIKioskCopyInit(uint8_t deviceIndex, uint8_t totalDevices, uint64_t blockCo
     _copyScreen->setInfoText(filename);
     _copyScreen->setShowRetriesAndErrors(false);
 
-    overrideSplashScreenLoad(SCREEN_COPY, 255);
+    overrideSplashScreenLoad(SCREEN_COPY, SCREEN_ID_OTHER);
 }
 
 void UIKioskCopyProgress(uint32_t blockTime, uint32_t blockCopied)
@@ -1248,7 +1248,7 @@ void UIInitiatorScanning(uint8_t deviceId, uint8_t initiatorId)
             g_devices[i].InitiatorDriveStatus = INITIATOR_DRIVE_SCANNED;
         }
     }
-    if (!deferredChangeScreen(SCREEN_INITIATOR_MAIN, -1))
+    if (!deferredChangeScreen(SCREEN_INITIATOR_MAIN, SCREEN_ID_NO_PREVIOUS))
         _initiatorMainScreen->tick();
 }
 
@@ -1362,7 +1362,7 @@ void UIInitiatorImagingComplete(uint8_t deviceId)
     DeviceMap *deviceMap = &g_devices[deviceId];
 
     deviceMap->InitiatorDriveStatus = INITIATOR_DRIVE_CLONED;
-    deferredChangeScreen(SCREEN_INITIATOR_MAIN, -1, true);
+    deferredChangeScreen(SCREEN_INITIATOR_MAIN, SCREEN_ID_NO_PREVIOUS, true);
 }
 
 

--- a/src/SDNavigator.cpp
+++ b/src/SDNavigator.cpp
@@ -5,14 +5,10 @@
 
 bool SDNavigator::startsWith(const char* str, const char* prefix) 
 {
-    // Loop until the prefix character is null or a mismatch is found
-    while (tolower(*prefix) && tolower(*str) == tolower(*prefix)) 
-    {
-        str++;
-        prefix++;
-    }
-    // If the prefix is fully matched (meaning it reached its null terminator)
-    return *prefix == '\0'; // or return *prefix == 0;
+    size_t prefix_len = strlen(prefix);
+    if (strlen(str) < prefix_len)
+        return false;
+    return strncasecmp(prefix, str, prefix_len) == 0;
 }
 
 PROCESS_DIR_ITEM_RESULT SDNavigator::ProcessDirectoryItem(FsFile &file, const char *filename, const char *path)


### PR DESCRIPTION
Full support for two digit SCSI IDs on all screens.
Able to switch between pages 1 and 2 on the main screen for IDs 0-7 and 8-15 respectively.

In initiator mode, SCSI IDs above 7 are not supported yet.