### PR TITLE
fix for splash screen not disappearing if no sd card at boot

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1080,10 +1080,7 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
         uint32_t input_wait_start = millis();
         while ((uint32_t)(millis() - input_wait_start) < 500)
         {
-          if (scsiDev.phase == BUS_FREE)
-          {
-            controlLoop();
-          }
+          controlLoop();
         }
       }
       platform_reset_watchdog();


### PR DESCRIPTION
`controlLoop();` in  `zuluscsi_setup_sd_card()` only seems to be  called if:
1 - There is no SD card
2 - It's booting

(This doesn't get called when the sd is removed, `controlLoop()` is called in `zuluscsi_main_loop()` in that case)

`scsiDev.phase == 0` which is why `controlLoop()` was never being called. I assume is just becuase it's not initialized yet.

so it seems safe to call this here without the: `if (scsiDev.phase == BUS_FREE)` check.

Or would it better to set scsiDev.phase to `BUS_FREE` earlier in the init process and keep the if check?