### PR TITLE
Fix eject buttons on RP2040 I2C lines

### DIFF
--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -648,6 +648,13 @@ void initDevices()
 
 void initUIPostSDInit(bool sd_card_present)
 {
+#if  defined(ZULUSCSI_MCU_RP20XX) && defined(ENABLE_AUDIO_OUTPUT_SPDIF)
+    // CD Audio uses the I2C pins in this case, do not attempt to init the UI
+    if(g_scsi_settings.getSystem()->enableCDAudio)
+    {
+        return;
+    }
+#endif
     if (!hasScreenBeenInitialized || hasControlBeenInitialized)
     {
         return;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1116,8 +1116,8 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
         logmsg("No SD card detected, please check SD card slot to make sure it is in correctly");
       }
 
-      // if booting and no card found, we want to init the display here as it usually gets inited
-      // from readint the config
+      // if booting and no card found, we want to init the display here as it usually gets initiated
+      // from reading the config
       initUIPostSDInit(false);
     }
     dbgmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),
@@ -1185,6 +1185,7 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
     ini_gets("SCSI", "System", "", presetName, sizeof(presetName), CONFIGFILE);
     scsi_system_settings_t *cfg = g_scsi_settings.initSystem(presetName);
     g_log_to_sd = g_scsi_settings.getSystem()->logToSDCard;
+    initUIPostSDInit(true);
 
     #ifdef RECLOCKING_SUPPORTED
     zuluscsi_speed_grade_t speed_grade = (zuluscsi_speed_grade_t) g_scsi_settings.getSystem()->speedGrade;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1373,7 +1373,7 @@ void s2s_configInit(S2S_BoardCfg* config)
     // Get default values from system preset, if any
     ini_gets("SCSI", "System", "", tmp, sizeof(tmp), CONFIGFILE);
     scsi_system_settings_t *sysCfg = g_scsi_settings.initSystem(tmp);
-
+    initUIPostSDInit(true);
     if (g_scsi_settings.getSystemPreset() != SYS_PRESET_NONE)
     {
         logmsg("Active configuration (using system preset \"", g_scsi_settings.getSystemPresetName(), "\"):");

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -481,9 +481,6 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
 #if ENABLE_COW
     cfgSys.cowBufferSize = ini_getl("SCSI", "CowBufferSize", cfgSys.cowBufferSize, CONFIGFILE);
 #endif
-
-    initUIPostSDInit(true);
-
     return &cfgSys;
 }
 


### PR DESCRIPTION
With the introduction of the control board and the merging of the RP2040 Audio build into the base RP2040 build, eject buttons on the I2C lines got lost.

This initiates GPIOs as inputs with pull up for buttons on the I2C lines if EnableCDAudio is disabled (default state) and no control board is found.

This is for issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/697