### PR TITLE
Improve SDIO card error recovery

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/sdio_rp2350_config.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/sdio_rp2350_config.h
@@ -21,6 +21,9 @@
 #define SDIO_DBGMSG(txt, arg1, arg2) dbgmsg(txt, " ", (uint32_t)(arg1), " ", (uint32_t)(arg2))
 #endif
 
+// Critical messages are logged always
+#define SDIO_CRITMSG(txt, arg1, arg2) logmsg(txt, " ", (uint32_t)(arg1), " ", (uint32_t)(arg2))
+
 // PIO block to use
 #define SDIO_PIO pio1
 #define SDIO_SM  0

--- a/platformio.ini
+++ b/platformio.ini
@@ -173,6 +173,7 @@ extends = env:ZuluSCSI_RP2MCU
 board = zuluscsi_rp2040
 linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     adafruit/Adafruit SSD1306@^2.5.15
@@ -201,6 +202,7 @@ extends = env:ZuluSCSI_RP2MCU
 board = rpipico
 linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_PICO
@@ -213,6 +215,7 @@ extends = env:ZuluSCSI_RP2MCU
 board = rpipicow
 linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
 debug_build_flags =
     ${env:ZuluSCSI_RP2MCU.debug_build_flags}
     ; This controls the depth NETWORK_PACKET_MAX_SIZE (1520 bytes)
@@ -244,6 +247,7 @@ extends = env:ZuluSCSI_RP2MCU
 board = rpipico
 linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_BS2

--- a/platformio.ini
+++ b/platformio.ini
@@ -257,7 +257,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.5
 debug_build_flags =
     ${env:ZuluSCSI_RP2MCU.debug_build_flags}
 build_flags =
@@ -318,7 +318,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.5
     adafruit/Adafruit SSD1306@^2.5.15
     adafruit/Adafruit GFX Library@^1.12.1
     adafruit/Adafruit BusIO@^1.17.1
@@ -348,7 +348,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.5
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_PICO_2
@@ -368,7 +368,7 @@ linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
 ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
-    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.4
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.5
     compact25519=https://github.com/rabbitholecomputing/compact25519
     adafruit/Adafruit SSD1306@^2.5.15
     adafruit/Adafruit GFX Library@^1.12.1


### PR DESCRIPTION
Several fixes to improve SDIO card robustness:

- Automatically reduce SDIO clockrate to 25 MHz when more than 3 CRC errors have been detected. Log message `Multiple SDIO CRC errors, reducing clock speed` is written when this happens.
- On RP2350, always log non-recoverable SDIO transfer failures (previously RP2350 only logged in debug mode, RP2040 has always logged them)
- On RP2350, fix a bug that retried indefinitely if read failure occurred during SDIO prefetch