### PR TITLE
Fix Blaster audio on reclock and set new speed grades for RP2040 bases boards now that their base clock is higher

### DIFF
--- a/lib/ZuluSCSI_audio_RP2MCU/ZuluI2S.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/ZuluI2S.cpp
@@ -33,6 +33,7 @@ I2S::I2S() {
     _sm = 1;
     _pinBCLK = 26;
     _pinDOUT = 28;
+    _offset = 0;
 }
 
 I2S::~I2S() {
@@ -84,10 +85,9 @@ bool I2S::begin(PIO pio, uint sm) {
     _pio = pio;
     _sm = sm;
     _running = true;
-    int off = 0;
     pio_sm_claim(_pio, _sm);
-    off = pio_add_program(_pio, &pio_i2s_out_program);
-    pio_i2s_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps);
+    _offset = pio_add_program(_pio, &pio_i2s_out_program);
+    pio_i2s_out_program_init(_pio, _sm, _offset, _pinDOUT, _pinBCLK, _bps);
     pio_sm_set_clkdiv_int_frac(_pio, _sm, _div_int, _div_frac);
     pio_sm_set_enabled(_pio, _sm, true);
     return true;
@@ -96,6 +96,7 @@ bool I2S::begin(PIO pio, uint sm) {
 void I2S::end() {
     if (_running) {
         pio_sm_set_enabled(_pio, _sm, false);
+        pio_remove_program_and_unclaim_sm(&pio_i2s_out_program, _pio, _sm, _offset);
         _running = false;
     }
 }

--- a/lib/ZuluSCSI_audio_RP2MCU/ZuluI2S.h
+++ b/lib/ZuluSCSI_audio_RP2MCU/ZuluI2S.h
@@ -44,6 +44,7 @@ private:
     uint8_t _div_frac;
     int _bps;
     bool _running;
+    int _offset;
 
     PIOProgram *_i2s;
     PIO _pio;

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
@@ -435,6 +435,14 @@ void audio_setup() {
     irq_clear(I2S_DMA_IRQ_NUM);
 }
 
+void audio_reclock()
+{
+    i2s.end();
+    i2s.setDivider(g_zuluscsi_timings->audio.clk_div_pio, 0);
+    i2s.begin(I2S_PIO_HW, I2S_PIO_SM);
+}
+
+
 void audio_poll() {
     if (audio_idle) return;
 

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.h
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.h
@@ -47,6 +47,11 @@ bool audio_is_active();
 void audio_setup();
 
 /**
+ * Reclocks the I2S interface
+ */
+void audio_reclock();
+
+/**
  * Called from platform_poll() to fill sample buffer(s) if needed.
  */
 void audio_poll();

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -380,7 +380,7 @@ void platform_init()
         termination = !gpio_get(DIP_TERM);
 
     }
-# elif defined(ZULUSCSI_V2_0)
+# elif defined(ZULUSCSI_RP2040)
     pin_setup_state_t dip_state = read_setup_ack_pin();
     if (dip_state == SETUP_UNDETERMINED)
     {
@@ -679,10 +679,15 @@ void platform_late_init()
 
 void platform_post_sd_card_init() 
 {
-#if defined(ENABLE_AUDIO_OUTPUT) && !defined(ZULUSCSI_BLASTER)
-        // one-time control setup for DMA channels and second core
-        audio_setup();
+#if defined(ENABLE_AUDIO_OUTPUT)
+# ifdef ENABLE_AUDIO_OUTPUT_I2S
+    audio_reclock();
+# elif defined(ENABLE_AUDIO_OUTPUT_SPDIF)
+    // one-time control setup for DMA channels and second core
+    audio_setup();
+# endif
 #endif // ENABLE_AUDIO_OUTPUT
+
 }
 
 bool platform_is_initiator_mode_enabled()

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -338,7 +338,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .audio =
         {
             // Divider for 44.1KHz to the nearest integer with a sys clk divided by 2 x 16-bit samples with the pio clock running 2x I2S clock
-            // 200.4Mhz / 16 / 2 / 2 / 44.1KHz = 71.003 ~= 71
+            // 250Mhz / 16 / 2 / 2 / 44.1KHz = 88.577 ~= 89
             .clk_div_pio = 89,
             .audio_clocked = false,
         }
@@ -602,7 +602,7 @@ static zuluscsi_timings_t  predefined_timings[]  = {
         .audio =
         {
             // Divider for 44.1KHz to the nearest integer with a sys clk divided by 2 x 16-bit samples with the pio clock running 2x I2S clock
-            // 200.4Mhz / 16 / 2 / 2 / 44.1KHz = 71.003 ~= 71
+            // 251.2Mhz / 16 / 2 / 2 / 44.1KHz = 89.00 ~= 89
             .clk_div_pio = 89,
             .audio_clocked = true,
         }
@@ -743,16 +743,42 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
     case SPEED_GRADE_BASE_155MHZ:
         timings_index = 5;
         break;
+#elif defined(ENABLE_AUDIO_OUTPUT_SPDIF)
+    case SPEED_GRADE_MAX:
+    case SPEED_GRADE_A:
+        timings_index = 8;
+        break;
+    case SPEED_GRADE_B:
+        timings_index = 4;
+        break;
+    case SPEED_GRADE_C:
+        timings_index = 2;
+        break;
+    case SPEED_GRADE_AUDIO_SPDIF:
+        timings_index = 9;
+        break;
+    case SPEED_GRADE_AUDIO_I2S:
+        timings_index = 5;
+        break;
+    case SPEED_GRADE_WIFI_RM2:
+        timings_index = 3;
+        break;
+    case SPEED_GRADE_BASE_203MHZ:
+        timings_index = 9;
+        break;
+    case SPEED_GRADE_BASE_155MHZ:
+        timings_index = 5;
+        break;
 #else
     case SPEED_GRADE_MAX:
     case SPEED_GRADE_A:
-        timings_index = 4;
+        timings_index = 8;
         break;
     case SPEED_GRADE_B:
-        timings_index = 3;
+        timings_index = 4;
         break;
     case SPEED_GRADE_C:
-        timings_index  = 1;
+        timings_index = 1;
         break;
     case SPEED_GRADE_AUDIO_SPDIF:
         timings_index = 9;

--- a/platformio.ini
+++ b/platformio.ini
@@ -186,7 +186,7 @@ debug_build_flags =
     -DLOGBUFSIZE=4096
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
-    -DZULUSCSI_V2_0
+    -DZULUSCSI_RP2040
     -DZULUSCSI_MCU_RP20XX
     -DENABLE_AUDIO_OUTPUT
     -DENABLE_AUDIO_OUTPUT_SPDIF

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1120,7 +1120,7 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
     }
     else
     {
-#ifndef ENABLE_AUDIO_OUTPUT // if audio is enabled, skip message because reclocking ocurred earlier
+#ifndef ENABLE_AUDIO_OUTPUT // if audio is enabled, skip message because reclocking occurred earlier
       logmsg("Speed grade set to Default, skipping reclocking");
 #endif
     }


### PR DESCRIPTION
ZuluSCSI Blaster audio is setup before reclocking because it is on by default. Added the ability to reclock Blaster's I2S audio PIO statemachine after the system clock has been reclocked. Which fixes the issue.

Using different speed grades for the RP2040 now that audio is compiled in and the default is 203.2 MHz. Speed grade A is now 251.2 MHz, B is 250, MHz and C is the original clock rate of 135.42 MHz that S/PDIF was originally designed around.

Also changed the speed grade value of the Pico/Pico W. It is now the same as the RP2040 but instead of C being 135.42 it is the 133 MHz.

Changed the ZuluSCSI RP2040 platformio.ini model define from ZULUSCSI_V2_0 to ZULUSCSI_RP2040 to be more clear.