### PR TITLE
Give the user more information when using WiFi

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -358,6 +358,36 @@ build_flags =
     -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
     -DSD_USE_RP2350_SDIO
 
+[env:ZuluSCSI_Pimoroni_Pico_Plus_2]
+extends = env:ZuluSCSI_RP2MCU
+board = rhc_zuluscsi_blaster
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+lib_deps =
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    adafruit/Adafruit SSD1306@^2.5.15
+    adafruit/Adafruit GFX Library@^1.12.1
+    adafruit/Adafruit BusIO@^1.17.1
+    ZuluSCSI_UI_RP2MCU
+    ZuluSCSI_audio_RP2MCU
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_PIMORONI_PICO_PLUS_2
+    -DZULUSCSI_MCU_RP23XX
+    ; -DENABLE_AUDIO_OUTPUT
+    ; -DENABLE_AUDIO_OUTPUT_I2S
+    -DSD_USE_RP2350_SDIO
+    -DZULUSCSI_NETWORK
+    -DZULUSCSI_DAYNAPORT
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    -DZULUSCSI_RM2
+; Use the -Wl line below as a "build_flags" entry if you wish to make a map file
+; to check memory locations of the compiled code.
+;    -Wl,-Map="${platformio.build_dir}/${this.__env__}/firmware.map"
+	-DCONTROL_BOARD
+    -DSSD1306_NO_SPLASH
+
 ;========================================
 ; RP2350B based variant with 16-bit wide SCSI bus support
 [env:ZuluSCSI_Wide]

--- a/src/Toolbox.cpp
+++ b/src/Toolbox.cpp
@@ -41,7 +41,7 @@ extern "C" int8_t scsiToolboxEnabled()
     if (enabled == -1)
     {
         enabled = ini_getbool("SCSI", "EnableToolbox", 0, CONFIGFILE);
-        logmsg("Toolbox enabled = ", enabled);
+        logmsg("Toolbox ", enabled == 1 ? "enabled" : "disabled");
     }
     return enabled == 1;
 }

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -812,14 +812,27 @@ static void reinitSCSI()
   scsiInit();
 
 #ifdef ZULUSCSI_NETWORK
+
   if (scsiDiskCheckAnyNetworkDevicesConfigured() && platform_network_supported())
   {
-    platform_network_init(scsiDev.boardCfg.wifiMACAddress);
     if (scsiDev.boardCfg.wifiSSID[0] != '\0')
+    {
+      platform_network_init(scsiDev.boardCfg.wifiMACAddress);
       platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+    }
+    else
+    {
+      logmsg("Wi-Fi device enabled, but no WiFi SSID specified."); 
+      logmsg("Please define \"WiFiSSID\" in the config file: ", CONFIGFILE, " under the heading \"[SCSI]\"");
+    }
   }
   else
   {
+    if (platform_network_supported() && scsiDev.boardCfg.wifiSSID[0] != '\0')
+    {
+      logmsg("Wi-Fi SSID specified as \"", scsiDev.boardCfg.wifiSSID, "\", but no SCSI ID assigned to a network device");
+      logmsg("Please create an empty file \"NEx.img\", where x is the SCSI ID of the network device, on the SD card");
+    }
     platform_network_deinit();
   }
 #endif // ZULUSCSI_NETWORK
@@ -1206,7 +1219,7 @@ extern "C" void zuluscsi_setup(void)
 #if ZULUSCSI_RESERVED_SRAM_LEN > 0
     dbgmsg("Shared buffer has ", (int) reserve_buffer_left(), " bytes left out of ", (int) ZULUSCSI_RESERVED_SRAM_LEN, " bytes total");
 #endif
-    logmsg("Initialization complete!");
+    logmsg("Firmware initialization complete!");
 }
 
 void control_disk_swap()

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1460,6 +1460,7 @@ void s2s_configInit(S2S_BoardCfg* config)
     ini_gets("SCSI", "WiFiSSID", "", tmp, sizeof(tmp), CONFIGFILE);
     if (tmp[0]) memcpy(config->wifiSSID, tmp, sizeof(config->wifiSSID));
 
+
     memset(tmp, 0, sizeof(tmp));
     ini_gets("SCSI", "WiFiPassword", "", tmp, sizeof(tmp), CONFIGFILE);
     if (tmp[0]) memcpy(config->wifiPassword, tmp, sizeof(config->wifiPassword));


### PR DESCRIPTION
Inform the user about these cases:
 - A NEx.img is set up but no WiFi SSID in zuluscsi.ini is set
 - A SSID is set in zuluscsi.ini but no NEx.img exist on the SD card
 - Inform the user when WiFi authentication has failed
 - Inform the user when no SSID is found
 - Inform the user when connected but no IP is given
 - Inform the user when a general WiFi failure occurs
 - Reword "Initialization complete!"" to "Firmware initialization complete!"
 - Reword "Toolbox enabled = 0/1" to "Toolbox enabled/disabled"