### PR TITLE
RP2350: Update SDIO_RP2350 library to improve SD card compatibility

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -255,7 +255,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
 debug_build_flags =
     ${env:ZuluSCSI_RP2MCU.debug_build_flags}
 build_flags =
@@ -317,7 +317,7 @@ ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     ZuluI2S
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
     adafruit/Adafruit SSD1306@^2.5.15
     adafruit/Adafruit GFX Library@^1.12.1
     adafruit/Adafruit BusIO@^1.17.1
@@ -344,7 +344,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_PICO_2
@@ -364,7 +364,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.3
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
     compact25519=https://github.com/rabbitholecomputing/compact25519
     ZuluI2S
 build_flags =


### PR DESCRIPTION
With this change, high speed SD communication is no longer attempted for cards that report class below 10. This improves compatibility with old SD cards.