### PR TITLE
Add System setting DOS to address CD-ROM ejection

### DIFF
--- a/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
@@ -24,9 +24,10 @@
 #include <hardware/spi.h>
 #include <pico/multicore.h>
 #include "audio_spdif.h"
-#include "ZuluSCSI_audio.h"
-#include "ZuluSCSI_config.h"
-#include "ZuluSCSI_log.h"
+#include <ZuluSCSI_audio.h>
+#include <ZuluSCSI_settings.h>
+#include <ZuluSCSI_config.h>
+#include <ZuluSCSI_log.h>
 #include "ZuluSCSI_platform.h"
 #include "ZuluSCSI_buffer_control.h"
 #ifdef CONTROL_BOARD
@@ -646,5 +647,12 @@ void audio_set_file_position(uint8_t id, uint32_t lba)
 {
     fpos = 2352 * (uint64_t)lba;
 
+}
+
+void audio_reset(uint8_t id)
+{
+    audio_set_channel(id, AUDIO_CHANNEL_ENABLE_MASK);
+    uint8_t vol = g_scsi_settings.getDevice(id)->vol;
+    audio_set_volume(id, (uint16_t)vol << 8 | vol);
 }
 #endif // ENABLE_AUDIO_OUTPUT_SPDIF

--- a/lib/ZuluSCSI_platform_GD32F205/audio_i2s.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/audio_i2s.cpp
@@ -22,9 +22,10 @@
 #ifdef ENABLE_AUDIO_OUTPUT_I2S
 #include "audio_i2s.h"
 #include "ZuluSCSI_platform.h"
-#include "ZuluSCSI_audio.h"
+#include <ZuluSCSI_audio.h>
 #include "ZuluSCSI_v1_1_gpio.h"
-#include "ZuluSCSI_log.h"
+#include <ZuluSCSI_log.h>
+#include <ZuluSCSI_settings.h>
 
 extern "C" 
 {
@@ -421,4 +422,10 @@ void audio_set_file_position(uint8_t id, uint32_t lba)
     fpos = 2352 * (uint64_t)lba;
 }
 
+void audio_reset(uint8_t id)
+{
+    audio_set_channel(id, AUDIO_CHANNEL_ENABLE_MASK);
+    uint8_t vol = g_scsi_settings.getDevice(id)->vol;
+    audio_set_volume(id, (uint16_t)vol << 8 | vol);
+}
 #endif // ENABLE_AUDIO_OUTPUT_I2S

--- a/src/ZuluSCSI_audio.h
+++ b/src/ZuluSCSI_audio.h
@@ -198,3 +198,9 @@ uint32_t audio_get_lba_position();
  * 
 */
 void audio_set_file_position(uint8_t id, uint32_t lba);
+
+
+/**
+ * Resets audio settings for example when inserting a new CD
+ */
+void audio_reset(uint8_t id);

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1275,6 +1275,11 @@ void cdromPerformEject(image_config_t &img)
         img.ejected = true;
         img.cdrom_events = 3; // Media removal
         switchNextImage(img); // Switch media for next time
