### PR TITLE
Fix crash when no control board is present

### DIFF
--- a/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
@@ -375,7 +375,7 @@ bool audio_is_playing(uint8_t id) {
 
 void audio_setup() {
 #ifdef CONTROL_BOARD
-    if (!g_scsi_settings.getSystem()->enableCDAudio || g_controlBoardEnabled)
+    if (!g_scsi_settings.getSystem()->enableCDAudio || g_controlBoardEnabled || g_displayEnabled)
 #else
     if (!g_scsi_settings.getSystem()->enableCDAudio)
 #endif

--- a/lib/ZuluSCSI_platform_GD32F205/ui.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ui.cpp
@@ -22,7 +22,7 @@
 #include "ui.h"
 
 extern "C" void scsiReinitComplete() {}
-extern "C" void sdCardStateChanged(bool sdAvailable) {}
+extern "C" void sdCardStateChanged(bool sdAvailable, bool romdrivePresent) {}
 extern "C" void controlLoop() {}
 extern "C" bool mscMode() { return false; }
 extern "C" void setRootFolder(int target_idx, bool userSet, const char *path) {}
@@ -32,6 +32,7 @@ extern "C" void initUIDisplay() {}
 extern "C" void initUIPostSDInit(bool cardPresent) {}
 
 bool g_controlBoardEnabled = false;
+bool g_displayEnabled = false;
 
 bool g_initiatorMessageToProcess;
 

--- a/lib/ZuluSCSI_platform_GD32F450/ui.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/ui.cpp
@@ -31,6 +31,7 @@ extern "C" void initUIDisplay() {}
 extern "C" void initUIPostSDInit(bool cardPresent) {}
 
 bool g_controlBoardEnabled = false;
+bool g_displayEnabled = false;
 
 bool g_initiatorMessageToProcess;
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1332,7 +1332,7 @@ void platform_reset_mcu(uint32_t reset_in_ms)
 uint8_t platform_get_buttons()
 {
     static bool init_buttons = false;
-    if (!g_controlBoardEnabled) // use legacy button pressing stuff
+    if (!g_displayEnabled) // use legacy button pressing stuff
     {
         uint8_t buttons = 0;
 
@@ -1341,7 +1341,7 @@ uint8_t platform_get_buttons()
         {   // pulled to VCC via resistor, sinking when pressed
             if (!gpio_get(GPIO_EXP_SPARE)) buttons |= 1;
         }
-        else if (!g_controlBoardEnabled)
+        else if (!g_displayEnabled)
         {
             if (!init_buttons)
             {

--- a/lib/ZuluSCSI_platform_RP2MCU/ui.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ui.cpp
@@ -23,9 +23,10 @@
 
 #ifndef CONTROL_BOARD
 bool g_controlBoardEnabled = false;
+bool g_displayEnabled = false;
 
 extern "C" void scsiReinitComplete() {}
-extern "C" void sdCardStateChanged(bool sdAvailable) {}
+extern "C" void sdCardStateChanged(bool sdAvailable, bool romdrivePresent) {}
 extern "C" void controlLoop() {}
 extern "C" bool mscMode() { return false; }
 extern "C" void setRootFolder(int target_idx, bool userSet, const char *path) {}

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2025.11.26"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2025.12.01"
+#define FW_VER_SUFFIX   "dev"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ui.h
+++ b/src/ui.h
@@ -45,7 +45,8 @@ typedef enum
 #define MAX_CATEGORY_NAME_LEN 32
 
 extern "C" void scsiReinitComplete();
-extern "C" void sdCardStateChanged(bool sdAvailable);
+extern "C" void sdCardStateChanged(bool sdAvailable, bool romdrive_present);
+
 
 extern "C" void controlLoop();
 extern "C" bool mscMode();
@@ -60,6 +61,7 @@ extern "C" void initUIPostSDInit(bool cardPresent);
 extern "C" void initScreens();
 
 extern bool g_controlBoardEnabled;
+extern bool g_displayEnabled;
 
 #if defined(CONTROL_BOARD)
 


### PR DESCRIPTION
This fixes a crash when no control board is present. A regression from https://github.com/ZuluSCSI/ZuluSCSI-firmware/pull/707