### PR TITLE
Free up SRAM for the RP2040 for COW

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -192,6 +192,7 @@ build_flags =
     -DENABLE_AUDIO_OUTPUT_SPDIF
     -DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
+    -DLOGBUFSIZE=8192
 
 ; Variant of RP2040 platform, based on Raspberry Pico board and a carrier PCB
 ; Part of the ZuluSCSI_RP2040 platform, but with different pins.


### PR DESCRIPTION
The RP2040 was freezing when using a Copy on Write image. Halving the log buffer to 8192 bytes fixed the issue.