+
+        if (g_scsi_settings.getDevice(target)->reinsertImmediately)
+        {
+            cdromCloseTray(img);
+        }
     }
     else
     {
@@ -1285,10 +1290,14 @@ void cdromPerformEject(image_config_t &img)
 // Reinsert any ejected CDROMs on reboot
 void cdromReinsertFirstImage(image_config_t &img)
 {
+    uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
+    if (g_scsi_settings.getDevice(target)->keepCurrentImageOnBusReset)
+        return;
+
     if (img.image_index > 0)
     {
         // Multiple images for this drive, force restart from first one
-        uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
+
         dbgmsg("---- Restarting from first CD-ROM image for ID ", (int)target);
         img.image_index = -1;
         img.current_image[0] = '\0';

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -36,7 +36,7 @@
 // SCSI system and device settings
 ZuluSCSISettings g_scsi_settings;
 
-const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000"};
+const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000", "DOS"};
 const char *devicePresetName[] = {"", "ST32430N"};
 
 // must be in the same order as zuluscsi_speed_grade_t in ZuluSCSI_settings.h
@@ -245,6 +245,8 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
     cfg.rightAlignStrings = ini_getbool(section, "RightAlignStrings", cfg.rightAlignStrings , CONFIGFILE);
     cfg.reinsertOnInquiry = ini_getbool(section, "ReinsertCDOnInquiry", cfg.reinsertOnInquiry, CONFIGFILE);
     cfg.reinsertAfterEject = ini_getbool(section, "ReinsertAfterEject", cfg.reinsertAfterEject, CONFIGFILE);
+    cfg.reinsertImmediately = ini_getbool(section, "ReinsertAfterEject", cfg.reinsertImmediately, CONFIGFILE);
+    cfg.keepCurrentImageOnBusReset = ini_getbool(section, "KeepCurrentImageOnBusReset", cfg.keepCurrentImageOnBusReset, CONFIGFILE);
     cfg.disableMacSanityCheck = ini_getbool(section, "DisableMacSanityCheck", cfg.disableMacSanityCheck, CONFIGFILE);
 
     cfg.sectorSDBegin = ini_getl(section, "SectorSDBegin", cfg.sectorSDBegin, CONFIGFILE);
@@ -363,6 +365,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
     cfgDev.rightAlignStrings = false;
     cfgDev.reinsertOnInquiry = true;
     cfgDev.reinsertAfterEject = true;
+    cfgDev.reinsertImmediately = false;
+    cfgDev.keepCurrentImageOnBusReset = false;
     cfgDev.disableMacSanityCheck = false;
 
     cfgDev.sectorSDBegin = 0;
@@ -415,6 +419,13 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName)
         cfgSys.quirks = S2S_CFG_QUIRKS_X68000;
         cfgSys.enableSCSI2 = false;
         cfgSys.maxSyncSpeed = 5;
+    }
+    else if (strequals(systemPresetName[SYS_PRESET_DOS], presetName))
+    {
+        m_sysPreset = SYS_PRESET_DOS;
+        cfgSys.enableUnitAttention = true;
+        cfgDev.reinsertImmediately = true;
+        cfgDev.keepCurrentImageOnBusReset = true;
     }
     else
     {

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -62,7 +62,9 @@ typedef enum
     SYS_PRESET_MACPLUS,
     SYS_PRESET_MPC3000,
     SYS_PRESET_MEGASTE,
-    SYS_PRESET_X68000
+    SYS_PRESET_X68000,
+    SYS_PRESET_DOS
+
 } scsi_system_preset_t;
 
 typedef enum
@@ -142,6 +144,8 @@ typedef struct __attribute__((__packed__)) scsi_device_settings_t
     bool rightAlignStrings;
     bool reinsertOnInquiry;
     bool reinsertAfterEject;
+    bool reinsertImmediately;
+    bool keepCurrentImageOnBusReset;
     bool disableMacSanityCheck;
 
     uint32_t sectorSDBegin;

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -4,7 +4,7 @@
 # Settings that apply to all SCSI IDs
 
 # Select a system preset to apply default settings
-# Known systems: "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000"
+# Known systems: "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000", "DOS"
 #System="Mac"
 
 #Debug = 0   # Same effect as DIPSW2, enables verbose log messages
@@ -95,7 +95,10 @@
 #RightAlignStrings = 0 # Right-align SCSI vendor / product strings
 #PrefetchBytes = 8192 # Maximum number of bytes to prefetch after a read request, 0 to disable
 #ReinsertCDOnInquiry = 1 # Reinsert any ejected CD-ROM image on Inquiry command
-#ReinsertAfterEject = 1 # Reinsert next CD image after eject, if multiple images configured.
+#ReinsertAfterEject = 1 # Reinsert next image after eject on hosts that poll drive status, if multiple images configured.
+#ReinsertImmediately = 0 # Reinsert next image after eject without waiting for next SCSI command
+# Mainly for DOS and similar OSes that don't poll the CD-ROM drive status, usually requires "EnableUnitAttention = 1" 
+#KeepCurrentImageOnBusReset = 0 # Set to 1 to keep current CD image on bus reset instead of loading the first image
 #EjectButton = 0 # Enable eject by button 1 or 2, or set 0 to disable
 
 # The default values of 20 and 50 give a visible and audible (with optional buzzer) eject notification


### PR DESCRIPTION
This setting allows a more natural eject functionality for ZuluSCSI CD-ROM emulation in DOS. It stems from trying to fix issue: https://github.com/ZuluSCSI/ZuluSCSI-firmware/issues/715 `System = DOS` in the zuluscsi.ini file sets these settings:
```
EnableUnitAttention = 1
ReinsertImmediately = 1
KeepCurrentImageOnBusReset = 1
```
By default all those setting are off.

When all are enabled:
1. The eject button will switch to the next image (eject then insert).
2. Issue a Unit Attention, Media Changed on the next SCSI command
3. On reboot (a SCSI BUS RESET), stay on the current image

The EnableUnitAttention and KeepCurrentImageOnBusReset should be considered as being enabled for default settings.

In the case of EnableUnitAttention = 0 should maybe disable only in the case of "status on power-on or SD card hotplug" and not disable unit attention in the case of image changes.

Enabling either one will break the current default behavior for some users, but could make sense for more general usability going forward.