### PR TITLE
Ignore ini system SCSI strings for network device

### DIFF
--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -217,11 +217,12 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
     }
 
     // If the scsi string has not been set system wide use default scsi string
-    if (!cfgDefault.vendor[0] && driveinfo[0][0])
+    // and do not set Network scsi strings to system wide ini settings
+    if ((!cfgDefault.vendor[0] || type == S2S_CFG_NETWORK) && driveinfo[0][0])
         strncpy(cfgDev.vendor, driveinfo[0], sizeof(cfgDev.vendor));
-    if (!cfgDefault.prodId[0] && driveinfo[1][0])
+    if ((!cfgDefault.prodId[0] || type == S2S_CFG_NETWORK) && driveinfo[1][0])
         strncpy(cfgDev.prodId, driveinfo[1], sizeof(cfgDev.prodId));
-    if (!cfgDefault.revision[0] && driveinfo[2][0])
+    if ((!cfgDefault.revision[0] || type == S2S_CFG_NETWORK) && driveinfo[2][0])
         strncpy(cfgDev.revision, driveinfo[2], sizeof(cfgDev.revision));
     if (!cfgDefault.serial[0] && driveinfo[3][0])
         strncpy(cfgDev.serial, driveinfo[3], sizeof(cfgDev.serial));


### PR DESCRIPTION
This is a requested solution for a discussion here https://github.com/ZuluSCSI/ZuluSCSI-firmware/discussions/516

If vendor, product id, and revision SCSI string are set in `zuluscsi.ini` under [SCSI] for system wide overrides, ignore those values for a network device.

This is to avoid overwriting DaynaPORT SCSI strings. They can still be overridden in the device specific header like [SCSI4] in `zuluscsi.ini`.