### PR TITLE
Ignore bootloader.elf when analyzing a local zuluerr.txt

### DIFF
--- a/utils/analyze_crashlog.sh
+++ b/utils/analyze_crashlog.sh
@@ -24,7 +24,7 @@ fwtime=$(grep 'FW Version' $logfile | tail -n 1 | egrep -o '[A-Z][a-z][a-z]\s+[0
 # Check if the firmware file is available locally
 echo "Searching for firmware compiled at $fwtime"
 scriptdir=$( dirname -- "${BASH_SOURCE[0]}" )
-fwfile=$(find $scriptdir/.. $2 -name '*.elf' -exec grep -q "$fwtime" {} \; -print -quit)
+fwfile=$(find $scriptdir/.. $2 -name '*.elf' ! -name 'bootloader.elf' -exec grep -q "$fwtime" {} \; -print -quit)
 
 # Search Github for artifacts uploaded within few minutes of the compilation time
 if [ "x$fwfile" = "x" ]; then


### PR DESCRIPTION
When using `analyze_crashlog.sh` on a local zuluerr.txt file, the utility would grab bootloader.elf because it is before firmware.elf when checking the build directory for elf files. This feature excludes bootloader.elf from the build directory search so firmware.elf is analyzed.