### PR TITLE
toolbox: Set DATA_IN phase for TOOLBOX_LIST_DEVICES command.

### DIFF
--- a/src/Toolbox.cpp
+++ b/src/Toolbox.cpp
@@ -222,6 +222,7 @@ static void onListDevices()
         }
     }
     scsiDev.dataLen = S2S_MAX_TARGETS;
+    scsiDev.phase = DATA_IN;
 }
 
 static void onSetNextCD(const char * img_dir)


### PR DESCRIPTION
I'm writing a small Amiga tool to interface with the toolbox and noticed I didn't get any data back from TOOLBOX_LIST_DEVICES command. I assume this is the issue, will verify once test build is done.