### PR TITLE
Add stack overflow protection to both cores

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
@@ -318,8 +318,8 @@ SECTIONS
     __StackLimit = ORIGIN(RAM) + LENGTH(RAM);
     __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
     __StackTop = ORIGIN(SCRATCH_Y) + LENGTH(SCRATCH_Y);
-    __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
-    __StackBottom = __StackTop - SIZEOF(.stack_dummy);
+    __StackOneBottom = __scratch_x_end__;
+    __StackBottom = __scratch_y_end__;
     PROVIDE(__stack = __StackTop);
 
     /* picolibc and LLVM */


### PR DESCRIPTION
The RP2350's ARM Cortex ARM-33 has stack overflow protection. Taken from ZuluIDE, the ZuluSCSI's with RP2350 MCUs now will throw a hardfault if either core stack overflows and record that state in the `zuluerr.txt` file.