### PR TITLE
Update to latest CUEParser library

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/library.json
+++ b/lib/ZuluSCSI_platform_RP2MCU/library.json
@@ -9,6 +9,6 @@
     "platforms": "*",
     "dependencies":
     {
-        "CUEParser": "https://github.com/rabbitholecomputing/CUEParser#v2025.02.25"
+        "CUEParser": "https://github.com/rabbitholecomputing/CUEParser#v2026.03.06"
     }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ lib_deps =
     minIni
     ZuluSCSI_platform_template
     SCSI2SD
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.06
 
 ; ZuluSCSI V1.0 hardware platform with GD32F205 CPU.
 [env:ZuluSCSIv1_0]
@@ -54,7 +54,7 @@ lib_deps =
     ZuluSCSI_platform_GD32F205
     SCSI2SD
     ZuluContainerFS=https://github.com/rabbitholecomputing/ZuluContainerFS.git
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.06
     GD32F20x_usbfs_library
 upload_protocol = stlink
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.100301.220327
@@ -146,7 +146,7 @@ lib_deps =
     SCSI2SD
     ZuluContainerFS=https://github.com/rabbitholecomputing/ZuluContainerFS.git
     ; When updating git tag for CUEParser here, also update lib\ZuluSCSI_platform_RP2MCU\library.json
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.06
     ZuluSCSI_platform_RP2MCU
 upload_protocol = cmsis-dap
 debug_tool = cmsis-dap
@@ -296,7 +296,7 @@ lib_deps =
     minIni
     ZuluSCSI_platform_GD32F450
     SCSI2SD
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.06
    
 upload_protocol = stlink
 platform_packages =


### PR DESCRIPTION
Updating to the latest the CUEParser library version where an edge case bug was fixed.
See: https://github.com/rabbitholecomputing/CUEParser/releases/tag/v2026.03.06