### PR TITLE
Upgrade arduino-pico library to v5.4.2-DaynaPORT

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -55,8 +55,7 @@
 
 #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
 # include <SerialUSB.h>
-# include <class/cdc/cdc_device.h>
-# include <device/usbd.h>
+# include <USB.h>
 #endif
 
 #include <pico/multicore.h>
@@ -390,10 +389,7 @@ void platform_init()
     gpio_set_input_enabled(GPIO_INT, true);
 #endif
 #endif
-    // In case of a firmware update the USB connection fails and needs to be restarted
-    tud_disconnect();
-    delay(10); // 10 ms delay to let pull-ups do their work
-    tud_connect();
+
     bool working_dip = true;
     bool dbglog = false;
     bool termination = false;

--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
@@ -49,7 +49,7 @@ SECTIONS
     * reduce the flash usage.
     */
     /DISCARD/ : {
-
+        *fprintf*(*)
         *scanf*(*)
         *strtod*(*)
         *libipv4.a:*(*)
@@ -78,7 +78,7 @@ SECTIONS
         init_cyw43_wifi = bootloader_main;
         setPendingImageLoad = 0;
         platform_poll = 0;
-
+        _vfprintf_r = 0;
 
         __logical_binary_start = .;
         KEEP (*(.btldr_vectors))

--- a/platformio.ini
+++ b/platformio.ini
@@ -123,7 +123,7 @@ lib_deps =
 [env:ZuluSCSI_RP2MCU]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6164ed92d83c1241a1d84ad848158d7b0fb486e3
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v4.7.0-DaynaPORT
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v5.4.2-DaynaPORT
 extra_scripts =
     src/build_bootloader.py
     src/process-linker-script.py

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -91,8 +91,8 @@ void save_logfile(bool always = false)
     return;
 #endif
 
-if (!g_log_to_sd)
-  return;
+  if (!g_log_to_sd)
+    return;
   
   static uint32_t prev_log_pos = 0;
   static uint32_t prev_log_len = 0;


### PR DESCRIPTION
The v5.4.2-DaynaPORT reworked the USB interface. RP2040USB.h has been replaced with USB.h. Made the necessary changes to get the mass storage to work with the new USB library.

Also shrunk the RP2350 bootloader's flash footprint so it would fit when compiled for debugging.