### PR TITLE
Save crash log on SD card insert

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -131,7 +131,7 @@ inline mass_storage_mode platform_rebooted_into_mass_storage() {return MASS_STOR
 
 // Reinitialize SD card connection and save log from interrupt context.
 // This can be used in crash handlers.
-void platform_emergency_log_save();
+bool platform_emergency_log_save();
 
 // Set callback that will be called during data transfer to/from SD card.
 // This can be used to implement simultaneous transfer to SCSI bus.

--- a/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F450/ZuluSCSI_platform.h
@@ -121,7 +121,7 @@ inline bool platform_rebooted_into_mass_storage() {return false;}
 
 // Reinitialize SD card connection and save log from interrupt context.
 // This can be used in crash handlers.
-void platform_emergency_log_save();
+bool platform_emergency_log_save();
 
 // Set callback that will be called during data transfer to/from SD card.
 // This can be used to implement simultaneous transfer to SCSI bus.

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -66,7 +66,7 @@ extern const char *g_platform_name;
 // Debug logging function, can be used to print to e.g. serial port.
 // May get called from interrupt handlers.
 void platform_log(const char *s);
-void platform_emergency_log_save();
+bool platform_emergency_log_save();
 
 // Timing and delay functions.
 // Arduino platform already provides these


### PR DESCRIPTION
If the device crashes without an SD card, then save the crash log when an SD card is inserted. For example if the device crashes while it is running as an ROM drive without an SD card present.