### PR TITLE
Small changes to SD card insertion and bus reset

### DIFF
--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1291,8 +1291,6 @@ void cdromPerformEject(image_config_t &img)
 void cdromReinsertFirstImage(image_config_t &img)
 {
     uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
-    if (g_scsi_settings.getDevice(target)->keepCurrentImageOnBusReset)
-        return;
 
     if (img.image_index > 0)
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -262,9 +262,10 @@ void scsiDiskCloseSDCardImages()
         if (!g_DiskImages[i].file.isRom())
         {
             g_DiskImages[i].file.close();
+            g_DiskImages[i].image_directory = false;
+            g_DiskImages[i].bin_container.close();
+            g_DiskImages[i].cuesheetfile.close();
         }
-
-        g_DiskImages[i].cuesheetfile.close();
     }
 }
 
@@ -2619,7 +2620,7 @@ void scsiDiskReset()
     for (int i = 0; i < S2S_MAX_TARGETS; ++i)
     {
         image_config_t &img = g_DiskImages[i];
-        if (img.deviceType == S2S_CFG_OPTICAL)
+        if (img.deviceType == S2S_CFG_OPTICAL && !g_scsi_settings.getDevice(i)->keepCurrentImageOnBusReset)
         {
             cdromReinsertFirstImage(img);
         }
@@ -2631,9 +2632,6 @@ void scsiDiskInit()
 {
     scsiDiskReset();
 }
-
-
-
 
 ///////////// These are so LoadImage works - There is a better way
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -97,7 +97,7 @@
 #ReinsertCDOnInquiry = 1 # Reinsert any ejected CD-ROM image on Inquiry command
 #ReinsertAfterEject = 1 # Reinsert next image after eject on hosts that poll drive status, if multiple images configured.
 #ReinsertImmediately = 0 # Reinsert next image after eject without waiting for next SCSI command
-# Mainly for DOS and similar OSes that don't poll the CD-ROM drive status, usually requires "EnableUnitAttention = 1" 
+#  Mainly for DOS and similar OSes that don't poll the CD-ROM drive status, usually requires "EnableUnitAttention = 1"
 #KeepCurrentImageOnBusReset = 0 # Set to 1 to keep current CD image on bus reset instead of loading the first image
 #EjectButton = 0 # Enable eject by button 1 or 2, or set 0 to disable
 


### PR DESCRIPTION
Added more to closing of files and resetting state to scsiDiskCloseSDCardImages. This removes the log message "Already found an image directory, skipping..." when an SD card is inserted after the first time.

Moved the keepCurrentImageOnBusReset check out of
cdromReinsertFirstImage and to where the bus reset code occurs. This should free up cdromReinsertFirstImage to be used somewhere else if necessary.