### PR TITLE
Add setting to close tray immediately

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1275,6 +1275,10 @@ void cdromPerformEject(image_config_t &img)
         img.ejected = true;
         img.cdrom_events = 3; // Media removal
         switchNextImage(img); // Switch media for next time
+        if (g_scsi_settings.getDevice(target)->reinsertImmediately)
+        {
+            cdromCloseTray(img);
+        }
     }
     else
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -894,6 +894,10 @@ static void doPerformEject(image_config_t &img)
         dbgmsg("------ Device open tray on ID ", (int)target);
         img.ejected = true;
         switchNextImage(img); // Switch media for next time
+        if (g_scsi_settings.getDevice(target)->reinsertImmediately)
+        {
+            doCloseTray(img);
+        }
     }
     else
     {

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -244,6 +244,7 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
     cfg.rightAlignStrings = ini_getbool(section, "RightAlignStrings", cfg.rightAlignStrings , CONFIGFILE);
     cfg.reinsertOnInquiry = ini_getbool(section, "ReinsertCDOnInquiry", cfg.reinsertOnInquiry, CONFIGFILE);
     cfg.reinsertAfterEject = ini_getbool(section, "ReinsertAfterEject", cfg.reinsertAfterEject, CONFIGFILE);
+    cfg.reinsertImmediately = ini_getbool(section, "ReinsertImmediately", cfg.reinsertImmediately, CONFIGFILE);
     cfg.disableMacSanityCheck = ini_getbool(section, "DisableMacSanityCheck", cfg.disableMacSanityCheck, CONFIGFILE);
 
     cfg.sectorSDBegin = ini_getl(section, "SectorSDBegin", cfg.sectorSDBegin, CONFIGFILE);
@@ -362,6 +363,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgDev.rightAlignStrings = false;
     cfgDev.reinsertOnInquiry = true;
     cfgDev.reinsertAfterEject = true;
+    cfgDev.reinsertImmediately = false;
     cfgDev.disableMacSanityCheck = false;
 
     cfgDev.sectorSDBegin = 0;

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -142,6 +142,7 @@ typedef struct __attribute__((__packed__)) scsi_device_settings_t
     bool rightAlignStrings;
     bool reinsertOnInquiry;
     bool reinsertAfterEject;
+    bool reinsertImmediately;
     bool disableMacSanityCheck;
 
     uint32_t sectorSDBegin;

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -95,7 +95,8 @@
 #RightAlignStrings = 0 # Right-align SCSI vendor / product strings
 #PrefetchBytes = 8192 # Maximum number of bytes to prefetch after a read request, 0 to disable
 #ReinsertCDOnInquiry = 1 # Reinsert any ejected CD-ROM image on Inquiry command
-#ReinsertAfterEject = 1 # Reinsert next CD image after eject, if multiple images configured.
+#ReinsertAfterEject = 1 # Reinsert next image after eject, if multiple images configured.
+#ReinsertImmediately = 0 # Reinsert the next image without waiting for a SCSI command
 #EjectButton = 0 # Enable eject by button 1 or 2, or set 0 to disable
 
 # The default values of 20 and 50 give a visible and audible (with optional buzzer) eject notification


### PR DESCRIPTION
Added the setting `ReinsertImmediately`, when set to 1, that calls the close tray method immediately after the open tray is called. This occurs before any SCSI commands gets sent the the ZuluSCSI board.

For example the setting `ReinsertAfterEject` waits for test unit ready or get event notification SCSI commands before calling the close tray method.

This is for issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/697