### PR TITLE
Fix eject not  wrapping back to the first image

### DIFF
--- a/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
@@ -556,7 +556,7 @@ bool  audio_play_track_index(uint8_t owner,      image_config_t* img,
         logmsg("Error attempting to play CD Audio with no cue/bin image(s)");
         return false;
     }
-    if (img->bin_container.isOpen() && img->bin_container.isDir())
+    if (img->is_multi_bin_cue())
     {
         audio_parent.close();
         audio_file.close();
@@ -687,7 +687,7 @@ bool audio_play(uint8_t owner, image_config_t* img, uint32_t start, uint32_t len
         return false;
     }
 
-    if (img->bin_container.isOpen() && img->bin_container.isDir())
+    if (img->is_multi_bin_cue())
     {
         audio_parent.close();
         audio_file.close();

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1003,6 +1003,17 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     char nextname[MAX_FILE_PATH];
     int nextlen;
 
+    char currentname[MAX_FILE_PATH];
+    // Test to see if we have a multi bin/cue file in a directory. Use the directory name instead
+    if (img.is_multi_bin_cue())
+    {
+        img.bin_container.getName(currentname, sizeof(currentname));
+    }
+    else
+    {
+        strcpy(currentname, img.current_image);
+    }
+
     if (img.image_directory)
     {
         // image directory was found during startup
@@ -1047,7 +1058,8 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
         }
 
         // find the next filename
-        nextlen = findNextImageAfter(img, dirname, img.current_image, nextname, sizeof(nextname));
+
+        nextlen = findNextImageAfter(img, dirname, currentname, nextname, sizeof(nextname));
 
         if (nextlen == 0)
         {
@@ -1099,10 +1111,10 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     }
     else if (img.use_prefix)
     {
-        nextlen = findNextImageAfter(img, "/", img.current_image, nextname, sizeof(nextname));
+        nextlen = findNextImageAfter(img, "/", currentname, nextname, sizeof(nextname));
         if (nextlen == 0)
         {
-            logmsg("Next file with the same prefix as ", img.current_image," not found for ID", target_idx);
+            logmsg("Next file with the same prefix as ", currentname," not found for ID", target_idx);
         }
         else if (buflen < nextlen + 1)
         {

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -92,6 +92,8 @@ struct image_config_t: public S2S_TargetCfg
     // the bin file for the cue sheet, the directory for multi bin files, or closed if neither
     FsFile bin_container;
 
+    inline bool is_multi_bin_cue() {return bin_container.isOpen() && bin_container.isDir();}
+
     // Right-align vendor / product type strings
     // Standard SCSI uses left alignment
     int rightAlignStrings;


### PR DESCRIPTION
This is concerning issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/705 In some cases of ejecting multi bin/cue directories with an eject button , the images would not wrap back to the first image and would get stuck indefinitely on a single image.

The cause was due to comparing a filename in the bin/cue directory with the next possible disc name instead of the directory name of the bin/cue disc.