### PR TITLE
Stefan's playground of random ZuluSCSI stuff

### DIFF
--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -52,6 +52,12 @@ static void process_Command(void);
 
 static void doReserveRelease(void);
 
+static struct {
+	int active;
+	int phase;
+	uint8_t cdbLen;
+} g_scsi_disconnect_state;
+
 void enter_BusFree()
 {
 	// This delay probably isn't needed for most SCSI hosts, but it won't
@@ -786,6 +792,7 @@ static void scsiReset()
 		scsiDev.targets[i].busWidth = 0;
 	}
 	scsiDev.minSyncPeriod = 0;
+	g_scsi_disconnect_state.active = 0;
 
 	scsiDiskReset();
 
@@ -826,6 +833,8 @@ static void enter_SelectionPhase()
 	scsiDev.postDataOutHook = NULL;
 
 	scsiDev.needSyncNegotiationAck = 0;
+	g_scsi_disconnect_state.active = 0;
+	g_scsi_sts_selection_initiator = 0xFF;
 }
 
 static void process_SelectionPhase()
@@ -910,7 +919,8 @@ static void process_SelectionPhase()
 		// Save our initiator now that we're no longer in a time-critical
 		// section.
 		// SCSI1/SASI initiators may not set their own ID.
-		scsiDev.initiatorId = (selStatus >> 3) & 0x7;
+		scsiDev.initiatorId =
+			(g_scsi_sts_selection_initiator <= 7) ? g_scsi_sts_selection_initiator : -1;
 
 		// Wait until the end of the selection phase.
 		uint32_t selTimerBegin = s2s_getTime_ms();
@@ -1256,7 +1266,8 @@ void scsiPoll(void)
 	break;
 
 	case RESELECTION:
-		// Not currently supported!
+		// Command-specific code performs the actual reconnect once it is ready
+		// to resume the disconnected command.
 	break;
 
 	case COMMAND:
@@ -1400,109 +1411,70 @@ void scsiInit()
 	firstInit = 0;
 }
 
-/* TODO REENABLE
 void scsiDisconnect()
 {
+	if (!scsiDev.target || !scsiDev.discPriv || g_scsi_disconnect_state.active)
+	{
+		return;
+	}
+
+	g_scsi_disconnect_state.active = 1;
+	g_scsi_disconnect_state.phase = scsiDev.phase;
+	g_scsi_disconnect_state.cdbLen = scsiDev.cdbLen;
+	scsiDev.savedDataPtr = scsiDev.dataPtr;
+
 	scsiEnterPhase(MESSAGE_IN);
-	scsiWriteByte(0x02); // save data pointer
-	scsiWriteByte(0x04); // disconnect msg.
+	scsiWriteByte(0x02); // SAVE DATA POINTER
+	scsiWriteByte(0x04); // DISCONNECT
 
-	// For now, the caller is responsible for tracking the disconnected
-	// state, and calling scsiReconnect.
-	// Ideally the client would exit their loop and we'd implement this
-	// as part of scsiPoll
-	int phase = scsiDev.phase;
+	if (scsiDev.resetFlag)
+	{
+		g_scsi_disconnect_state.active = 0;
+		return;
+	}
+
 	enter_BusFree();
-	scsiDev.phase = phase;
+	scsiDev.phase = RESELECTION;
+	scsiDev.cdbLen = g_scsi_disconnect_state.cdbLen;
 }
-*/
 
-/* TODO REENABLE
 int scsiReconnect()
 {
-	int reconnected = 0;
-
-	int sel = SCSI_ReadFilt(SCSI_Filt_SEL);
-	int bsy = SCSI_ReadFilt(SCSI_Filt_BSY);
-	if (!sel && !bsy)
+	if (!g_scsi_disconnect_state.active ||
+		!scsiDev.target ||
+		scsiDev.initiatorId < 0 ||
+		scsiDev.resetFlag)
 	{
-		s2s_delay_us(1);
-		sel = SCSI_ReadFilt(SCSI_Filt_SEL);
-		bsy = SCSI_ReadFilt(SCSI_Filt_BSY);
+		return 0;
 	}
 
-	if (!sel && !bsy)
+	if (!scsiPhyReselect(scsiDev.target->targetId, scsiDev.initiatorId))
 	{
-		// Arbitrate.
-		s2s_ledOn();
-		uint8_t scsiIdMask = 1 << scsiDev.target->targetId;
-		SCSI_Out_Bits_Write(scsiIdMask);
-		SCSI_Out_Ctl_Write(1); // Write bits manually.
-		SCSI_SetPin(SCSI_Out_BSY);
-
-		s2s_delay_us(3); // arbitrate delay. 2.4us.
-
-		uint8_t dbx = scsiReadDBxPins();
-		sel = SCSI_ReadFilt(SCSI_Filt_SEL);
-		if (sel || ((dbx ^ scsiIdMask) > scsiIdMask))
-		{
-			// Lost arbitration.
-			SCSI_Out_Ctl_Write(0);
-			SCSI_ClearPin(SCSI_Out_BSY);
-			s2s_ledOff();
-		}
-		else
-		{
-			// Won arbitration
-			SCSI_SetPin(SCSI_Out_SEL);
-			s2s_delay_us(1); // Bus clear + Bus settle.
-
-			// Reselection phase
-			SCSI_CTL_PHASE_Write(__scsiphase_io);
-			SCSI_Out_Bits_Write(scsiIdMask | (1 << scsiDev.initiatorId));
-			scsiDeskewDelay(); // 2 deskew delays
-			scsiDeskewDelay(); // 2 deskew delays
-			SCSI_ClearPin(SCSI_Out_BSY);
-			s2s_delay_us(1);  // Bus Settle Delay
-
-			uint32_t waitStart_ms = getTime_ms();
-			bsy = SCSI_ReadFilt(SCSI_Filt_BSY);
-			// Wait for initiator.
-			while (
-				!bsy &&
-				!scsiDev.resetFlag &&
-				(elapsedTime_ms(waitStart_ms) < 250))
-			{
-				bsy = SCSI_ReadFilt(SCSI_Filt_BSY);
-			}
-
-			if (bsy)
-			{
-				SCSI_SetPin(SCSI_Out_BSY);
-				scsiDeskewDelay(); // 2 deskew delays
-				scsiDeskewDelay(); // 2 deskew delays
-				SCSI_ClearPin(SCSI_Out_SEL);
-
-				// Prepare for the initial IDENTIFY message.
-				SCSI_Out_Ctl_Write(0);
-				scsiEnterPhase(MESSAGE_IN);
-
-				// Send identify command
-				scsiWriteByte(0x80);
-
-				scsiEnterPhase(scsiDev.phase);
-				reconnected = 1;
-			}
-			else
-			{
-				// reselect timeout.
-				SCSI_Out_Ctl_Write(0);
-				SCSI_ClearPin(SCSI_Out_SEL);
-				SCSI_CTL_PHASE_Write(0);
-				s2s_ledOff();
-			}
-		}
+		return 0;
 	}
-	return reconnected;
+
+	// Prepare for the initial IDENTIFY message.
+	scsiDev.atnFlag = 0;
+	scsiDev.selFlag = 0;
+	scsiDev.cdbLen = g_scsi_disconnect_state.cdbLen;
+	scsiDev.dataPtr = scsiDev.savedDataPtr;
+	scsiEnterPhase(MESSAGE_IN);
+	scsiWriteByte(0x80 | (scsiDev.lun & 0x7));
+
+	if (scsiDev.resetFlag)
+	{
+		g_scsi_disconnect_state.active = 0;
+		return 0;
+	}
+
+	scsiDev.phase = g_scsi_disconnect_state.phase;
+	scsiDev.cdbLen = g_scsi_disconnect_state.cdbLen;
+	scsiDev.dataPtr = scsiDev.savedDataPtr;
+	if (scsiDev.phase >= 0)
+	{
+		scsiEnterPhase(scsiDev.phase);
+	}
+
+	g_scsi_disconnect_state.active = 0;
+	return 1;
 }
-*/

--- a/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/scsiPhy.cpp
@@ -81,31 +81,54 @@ extern "C" bool scsiStatusBSY()
 /* SCSI selection logic */
 /************************/
 
+static SCSI_PHASE g_scsi_phase;
 volatile uint8_t g_scsi_sts_selection;
+volatile uint8_t g_scsi_sts_selection_initiator;
 volatile uint8_t g_scsi_ctrl_bsy;
+
+static uint8_t pack_selection_status(uint8_t sel_bits)
+{
+    int sel_id = -1;
+    for (int i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        if (scsiDev.targets[i].targetId <= 7 && scsiDev.targets[i].cfg)
+        {
+            if (sel_bits & (1 << scsiDev.targets[i].targetId))
+            {
+                sel_id = scsiDev.targets[i].targetId;
+                break;
+            }
+        }
+    }
+
+    if (sel_id < 0)
+    {
+        return 0;
+    }
+
+    g_scsi_sts_selection_initiator = 0xFF;
+    for (int id = 0; id < 8; id++)
+    {
+        if (id != sel_id && (sel_bits & (1 << id)))
+        {
+            g_scsi_sts_selection_initiator = id;
+            break;
+        }
+    }
+
+    uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
+    return SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+}
 
 static void scsi_bsy_deassert_interrupt()
 {
     if (!SCSI_IN(BSY) && ((g_moved_select_in && SCSI_IN(ODE_SEL)) || (!g_moved_select_in && SCSI_IN(SEL))))
     {
         uint8_t sel_bits = SCSI_IN_DATA();
-        int sel_id = -1;
-        for (int i = 0; i < S2S_MAX_TARGETS; i++)
+        uint8_t sel_status = pack_selection_status(sel_bits);
+        if (sel_status != 0)
         {
-            if (scsiDev.targets[i].targetId <= 7 && scsiDev.targets[i].cfg)
-            {
-                if (sel_bits & (1 << scsiDev.targets[i].targetId))
-                {
-                    sel_id = scsiDev.targets[i].targetId;
-                    break;
-                }
-            }
-        }
-
-        if (sel_id >= 0)
-        {
-            uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
-            g_scsi_sts_selection = SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+            g_scsi_sts_selection = sel_status;
         }
 
         // selFlag is required for Philips P2000C which releases it after 600ns
@@ -132,6 +155,75 @@ extern "C" bool scsiStatusSEL()
     }
     return SCSI_IN(SEL);
      
+}
+
+extern "C" bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId)
+{
+    if (initiatorId > 7 || targetId >= S2S_MAX_TARGETS)
+    {
+        return false;
+    }
+
+    if (SCSI_IN(BSY) || scsiStatusSEL())
+    {
+        return false;
+    }
+
+    s2s_delay_us(1);
+    if (SCSI_IN(BSY) || scsiStatusSEL())
+    {
+        return false;
+    }
+
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    g_scsi_phase = RESELECTION;
+    scsiLogPhaseChange(RESELECTION);
+    SCSI_OUT(BSY, 1);
+    for (int wait = 0; wait < 10; wait++)
+    {
+        s2s_delay_us(1);
+        if (SCSI_IN_DATA() != 0)
+        {
+            SCSI_OUT(BSY, 0);
+            g_scsi_phase = BUS_FREE;
+            return false;
+        }
+    }
+
+    SCSI_OUT(IO, 1);
+    SCSI_OUT(SEL, 1);
+    s2s_delay_us(1);
+    SCSI_OUT_DATA((1u << targetId) | (1u << initiatorId));
+    s2s_delay_us(1);
+    SCSI_OUT(BSY, 0);
+
+    uint32_t waitStart_ms = s2s_getTime_ms();
+    while (!SCSI_IN(BSY) &&
+           !scsiDev.resetFlag &&
+           s2s_elapsedTime_ms(waitStart_ms) < 250)
+    {
+        platform_poll();
+    }
+
+    if (!SCSI_IN(BSY))
+    {
+        SCSI_RELEASE_DATA_REQ();
+        SCSI_OUT(SEL, 0);
+        SCSI_OUT(IO, 0);
+        g_scsi_phase = BUS_FREE;
+        return false;
+    }
+
+    SCSI_OUT(BSY, 1);
+    s2s_delay_us(1);
+    SCSI_RELEASE_DATA_REQ();
+    SCSI_OUT(SEL, 0);
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    return true;
 }
 
 /************************/
@@ -201,6 +293,7 @@ extern "C" void scsiPhyReset(void)
     scsi_accel_dma_stopWrite();
 
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     g_scsi_writereq.count = 0;
     init_irqs();
@@ -224,8 +317,6 @@ extern "C" void scsiPhyReset(void)
 /************************/
 /* SCSI bus phase logic */
 /************************/
-
-static SCSI_PHASE g_scsi_phase;
 
 extern "C" void scsiEnterPhase(int phase)
 {
@@ -295,6 +386,7 @@ void scsiEnterBusFree(void)
 {
     g_scsi_phase = BUS_FREE;
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     scsiDev.cdbLen = 0;
     
@@ -644,5 +736,3 @@ static void init_irqs()
         NVIC_EnableIRQ(SCSI_SEL_IRQn);
     }
 }
-
-

--- a/lib/ZuluSCSI_platform_GD32F205/scsiPhy.h
+++ b/lib/ZuluSCSI_platform_GD32F205/scsiPhy.h
@@ -43,11 +43,12 @@ bool scsiStatusSEL();
 
 // Get SCSI selection status.
 // This is latched by interrupt when BSY is deasserted while SEL is asserted.
-// Lowest 3 bits are the selected target id.
-// Highest bits are status information.
+// Low target-id bits are the selected target id.
+// Highest bits are status information. Initiator ID is latched separately.
 #define SCSI_STS_SELECTION_SUCCEEDED 0x40
 #define SCSI_STS_SELECTION_ATN 0x80
 extern volatile uint8_t g_scsi_sts_selection;
+extern volatile uint8_t g_scsi_sts_selection_initiator;
 #define SCSI_STS_SELECTED (&g_scsi_sts_selection)
 extern volatile uint8_t g_scsi_ctrl_bsy;
 #define SCSI_CTRL_BSY (&g_scsi_ctrl_bsy)
@@ -64,6 +65,10 @@ uint32_t scsiEnterPhaseImmediate(int phase);
 
 // Release all signals
 void scsiEnterBusFree(void);
+
+// Arbitrate for and perform target reselection of an initiator.
+// Returns true once the initiator responds with BSY.
+bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId);
 
 // Blocking data transfer
 void scsiWrite(const uint8_t* data, uint32_t count);

--- a/lib/ZuluSCSI_platform_GD32F450/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_GD32F450/scsiPhy.cpp
@@ -81,31 +81,54 @@ extern "C" bool scsiStatusBSY()
 /* SCSI selection logic */
 /************************/
 
+static SCSI_PHASE g_scsi_phase;
 volatile uint8_t g_scsi_sts_selection;
+volatile uint8_t g_scsi_sts_selection_initiator;
 volatile uint8_t g_scsi_ctrl_bsy;
+
+static uint8_t pack_selection_status(uint8_t sel_bits)
+{
+    int sel_id = -1;
+    for (int i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        if (scsiDev.targets[i].targetId <= 7 && scsiDev.targets[i].cfg)
+        {
+            if (sel_bits & (1 << scsiDev.targets[i].targetId))
+            {
+                sel_id = scsiDev.targets[i].targetId;
+                break;
+            }
+        }
+    }
+
+    if (sel_id < 0)
+    {
+        return 0;
+    }
+
+    g_scsi_sts_selection_initiator = 0xFF;
+    for (int id = 0; id < 8; id++)
+    {
+        if (id != sel_id && (sel_bits & (1 << id)))
+        {
+            g_scsi_sts_selection_initiator = id;
+            break;
+        }
+    }
+
+    uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
+    return SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+}
 
 static void scsi_bsy_deassert_interrupt()
 {
     if (SCSI_IN(SEL) && !SCSI_IN(BSY))
     {
         uint8_t sel_bits = SCSI_IN_DATA();
-        int sel_id = -1;
-        for (int i = 0; i < S2S_MAX_TARGETS; i++)
+        uint8_t sel_status = pack_selection_status(sel_bits);
+        if (sel_status != 0)
         {
-            if (scsiDev.targets[i].targetId <= 7 && scsiDev.targets[i].cfg)
-            {
-                if (sel_bits & (1 << scsiDev.targets[i].targetId))
-                {
-                    sel_id = scsiDev.targets[i].targetId;
-                    break;
-                }
-            }
-        }
-
-        if (sel_id >= 0)
-        {
-            uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
-            g_scsi_sts_selection = SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+            g_scsi_sts_selection = sel_status;
         }
 
         // selFlag is required for Philips P2000C which releases it after 600ns
@@ -127,6 +150,75 @@ extern "C" bool scsiStatusSEL()
     }
 
     return SCSI_IN(SEL);
+}
+
+extern "C" bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId)
+{
+    if (initiatorId > 7 || targetId >= S2S_MAX_TARGETS)
+    {
+        return false;
+    }
+
+    if (SCSI_IN(BSY) || SCSI_IN(SEL))
+    {
+        return false;
+    }
+
+    s2s_delay_us(1);
+    if (SCSI_IN(BSY) || SCSI_IN(SEL))
+    {
+        return false;
+    }
+
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    g_scsi_phase = RESELECTION;
+    scsiLogPhaseChange(RESELECTION);
+    SCSI_OUT(BSY, 1);
+    for (int wait = 0; wait < 10; wait++)
+    {
+        s2s_delay_us(1);
+        if (SCSI_IN_DATA() != 0)
+        {
+            SCSI_OUT(BSY, 0);
+            g_scsi_phase = BUS_FREE;
+            return false;
+        }
+    }
+
+    SCSI_OUT(IO, 1);
+    SCSI_OUT(SEL, 1);
+    s2s_delay_us(1);
+    SCSI_OUT_DATA((1u << targetId) | (1u << initiatorId));
+    s2s_delay_us(1);
+    SCSI_OUT(BSY, 0);
+
+    uint32_t waitStart_ms = s2s_getTime_ms();
+    while (!SCSI_IN(BSY) &&
+           !scsiDev.resetFlag &&
+           s2s_elapsedTime_ms(waitStart_ms) < 250)
+    {
+        platform_poll();
+    }
+
+    if (!SCSI_IN(BSY))
+    {
+        SCSI_RELEASE_DATA_REQ();
+        SCSI_OUT(SEL, 0);
+        SCSI_OUT(IO, 0);
+        g_scsi_phase = BUS_FREE;
+        return false;
+    }
+
+    SCSI_OUT(BSY, 1);
+    s2s_delay_us(1);
+    SCSI_RELEASE_DATA_REQ();
+    SCSI_OUT(SEL, 0);
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    return true;
 }
 
 /************************/
@@ -198,6 +290,7 @@ extern "C" void scsiPhyReset(void)
     scsi_accel_dma_stopWrite();
 
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     g_scsi_writereq.count = 0;
     init_irqs();
@@ -221,8 +314,6 @@ extern "C" void scsiPhyReset(void)
 /************************/
 /* SCSI bus phase logic */
 /************************/
-
-static SCSI_PHASE g_scsi_phase;
 
 extern "C" void scsiEnterPhase(int phase)
 {
@@ -292,6 +383,7 @@ void scsiEnterBusFree(void)
 {
     g_scsi_phase = BUS_FREE;
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     scsiDev.cdbLen = 0;
     
@@ -628,5 +720,3 @@ static void init_irqs()
     NVIC_SetPriority(SCSI_SEL_IRQn, 1);
     NVIC_EnableIRQ(SCSI_SEL_IRQn);
 }
-
-

--- a/lib/ZuluSCSI_platform_GD32F450/scsiPhy.h
+++ b/lib/ZuluSCSI_platform_GD32F450/scsiPhy.h
@@ -43,11 +43,12 @@ bool scsiStatusSEL();
 
 // Get SCSI selection status.
 // This is latched by interrupt when BSY is deasserted while SEL is asserted.
-// Lowest 3 bits are the selected target id.
-// Highest bits are status information.
+// Low target-id bits are the selected target id.
+// Highest bits are status information. Initiator ID is latched separately.
 #define SCSI_STS_SELECTION_SUCCEEDED 0x40
 #define SCSI_STS_SELECTION_ATN 0x80
 extern volatile uint8_t g_scsi_sts_selection;
+extern volatile uint8_t g_scsi_sts_selection_initiator;
 #define SCSI_STS_SELECTED (&g_scsi_sts_selection)
 extern volatile uint8_t g_scsi_ctrl_bsy;
 #define SCSI_CTRL_BSY (&g_scsi_ctrl_bsy)
@@ -64,6 +65,10 @@ uint32_t scsiEnterPhaseImmediate(int phase);
 
 // Release all signals
 void scsiEnterBusFree(void);
+
+// Arbitrate for and perform target reselection of an initiator.
+// Returns true once the initiator responds with BSY.
+bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId);
 
 // Blocking data transfer
 void scsiWrite(const uint8_t* data, uint32_t count);

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -87,6 +87,8 @@ extern "C" {
 extern bool g_rebooting;
 const char *g_platform_name = PLATFORM_NAME;
 bool g_scsi_initiator = false;
+uint32_t g_platform_sys_clock_hz = 125000000;
+uint32_t g_platform_delay_100ns_cycles = 13;
 static uint32_t g_flash_chip_size = 0;
 static bool g_uart_initialized = false;
 static bool g_led_blinking = false;
@@ -194,6 +196,13 @@ static void reclock() {
         uart_init(uart0, 1000000);
 }
 
+void platform_update_delay_calibration(void)
+{
+    g_platform_sys_clock_hz = platform_sys_clock_in_hz();
+    uint64_t cycles = ((uint64_t)g_platform_sys_clock_hz * 100ULL + 999999999ULL) / 1000000000ULL;
+    g_platform_delay_100ns_cycles = cycles > 0 ? (uint32_t)cycles : 1;
+}
+
 uint32_t platform_sys_clock_in_hz()
 {
     return clock_get_hz(clk_sys);
@@ -236,6 +245,7 @@ bool platform_reclock(zuluscsi_speed_grade_t speed_grade)
 #endif
             usb_log_poll();
             reclock();
+            platform_update_delay_calibration();
             logmsg("After reclocking, system reports clock set to ", (int) platform_sys_clock_in_hz(), "Hz");
         }
     }
@@ -392,6 +402,8 @@ void platform_init()
 {
     // Make sure second core is stopped
     multicore_reset_core1();
+
+    platform_update_delay_calibration();
 
     // Keep negotiated sync limits aligned with the currently selected timing set
     // even when no explicit reclocking profile is applied.

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -211,8 +211,7 @@ bool platform_reclock(zuluscsi_speed_grade_t speed_grade)
             {
 
                 logmsg("Using custom timings found in \"", CUSTOM_TIMINGS_FILE, "\" for reclocking");
-                ct.set_timings_from_file();
-                do_reclock = true;
+                do_reclock = ct.set_timings_from_file();
             }
             else
             {

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -393,6 +393,10 @@ void platform_init()
     // Make sure second core is stopped
     multicore_reset_core1();
 
+    // Keep negotiated sync limits aligned with the currently selected timing set
+    // even when no explicit reclocking profile is applied.
+    update_sync_period_limits();
+
 #ifdef ZULUSCSI_MCU_RP23XX
     // Set stack overflow limit, with space reserved for exception entry
     extern uint32_t __StackBottom; // From rp23xx-template.ld

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <Arduino.h>
+#include <pico/platform.h>
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform_network.h"
 #include <ZuluSCSI_settings.h>
@@ -72,17 +73,29 @@ bool platform_emergency_log_save();
 // Arduino platform already provides these
 unsigned long millis(void);
 void delay(unsigned long ms);
+extern uint32_t g_platform_sys_clock_hz;
+extern uint32_t g_platform_delay_100ns_cycles;
+void platform_update_delay_calibration(void);
 
 // Short delays, can be called from interrupt mode
 static inline void delay_ns(unsigned long ns)
 {
-    delayMicroseconds((ns + 999) / 1000);
+    if (ns >= 1000000UL)
+    {
+        delayMicroseconds((ns + 999) / 1000);
+        return;
+    }
+
+    uint64_t cycles = ((uint64_t)g_platform_sys_clock_hz * ns + 999999999ULL) / 1000000000ULL;
+    if (cycles > 0)
+    {
+        busy_wait_at_least_cycles((uint32_t)cycles);
+    }
 }
 
-// Approximate fast delay
 static inline void delay_100ns()
 {
-    asm volatile ("nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop");
+    busy_wait_at_least_cycles(g_platform_delay_100ns_cycles);
 }
 
 // Initialize SD card and GPIO configuration

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -44,6 +44,30 @@ static bool network_in_use = false;
 static bool g_wifi_reconnect = false;
 static char g_wifi_reconnect_ssid[32 + 1] = {0};
 static char g_wifi_reconnect_password[63 + 1] = {0};
+static bool g_wifi_scan_restore_connection = false;
+static bool g_wifi_scan_suspend_reconnect = false;
+
+static void platform_network_wifi_store_reconnect_credentials(const char *ssid, const char *password)
+{
+	if (ssid != NULL)
+		strlcpy(g_wifi_reconnect_ssid, ssid, sizeof(g_wifi_reconnect_ssid));
+	else
+		g_wifi_reconnect_ssid[0] = '\0';
+
+	if (password != NULL)
+		strlcpy(g_wifi_reconnect_password, password, sizeof(g_wifi_reconnect_password));
+	else
+		g_wifi_reconnect_password[0] = '\0';
+}
+
+static void platform_network_wifi_schedule_reconnect()
+{
+	if (g_wifi_reconnect_ssid[0] == '\0')
+		return;
+
+	g_wifi_scan_suspend_reconnect = false;
+	g_wifi_reconnect = true;
+}
 
 bool platform_network_supported()
 {
@@ -142,8 +166,7 @@ bool platform_network_wifi_join(char *ssid, char *password)
 	if (!platform_network_supported())
 		return false;
 
-	strlcpy(g_wifi_reconnect_ssid, ssid, sizeof(g_wifi_reconnect_ssid));
-	strlcpy(g_wifi_reconnect_password, ssid, sizeof(g_wifi_reconnect_password));
+	platform_network_wifi_store_reconnect_credentials(ssid, password);
 
 	if (password == NULL || password[0] == 0)
 	{
@@ -174,6 +197,13 @@ bool platform_network_wifi_join(char *ssid, char *password)
 
 void platform_network_poll(bool bus_free)
 {
+	if (g_wifi_scan_restore_connection && !cyw43_wifi_scan_active(&cyw43_state))
+	{
+		logmsg("Wi-Fi scan complete, reconnecting to \"", g_wifi_reconnect_ssid, "\"");
+		g_wifi_scan_restore_connection = false;
+		platform_network_wifi_schedule_reconnect();
+	}
+
 	if (bus_free && g_wifi_reconnect)
 	{
 		platform_network_wifi_reconnect();
@@ -295,9 +325,40 @@ int platform_network_wifi_start_scan()
 	if (cyw43_wifi_scan_active(&cyw43_state))
 		return -1;
 
+	int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+	if (status != CYW43_LINK_DOWN)
+	{
+		if (g_wifi_reconnect_ssid[0] == '\0' && scsiDev.boardCfg.wifiSSID[0] != '\0')
+			platform_network_wifi_store_reconnect_credentials(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+
+		if (g_wifi_reconnect_ssid[0] != '\0')
+		{
+			logmsg("Temporarily disconnecting from Wi-Fi SSID \"", g_wifi_reconnect_ssid, "\" to scan for hotspots");
+			g_wifi_scan_restore_connection = true;
+			g_wifi_scan_suspend_reconnect = true;
+			cyw43_arch_disable_sta_mode();
+			cyw43_arch_enable_sta_mode();
+		}
+		else
+		{
+			logmsg("Wi-Fi scan requested while connected, but reconnect credentials are not available");
+		}
+	}
+
 	cyw43_wifi_scan_options_t scan_options = { 0 };
 	memset(wifi_network_list, 0, sizeof(wifi_network_list));
-	return cyw43_wifi_scan(&cyw43_state, &scan_options, NULL, platform_network_wifi_scan_result);
+	int ret = cyw43_wifi_scan(&cyw43_state, &scan_options, NULL, platform_network_wifi_scan_result);
+	if (ret != 0)
+	{
+		logmsg("Failed to start Wi-Fi scan: ", ret);
+		if (g_wifi_scan_restore_connection)
+		{
+			g_wifi_scan_restore_connection = false;
+			platform_network_wifi_schedule_reconnect();
+		}
+	}
+
+	return ret;
 }
 
 int platform_network_wifi_scan_finished()
@@ -383,6 +444,12 @@ void cyw43_cb_process_ethernet(void *cb_data, int itf, size_t len, const uint8_t
 
 void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf)
 {
+	if (g_wifi_scan_suspend_reconnect)
+	{
+		logmsg("Disassociated from Wi-Fi to scan for hotspots");
+		return;
+	}
+
 	logmsg("Disassociated from Wi-Fi SSID \"",  g_wifi_reconnect_ssid,"\" reconnecting");
 	g_wifi_reconnect = true;
 }

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
@@ -31,6 +31,21 @@ extern "C"
     #include <timings.h>
 }
 
+static bool readIniIntRange(const char *section, const char *key, int32_t current,
+    int32_t min_value, int32_t max_value, int32_t *out)
+{
+    int32_t value = ini_getl(section, key, current, CUSTOM_TIMINGS_FILE);
+    if (value < min_value || value > max_value)
+    {
+        logmsg("Invalid value for [", section, "] ", key, " in ", CUSTOM_TIMINGS_FILE,
+            ": ", value, " (expected ", min_value, "..", max_value, ")");
+        return false;
+    }
+
+    *out = value;
+    return true;
+}
+
 bool CustomTimings::use_custom_timings()
 {
     return SD.exists(CUSTOM_TIMINGS_FILE) && !ini_getbool("settings", "disable", 0, CUSTOM_TIMINGS_FILE);
@@ -47,83 +62,151 @@ bool CustomTimings::set_timings_from_file()
     const char sdio_section[] = "sdio";
     const char audio_section[] = "audio";
 
-    // pll
-    int32_t vco = ini_getl(pll_section, "vco_freq_hz", g_zuluscsi_timings->pll.vco_freq, CUSTOM_TIMINGS_FILE);
-    int32_t post_div1 = ini_getl(pll_section, "pd1", g_zuluscsi_timings->pll.post_div1, CUSTOM_TIMINGS_FILE);
-    int32_t post_div2 = ini_getl(pll_section, "pd2", g_zuluscsi_timings->pll.post_div2, CUSTOM_TIMINGS_FILE);
-
-    if (vco > 0 && post_div1 > 0 && post_div2 > 0)
-    {
-        if (vco / post_div1 / post_div2 > 252000000)
-        {
-            logmsg("Reclocking over 252MHz with the PLL settings is not allowed using ", CUSTOM_TIMINGS_FILE);
-            return false;
-        }
-    }
-    else
-    {
-        logmsg("Reclocking failed because 0 or negative PLL settings values");
-        return false;
-    }
-
-    g_zuluscsi_timings->pll.vco_freq = vco;
-    g_zuluscsi_timings->pll.post_div1 = post_div1;
-    g_zuluscsi_timings->pll.post_div2 = post_div2;
-    g_zuluscsi_timings->pll.refdiv =  ini_getl(pll_section, "refdiv", g_zuluscsi_timings->pll.refdiv, CUSTOM_TIMINGS_FILE);
-
     char speed_grade_str[10];
     ini_gets(settings_section, "extends_speed_grade", "Default", speed_grade_str, sizeof(speed_grade_str), CUSTOM_TIMINGS_FILE);
     zuluscsi_speed_grade_t speed_grade =  g_scsi_settings.stringToSpeedGrade(speed_grade_str, sizeof(speed_grade_str));
     set_timings(speed_grade);
 
-    int32_t number_setting = ini_getl(settings_section, "boot_with_sync_value", 0, CUSTOM_TIMINGS_FILE);
+    zuluscsi_timings_t candidate = *g_zuluscsi_timings;
+    uint8_t force_sync = g_force_sync;
+    uint8_t force_offset = g_force_offset;
+
+    int32_t number_setting = 0;
+    if (!readIniIntRange(settings_section, "boot_with_sync_value", 0, 0, 255, &number_setting))
+    {
+        return false;
+    }
 
     if (number_setting > 0)
     {
-        g_force_sync = number_setting;
-        number_setting = ini_getl(settings_section, "boot_with_offset_value", 15, CUSTOM_TIMINGS_FILE);
-        g_force_offset = number_setting > 15 ? 15 : number_setting;
-        logmsg("Forcing sync of ", (int) g_force_sync, " and offset of ", (int) g_force_offset);
+        force_sync = number_setting;
+        if (!readIniIntRange(settings_section, "boot_with_offset_value", 15, 0, 15, &number_setting))
+        {
+            return false;
+        }
+        force_offset = number_setting;
     }
-    g_zuluscsi_timings->clk_hz = ini_getl(settings_section, "clk_hz", g_zuluscsi_timings->clk_hz, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(settings_section, "clk_hz", candidate.clk_hz, 1, 252000000, &number_setting))
+    {
+        return false;
+    }
+    candidate.clk_hz = number_setting;
+    if (!readIniIntRange(pll_section, "refdiv", candidate.pll.refdiv, 1, 63, &number_setting))
+    {
+        return false;
+    }
+    candidate.pll.refdiv = number_setting;
+    if (!readIniIntRange(pll_section, "vco_freq_hz", candidate.pll.vco_freq, 1, 2000000000, &number_setting))
+    {
+        return false;
+    }
+    candidate.pll.vco_freq = number_setting;
+    if (!readIniIntRange(pll_section, "pd1", candidate.pll.post_div1, 1, 7, &number_setting))
+    {
+        return false;
+    }
+    candidate.pll.post_div1 = number_setting;
+    if (!readIniIntRange(pll_section, "pd2", candidate.pll.post_div2, 1, 7, &number_setting))
+    {
+        return false;
+    }
+    candidate.pll.post_div2 = number_setting;
+    uint32_t pll_output_hz = candidate.pll.vco_freq / candidate.pll.post_div1 / candidate.pll.post_div2;
+    if (pll_output_hz > 252000000)
+    {
+        logmsg("Reclocking over 252MHz with the PLL settings is not allowed using ", CUSTOM_TIMINGS_FILE);
+        return false;
+    }
+    if (pll_output_hz != candidate.clk_hz)
+    {
+        logmsg("PLL output clock ", (int)pll_output_hz, "Hz does not match clk_hz ",
+            (int)candidate.clk_hz, "Hz in ", CUSTOM_TIMINGS_FILE);
+        return false;
+    }
 
 
     // scsi
-    g_zuluscsi_timings->scsi.clk_period_ps = ini_getl(scsi_section, "clk_period_ps", g_zuluscsi_timings->scsi.clk_period_ps, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi.req_delay = ini_getl(scsi_section, "req_delay_cc", g_zuluscsi_timings->scsi.req_delay, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(scsi_section, "clk_period_ps", candidate.scsi.clk_period_ps, 1, 1000000, &number_setting))
+    {
+        return false;
+    }
+    candidate.scsi.clk_period_ps = number_setting;
+    if (!readIniIntRange(scsi_section, "req_delay_cc", candidate.scsi.req_delay, 2, 31, &number_setting))
+    {
+        return false;
+    }
+    candidate.scsi.req_delay = number_setting;
 
     // scsi 20
-    g_zuluscsi_timings->scsi_20.delay0 = ini_getl(scsi_20_section, "delay0_cc", g_zuluscsi_timings->scsi_20.delay0, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_20.delay1 = ini_getl(scsi_20_section, "delay1_cc", g_zuluscsi_timings->scsi_20.delay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_20.total_period_adjust = ini_getl(scsi_20_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_20.total_period_adjust, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_20.max_sync = ini_getl(scsi_20_section, "max_sync", g_zuluscsi_timings->scsi_20.max_sync, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_20.rdelay1 = ini_getl(scsi_20_section, "read_delay1_cc", g_zuluscsi_timings->scsi_20.rdelay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_20.rtotal_period_adjust = ini_getl(scsi_20_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_20.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(scsi_20_section, "delay0_cc", candidate.scsi_20.delay0, 0, 31, &number_setting)) return false;
+    candidate.scsi_20.delay0 = number_setting;
+    if (!readIniIntRange(scsi_20_section, "delay1_cc", candidate.scsi_20.delay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_20.delay1 = number_setting;
+    if (!readIniIntRange(scsi_20_section, "total_period_adjust_cc", candidate.scsi_20.total_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_20.total_period_adjust = number_setting;
+    if (!readIniIntRange(scsi_20_section, "max_sync", candidate.scsi_20.max_sync, 1, 255, &number_setting)) return false;
+    candidate.scsi_20.max_sync = number_setting;
+    if (!readIniIntRange(scsi_20_section, "read_delay1_cc", candidate.scsi_20.rdelay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_20.rdelay1 = number_setting;
+    if (!readIniIntRange(scsi_20_section, "read_total_period_adjust_cc", candidate.scsi_20.rtotal_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_20.rtotal_period_adjust = number_setting;
 
     // scsi 10
-    g_zuluscsi_timings->scsi_10.delay0 = ini_getl(scsi_10_section, "delay0_cc", g_zuluscsi_timings->scsi_10.delay0, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_10.delay1 = ini_getl(scsi_10_section, "delay1_cc", g_zuluscsi_timings->scsi_10.delay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_10.total_period_adjust = ini_getl(scsi_10_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_10.total_period_adjust, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_10.max_sync = ini_getl(scsi_10_section, "max_sync", g_zuluscsi_timings->scsi_10.max_sync, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_10.rdelay1 = ini_getl(scsi_10_section, "read_delay1_cc", g_zuluscsi_timings->scsi_10.rdelay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_10.rtotal_period_adjust = ini_getl(scsi_10_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_10.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(scsi_10_section, "delay0_cc", candidate.scsi_10.delay0, 0, 31, &number_setting)) return false;
+    candidate.scsi_10.delay0 = number_setting;
+    if (!readIniIntRange(scsi_10_section, "delay1_cc", candidate.scsi_10.delay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_10.delay1 = number_setting;
+    if (!readIniIntRange(scsi_10_section, "total_period_adjust_cc", candidate.scsi_10.total_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_10.total_period_adjust = number_setting;
+    if (!readIniIntRange(scsi_10_section, "max_sync", candidate.scsi_10.max_sync, 1, 255, &number_setting)) return false;
+    candidate.scsi_10.max_sync = number_setting;
+    if (!readIniIntRange(scsi_10_section, "read_delay1_cc", candidate.scsi_10.rdelay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_10.rdelay1 = number_setting;
+    if (!readIniIntRange(scsi_10_section, "read_total_period_adjust_cc", candidate.scsi_10.rtotal_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_10.rtotal_period_adjust = number_setting;
 
     // scsi 5
-    g_zuluscsi_timings->scsi_5.delay0 = ini_getl(scsi_5_section, "delay0_cc", g_zuluscsi_timings->scsi_5.delay0, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_5.delay1 = ini_getl(scsi_5_section, "delay1_cc", g_zuluscsi_timings->scsi_5.delay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_5.total_period_adjust = ini_getl(scsi_5_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_5.total_period_adjust, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_5.max_sync = ini_getl(scsi_5_section, "max_sync", g_zuluscsi_timings->scsi_5.max_sync, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_5.rdelay1 = ini_getl(scsi_5_section, "read_delay1_cc", g_zuluscsi_timings->scsi_5.rdelay1, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->scsi_5.rtotal_period_adjust = ini_getl(scsi_5_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_5.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(scsi_5_section, "delay0_cc", candidate.scsi_5.delay0, 0, 31, &number_setting)) return false;
+    candidate.scsi_5.delay0 = number_setting;
+    if (!readIniIntRange(scsi_5_section, "delay1_cc", candidate.scsi_5.delay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_5.delay1 = number_setting;
+    if (!readIniIntRange(scsi_5_section, "total_period_adjust_cc", candidate.scsi_5.total_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_5.total_period_adjust = number_setting;
+    if (!readIniIntRange(scsi_5_section, "max_sync", candidate.scsi_5.max_sync, 1, 255, &number_setting)) return false;
+    candidate.scsi_5.max_sync = number_setting;
+    if (!readIniIntRange(scsi_5_section, "read_delay1_cc", candidate.scsi_5.rdelay1, 0, 31, &number_setting)) return false;
+    candidate.scsi_5.rdelay1 = number_setting;
+    if (!readIniIntRange(scsi_5_section, "read_total_period_adjust_cc", candidate.scsi_5.rtotal_period_adjust, -128, 127, &number_setting)) return false;
+    candidate.scsi_5.rtotal_period_adjust = number_setting;
 
     // sdio
-    g_zuluscsi_timings->sdio.clk_div_pio = ini_getl(sdio_section, "clk_div_pio", g_zuluscsi_timings->sdio.clk_div_pio, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->sdio.clk_div_1mhz = ini_getl(sdio_section, "clk_div_1mhz", g_zuluscsi_timings->sdio.clk_div_1mhz, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->sdio.delay0 = ini_getl(sdio_section, "delay0", g_zuluscsi_timings->sdio.delay0, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->sdio.delay1 = ini_getl(sdio_section, "delay1", g_zuluscsi_timings->sdio.delay1, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(sdio_section, "clk_div_pio", candidate.sdio.clk_div_pio, 1, 255, &number_setting)) return false;
+    candidate.sdio.clk_div_pio = number_setting;
+    if (!readIniIntRange(sdio_section, "clk_div_1mhz", candidate.sdio.clk_div_1mhz, 1, 255, &number_setting)) return false;
+    candidate.sdio.clk_div_1mhz = number_setting;
+    if (!readIniIntRange(sdio_section, "delay0", candidate.sdio.delay0, 0, 255, &number_setting)) return false;
+    candidate.sdio.delay0 = number_setting;
+    if (!readIniIntRange(sdio_section, "delay1", candidate.sdio.delay1, 0, 255, &number_setting)) return false;
+    candidate.sdio.delay1 = number_setting;
 
     // audio
-    g_zuluscsi_timings->audio.clk_div_pio = ini_getl(audio_section, "clk_div_pio", g_zuluscsi_timings->audio.clk_div_pio, CUSTOM_TIMINGS_FILE);
-    g_zuluscsi_timings->audio.audio_clocked = ini_getbool(audio_section, "clk_for_audio", g_zuluscsi_timings->audio.audio_clocked, CUSTOM_TIMINGS_FILE);
+    if (!readIniIntRange(audio_section, "clk_div_pio", candidate.audio.clk_div_pio, 1, 255, &number_setting))
+    {
+        return false;
+    }
+    candidate.audio.clk_div_pio = number_setting;
+    candidate.audio.audio_clocked = ini_getbool(audio_section, "clk_for_audio", candidate.audio.audio_clocked, CUSTOM_TIMINGS_FILE);
+
+    *g_zuluscsi_timings = candidate;
+    g_force_sync = force_sync;
+    g_force_offset = force_offset;
+    g_max_sync_20_period = g_zuluscsi_timings->scsi_20.max_sync;
+    g_max_sync_10_period = g_zuluscsi_timings->scsi_10.max_sync;
+    g_max_sync_5_period = g_zuluscsi_timings->scsi_5.max_sync;
+
+    if (g_force_sync > 0)
+    {
+        logmsg("Forcing sync of ", (int) g_force_sync, " and offset of ", (int) g_force_offset);
+    }
     return true;
 }

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
@@ -198,11 +198,21 @@ bool CustomTimings::set_timings_from_file()
     candidate.audio.audio_clocked = ini_getbool(audio_section, "clk_for_audio", candidate.audio.audio_clocked, CUSTOM_TIMINGS_FILE);
 
     *g_zuluscsi_timings = candidate;
+    update_sync_period_limits();
+
+    if (force_sync > 0)
+    {
+        uint8_t adjusted_force_sync = calculate_sync_period_limit(g_zuluscsi_timings, force_sync);
+        if (adjusted_force_sync != force_sync)
+        {
+            logmsg("Adjusting forced sync period from ", (int)force_sync, " to ",
+                (int)adjusted_force_sync, " to match the RP2 DATA OUT timing floor");
+        }
+        force_sync = adjusted_force_sync;
+    }
+
     g_force_sync = force_sync;
     g_force_offset = force_offset;
-    g_max_sync_20_period = g_zuluscsi_timings->scsi_20.max_sync;
-    g_max_sync_10_period = g_zuluscsi_timings->scsi_10.max_sync;
-    g_max_sync_5_period = g_zuluscsi_timings->scsi_5.max_sync;
 
     if (g_force_sync > 0)
     {

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
@@ -38,7 +38,7 @@ static bool readIniIntRange(const char *section, const char *key, int32_t curren
     if (value < min_value || value > max_value)
     {
         logmsg("Invalid value for [", section, "] ", key, " in ", CUSTOM_TIMINGS_FILE,
-            ": ", value, " (expected ", min_value, "..", max_value, ")");
+            ": ", (int)value, " (expected ", (int)min_value, "..", (int)max_value, ")");
         return false;
     }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.cpp
@@ -57,7 +57,43 @@ extern "C" bool scsiStatusBSY()
 
 static SCSI_PHASE g_scsi_phase;
 volatile uint8_t g_scsi_sts_selection;
+volatile uint8_t g_scsi_sts_selection_initiator;
 volatile uint8_t g_scsi_ctrl_bsy;
+
+static uint8_t pack_selection_status(uint32_t sel_bits)
+{
+    int sel_id = -1;
+
+    for (int i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        if (scsiDev.targets[i].targetId < S2S_MAX_TARGETS && scsiDev.targets[i].cfg)
+        {
+            if (sel_bits & (1u << scsiDev.targets[i].targetId))
+            {
+                sel_id = scsiDev.targets[i].targetId;
+                break;
+            }
+        }
+    }
+
+    if (sel_id < 0)
+    {
+        return 0;
+    }
+
+    g_scsi_sts_selection_initiator = 0xFF;
+    for (int id = 0; id < 8; id++)
+    {
+        if (id != sel_id && (sel_bits & (1u << id)))
+        {
+            g_scsi_sts_selection_initiator = id;
+            break;
+        }
+    }
+
+    // ATN is only reliably readable after BSY enables the bus transceiver.
+    return SCSI_STS_SELECTION_SUCCEEDED | SCSI_STS_SELECTION_ATN | sel_id;
+}
 
 void scsi_bsy_deassert_interrupt()
 {
@@ -67,24 +103,10 @@ void scsi_bsy_deassert_interrupt()
 
         // Check if any of the targets we simulate is selected
         uint32_t sel_bits = SCSI_IN_DATA();
-        int sel_id = -1;
-        for (int i = 0; i < S2S_MAX_TARGETS; i++)
+        uint8_t sel_status = pack_selection_status(sel_bits);
+        if (sel_status != 0)
         {
-            if (scsiDev.targets[i].targetId < S2S_MAX_TARGETS && scsiDev.targets[i].cfg)
-            {
-                if (sel_bits & (1 << scsiDev.targets[i].targetId))
-                {
-                    sel_id = scsiDev.targets[i].targetId;
-                    break;
-                }
-            }
-        }
-
-        if (sel_id >= 0)
-        {
-            // Set ATN flag here unconditionally, real value is only known after
-            // OUT_BSY is enabled in scsiStatusSEL() below.
-            g_scsi_sts_selection = SCSI_STS_SELECTION_SUCCEEDED | SCSI_STS_SELECTION_ATN | sel_id;
+            g_scsi_sts_selection = sel_status;
         }
 
         // selFlag is required for Philips P2000C which releases it after 600ns
@@ -125,6 +147,77 @@ extern "C" bool scsiStatusSEL()
     }
 
     return SCSI_IN(SEL);
+}
+
+extern "C" bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId)
+{
+    if (initiatorId > 7 || targetId >= S2S_MAX_TARGETS)
+    {
+        return false;
+    }
+
+    if (SCSI_IN(BSY) || SCSI_IN(SEL))
+    {
+        return false;
+    }
+
+    s2s_delay_us(1);
+    if (SCSI_IN(BSY) || SCSI_IN(SEL))
+    {
+        return false;
+    }
+
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    g_scsi_phase = RESELECTION;
+    scsiLogPhaseChange(RESELECTION);
+    // Match the existing initiator-mode simplified arbitration and yield if
+    // another initiator is already driving IDs on the bus.
+    SCSI_OUT(BSY, 1);
+    for (int wait = 0; wait < 10; wait++)
+    {
+        s2s_delay_us(1);
+        if (SCSI_IN_DATA() != 0)
+        {
+            SCSI_OUT(BSY, 0);
+            g_scsi_phase = BUS_FREE;
+            return false;
+        }
+    }
+
+    SCSI_OUT(IO, 1);
+    SCSI_OUT(SEL, 1);
+    s2s_delay_us(1);
+    SCSI_OUT_DATA((1u << targetId) | (1u << initiatorId));
+    s2s_delay_us(1);
+    SCSI_OUT(BSY, 0);
+
+    uint32_t waitStart_ms = s2s_getTime_ms();
+    while (!SCSI_IN(BSY) &&
+           !scsiDev.resetFlag &&
+           s2s_elapsedTime_ms(waitStart_ms) < 250)
+    {
+        platform_poll();
+    }
+
+    if (!SCSI_IN(BSY))
+    {
+        SCSI_RELEASE_DATA_REQ();
+        SCSI_OUT(SEL, 0);
+        SCSI_OUT(IO, 0);
+        g_scsi_phase = BUS_FREE;
+        return false;
+    }
+
+    SCSI_OUT(BSY, 1);
+    s2s_delay_us(1);
+    SCSI_RELEASE_DATA_REQ();
+    SCSI_OUT(SEL, 0);
+    g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
+    scsiDev.selFlag = 0;
+    return true;
 }
 
 /************************/
@@ -172,6 +265,7 @@ extern "C" void scsiPhyReset(void)
 {
     SCSI_RELEASE_OUTPUTS();
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     g_scsi_phase = BUS_FREE;
 
@@ -301,6 +395,7 @@ void scsiEnterBusFree(void)
 {
     g_scsi_phase = BUS_FREE;
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
     scsiDev.cdbLen = 0;
 

--- a/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiPhy.h
@@ -43,11 +43,12 @@ bool scsiStatusSEL();
 
 // Get SCSI selection status.
 // This is latched by interrupt when BSY is deasserted while SEL is asserted.
-// Lowest 3 bits are the selected target id.
-// Highest bits are status information.
+// Low target-id bits are the selected target id.
+// Highest bits are status information. Initiator ID is latched separately.
 #define SCSI_STS_SELECTION_SUCCEEDED 0x40
 #define SCSI_STS_SELECTION_ATN 0x80
 extern volatile uint8_t g_scsi_sts_selection;
+extern volatile uint8_t g_scsi_sts_selection_initiator;
 #define SCSI_STS_SELECTED (&g_scsi_sts_selection)
 extern volatile uint8_t g_scsi_ctrl_bsy;
 #define SCSI_CTRL_BSY (&g_scsi_ctrl_bsy)
@@ -64,6 +65,10 @@ uint32_t scsiEnterPhaseImmediate(int phase);
 
 // Release all signals
 void scsiEnterBusFree(void);
+
+// Arbitrate for and perform target reselection of an initiator.
+// Returns true once the initiator responds with BSY.
+bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId);
 
 // Blocking data transfer
 void scsiWrite(const uint8_t* data, uint32_t count);

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -687,6 +687,62 @@ zuluscsi_timings_t *g_zuluscsi_timings = &predefined_timings[1];
 zuluscsi_timings_t *g_zuluscsi_timings = &predefined_timings[0];
 #endif
 
+static uint32_t effective_sync_period_ps(const zuluscsi_timings_t *timings, uint8_t sync_period)
+{
+    uint32_t delay_in_ps = (uint32_t)sync_period * 4000U;
+    uint32_t up_rounder = timings->scsi.clk_period_ps / 2 + 1;
+    int totalPeriod = (delay_in_ps + up_rounder) / timings->scsi.clk_period_ps;
+    int rtotalPeriod = totalPeriod;
+    int clkdiv = 1;
+
+    if (sync_period < 25)
+    {
+        rtotalPeriod += timings->scsi_20.rtotal_period_adjust;
+    }
+    else if (sync_period < 50)
+    {
+        rtotalPeriod += timings->scsi_10.rtotal_period_adjust;
+    }
+    else
+    {
+        clkdiv = timings->scsi_5.clkdiv > 0 ? timings->scsi_5.clkdiv : 1;
+        totalPeriod /= clkdiv;
+        rtotalPeriod /= clkdiv;
+        rtotalPeriod += timings->scsi_5.rtotal_period_adjust;
+    }
+
+#ifdef RP2MCU_SCSI_ACCEL_WIDE
+    // The wide target path does not apply the narrow DMA read-pacer floor.
+#elif defined(ZULUSCSI_MCU_RP23XX)
+    if (rtotalPeriod < 14) rtotalPeriod = 14;
+#else
+    if (rtotalPeriod < 18) rtotalPeriod = 18;
+#endif
+
+    return (uint32_t)rtotalPeriod * (uint32_t)clkdiv * timings->scsi.clk_period_ps;
+}
+
+uint8_t calculate_sync_period_limit(const zuluscsi_timings_t *timings, uint8_t requested_min_period)
+{
+    uint16_t sync_period = requested_min_period;
+    while (sync_period <= UINT8_MAX)
+    {
+        if (effective_sync_period_ps(timings, sync_period) <= (uint32_t)sync_period * 4000U)
+        {
+            return sync_period;
+        }
+        sync_period++;
+    }
+    return UINT8_MAX;
+}
+
+void update_sync_period_limits(void)
+{
+    g_max_sync_20_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_20.max_sync);
+    g_max_sync_10_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_10.max_sync);
+    g_max_sync_5_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_5.max_sync);
+}
+
 
 bool set_timings(zuluscsi_speed_grade_t speed_grade)
 {
@@ -800,9 +856,7 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
     {
         g_zuluscsi_timings = &current_timings;
         memcpy(g_zuluscsi_timings, &predefined_timings[timings_index], sizeof(*g_zuluscsi_timings));
-        g_max_sync_10_period = g_zuluscsi_timings->scsi_10.max_sync;
-        g_max_sync_20_period = g_zuluscsi_timings->scsi_20.max_sync;
-        g_max_sync_5_period = g_zuluscsi_timings->scsi_5.max_sync;
+        update_sync_period_limits();
         return true;
     }
     return false;

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
@@ -135,6 +135,13 @@ typedef struct
 
 extern  zuluscsi_timings_t *g_zuluscsi_timings;
 
+// Return the fastest sync period this timing set can honestly advertise
+// without the DATA OUT read pacer stretching beyond the negotiated period.
+uint8_t calculate_sync_period_limit(const zuluscsi_timings_t *timings, uint8_t requested_min_period);
+
+// Refresh g_max_sync_* from the current timing set after applying runtime constraints.
+void update_sync_period_limits(void);
+
 // Sets timings to the speed_grade, returns false on SPEED_GRADE_DEFAULT and SPEED_GRADE_CUSTOM
 bool set_timings(zuluscsi_speed_grade_t speed_grade);
 

--- a/lib/ZuluSCSI_platform_template/scsiPhy.cpp
+++ b/lib/ZuluSCSI_platform_template/scsiPhy.cpp
@@ -55,7 +55,43 @@ extern "C" bool scsiStatusBSY()
 /************************/
 
 volatile uint8_t g_scsi_sts_selection;
+volatile uint8_t g_scsi_sts_selection_initiator;
 volatile uint8_t g_scsi_ctrl_bsy;
+
+static uint8_t pack_selection_status(uint8_t sel_bits)
+{
+    int sel_id = -1;
+
+    for (int i = 0; i < S2S_MAX_TARGETS; i++)
+    {
+        if (scsiDev.targets[i].targetId < S2S_MAX_TARGETS && scsiDev.targets[i].cfg)
+        {
+            if (sel_bits & (1 << scsiDev.targets[i].targetId))
+            {
+                sel_id = scsiDev.targets[i].targetId;
+                break;
+            }
+        }
+    }
+
+    if (sel_id < 0)
+    {
+        return 0;
+    }
+
+    g_scsi_sts_selection_initiator = 0xFF;
+    for (int id = 0; id < 8; id++)
+    {
+        if (id != sel_id && (sel_bits & (1 << id)))
+        {
+            g_scsi_sts_selection_initiator = id;
+            break;
+        }
+    }
+
+    uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
+    return SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+}
 
 void scsi_bsy_deassert_interrupt()
 {
@@ -63,23 +99,10 @@ void scsi_bsy_deassert_interrupt()
     {
         // Check if any of the targets we simulate is selected
         uint8_t sel_bits = SCSI_IN_DATA();
-        int sel_id = -1;
-        for (int i = 0; i < S2S_MAX_TARGETS; i++)
+        uint8_t sel_status = pack_selection_status(sel_bits);
+        if (sel_status != 0)
         {
-            if (scsiDev.targets[i].targetId < S2S_MAX_TARGETS && scsiDev.targets[i].cfg)
-            {
-                if (sel_bits & (1 << scsiDev.targets[i].targetId))
-                {
-                    sel_id = scsiDev.targets[i].targetId;
-                    break;
-                }
-            }
-        }
-
-        if (sel_id >= 0)
-        {
-            uint8_t atn_flag = SCSI_IN(ATN) ? SCSI_STS_SELECTION_ATN : 0;
-            g_scsi_sts_selection = SCSI_STS_SELECTION_SUCCEEDED | atn_flag | sel_id;
+            g_scsi_sts_selection = sel_status;
         }
 
         // selFlag is required for Philips P2000C which releases it after 600ns
@@ -101,6 +124,13 @@ extern "C" bool scsiStatusSEL()
     }
 
     return SCSI_IN(SEL);
+}
+
+extern "C" bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId)
+{
+    (void)targetId;
+    (void)initiatorId;
+    return false;
 }
 
 /************************/
@@ -127,6 +157,7 @@ extern "C" void scsiPhyReset(void)
 {
     SCSI_RELEASE_OUTPUTS();
     g_scsi_sts_selection = 0;
+    g_scsi_sts_selection_initiator = 0xFF;
     g_scsi_ctrl_bsy = 0;
 
     /* Implement here code to enable two interrupts:

--- a/lib/ZuluSCSI_platform_template/scsiPhy.h
+++ b/lib/ZuluSCSI_platform_template/scsiPhy.h
@@ -43,11 +43,12 @@ bool scsiStatusSEL();
 
 // Get SCSI selection status.
 // This is latched by interrupt when BSY is deasserted while SEL is asserted.
-// Lowest 3 bits are the selected target id.
-// Highest bits are status information.
+// Low target-id bits are the selected target id.
+// Highest bits are status information. Initiator ID is latched separately.
 #define SCSI_STS_SELECTION_SUCCEEDED 0x40
 #define SCSI_STS_SELECTION_ATN 0x80
 extern volatile uint8_t g_scsi_sts_selection;
+extern volatile uint8_t g_scsi_sts_selection_initiator;
 #define SCSI_STS_SELECTED (&g_scsi_sts_selection)
 extern volatile uint8_t g_scsi_ctrl_bsy;
 #define SCSI_CTRL_BSY (&g_scsi_ctrl_bsy)
@@ -64,6 +65,10 @@ uint32_t scsiEnterPhaseImmediate(int phase);
 
 // Release all signals
 void scsiEnterBusFree(void);
+
+// Arbitrate for and perform target reselection of an initiator.
+// Returns true once the initiator responds with BSY.
+bool scsiPhyReselect(uint8_t targetId, uint8_t initiatorId);
 
 // Blocking data transfer
 void scsiWrite(const uint8_t* data, uint32_t count);

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -495,7 +495,8 @@ static bool cdromSelectBinFileForTrack(image_config_t &img, const CUETrackInfo *
 
 // Fetch track info based on LBA
 // Returns with the requested track already selected for bin file
-static void getTrackFromLBA(image_config_t &img, uint32_t lba, CUETrackInfo *result, CUEParser *parser = nullptr)
+static void getTrackFromLBA(image_config_t &img, uint32_t lba, CUETrackInfo *result,
+    uint32_t *track_end_lba = nullptr, CUEParser *parser = nullptr)
 {
     if (!img.cuesheetfile.isOpen())
     {
@@ -504,13 +505,21 @@ static void getTrackFromLBA(image_config_t &img, uint32_t lba, CUETrackInfo *res
         result->track_mode = CUETrack_MODE1_2048;
         result->sector_length = 2048;
         result->track_number = 1;
+        if (track_end_lba)
+        {
+            *track_end_lba = img.file.size() / result->sector_length;
+        }
     }
     else if (img.cdrom_binfile_index == img.cdrom_trackinfo.file_index &&
              lba >= img.cdrom_trackinfo.track_start &&
-             lba < img.cdrom_trackinfo.data_start + img.file.size() / img.cdrom_trackinfo.sector_length)
+             lba < img.cdrom_track_end_lba)
     {
         // Same track as previous time
         *result = img.cdrom_trackinfo;
+        if (track_end_lba)
+        {
+            *track_end_lba = img.cdrom_track_end_lba;
+        }
     }
     else
     {
@@ -528,14 +537,18 @@ static void getTrackFromLBA(image_config_t &img, uint32_t lba, CUETrackInfo *res
 
         const CUETrackInfo *tmptrack;
         uint64_t prev_capacity = 0;
+        uint32_t next_track_start = 0;
+        bool found_track = false;
         while ((tmptrack = parser->next_track(prev_capacity)) != NULL)
         {
             if (tmptrack->track_start <= lba)
             {
                 *result = *tmptrack;
+                found_track = true;
             }
             else
             {
+                next_track_start = tmptrack->track_start;
                 break;
             }
 
@@ -543,7 +556,27 @@ static void getTrackFromLBA(image_config_t &img, uint32_t lba, CUETrackInfo *res
             prev_capacity = img.file.size();
         }
 
-        img.cdrom_trackinfo = *result;
+        if (track_end_lba)
+        {
+            if (!found_track)
+            {
+                *track_end_lba = 0;
+            }
+            else if (next_track_start != 0)
+            {
+                *track_end_lba = next_track_start;
+            }
+            else
+            {
+                *track_end_lba = getLeadOutLBA(result);
+            }
+        }
+
+        if (found_track)
+        {
+            img.cdrom_trackinfo = *result;
+            img.cdrom_track_end_lba = track_end_lba ? *track_end_lba : getLeadOutLBA(result);
+        }
     }
 }
 
@@ -840,7 +873,7 @@ void doReadHeader(bool MSF, uint32_t lba, uint16_t allocationLength)
         // Track mode (audio / data)
         if (trackinfo.track_mode == CUETrack_AUDIO)
         {
-            scsiDev.data[0] = 0;
+            mode = 0;
         }
     }
 
@@ -1654,7 +1687,8 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
     // Search the track with the requested LBA
     // Supplies dummy data if no cue sheet is active.
     CUETrackInfo trackinfo = {};
-    getTrackFromLBA(img, lba, &trackinfo);
+    uint32_t track_end_lba = 0;
+    getTrackFromLBA(img, lba, &trackinfo, &track_end_lba);
 
     // Figure out the data offset in the file
     int64_t offset;
@@ -1700,6 +1734,11 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
 
     // Ensure read is not out of range of the image
     uint32_t total_length = length;
+    if (track_end_lba > lba && length > track_end_lba - lba)
+    {
+        dbgmsg("------ Splitting read request at track boundary");
+        length = track_end_lba - lba;
+    }
     uint64_t readend = offset + trackinfo.sector_length * length;
     if (offset < 0 && -offset > trackinfo.unstored_pregap_length * trackinfo.sector_length)
     {
@@ -1859,6 +1898,16 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
     uint32_t result_length = sector_length + (field_q_subchannel ? 16 : 0) + (add_fake_headers ? 304 : 0);
     uint8_t *buf0 = scsiDev.data;
     uint8_t *buf1 = scsiDev.data + result_length;
+    auto failRead = [&](const char *operation, uint32_t failed_lba)
+    {
+        logmsg("CD-ROM ", operation, " failed at LBA ", (int)failed_lba,
+            " on SCSI ID ", (int)(img.scsiId & S2S_CFG_TARGET_ID_BITS));
+        scsiFinishWrite();
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = MEDIUM_ERROR;
+        scsiDev.target->sense.asc = 0x1106; // CIRC UNRECOVERED ERROR
+        scsiDev.phase = STATUS;
+    };
 
     // Format the sectors for transfer
     for (uint32_t idx = 0; idx < length; idx++)
@@ -1866,7 +1915,11 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
         platform_poll();
         diskEjectButtonUpdate(false);
 
-        img.file.seek(offset + idx * trackinfo.sector_length + skip_begin);
+        if (!img.file.seek(offset + idx * trackinfo.sector_length + skip_begin))
+        {
+            failRead("seek", lba + idx);
+            return;
+        }
 
         // Verify that previous write using this buffer has finished
         uint8_t *buf = ((idx & 1) ? buf1 : buf0);
@@ -1888,7 +1941,11 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
             if (sector_length > 0)
             {
                 // User data
-                img.file.read(buf, sector_length);
+                if (img.file.read(buf, sector_length) != sector_length)
+                {
+                    failRead("read", lba + idx);
+                    return;
+                }
                 buf += sector_length;
             }
         }
@@ -1913,7 +1970,11 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
             if (sector_length > 0)
             {
                 // User data
-                img.file.read(buf, sector_length);
+                if (img.file.read(buf, sector_length) != sector_length)
+                {
+                    failRead("read", lba + idx);
+                    return;
+                }
                 buf += sector_length;
             }
 
@@ -1955,8 +2016,8 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
 
     if (length != total_length)
     {
-        // This read request was split across multiple .bin files
-        // Tail recurse to read the next track.
+        // This read request was split across a track boundary or image file end.
+        // Tail recurse to read the next track segment.
         doReadCD(lba + length, total_length - length, sector_type, main_channel, sub_channel, data_only);
         return;
     }
@@ -2213,7 +2274,11 @@ extern "C" int scsiCDRomCommand()
     {
         // CD-ROM Read Header
         bool MSF = (scsiDev.cdb[1] & 0x02);
-        uint32_t lba = 0; // IGNORED for now
+        uint32_t lba =
+            (((uint32_t) scsiDev.cdb[2]) << 24) +
+            (((uint32_t) scsiDev.cdb[3]) << 16) +
+            (((uint32_t) scsiDev.cdb[4]) << 8) +
+            scsiDev.cdb[5];
         uint16_t allocationLength =
             (((uint32_t) scsiDev.cdb[7]) << 8) +
             scsiDev.cdb[8];

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1896,9 +1896,13 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
 
     // Use two buffers alternately for formatting sector data
     uint32_t result_length = sector_length + (field_q_subchannel ? 16 : 0) + (add_fake_headers ? 304 : 0);
-    uint8_t *buf0 = scsiDev.data;
-    uint8_t *buf1 = scsiDev.data + result_length;
     bool sequential_file_read = sector_length > 0 && skip_begin == 0;
+    uint32_t direct_sectors_per_buffer = 0;
+    if (sequential_file_read && !add_fake_headers && !field_q_subchannel &&
+        result_length == (uint32_t)sector_length)
+    {
+        direct_sectors_per_buffer = (sizeof(scsiDev.data) / 2) / result_length;
+    }
     auto failRead = [&](const char *operation, uint32_t failed_lba)
     {
         logmsg("CD-ROM ", operation, " failed at LBA ", (int)failed_lba,
@@ -1916,108 +1920,163 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
         return;
     }
 
-    // Format the sectors for transfer
-    for (uint32_t idx = 0; idx < length; idx++)
+    if (direct_sectors_per_buffer > 1)
     {
-        platform_poll();
-        diskEjectButtonUpdate(false);
+        uint32_t direct_buffer_bytes = direct_sectors_per_buffer * result_length;
+        uint8_t *buf0 = scsiDev.data;
+        uint8_t *buf1 = scsiDev.data + direct_buffer_bytes;
 
-        if (!sequential_file_read && sector_length > 0 &&
-            !img.file.seek(offset + idx * trackinfo.sector_length + skip_begin))
+        for (uint32_t idx = 0; idx < length; )
         {
-            failRead("seek", lba + idx);
-            return;
-        }
-
-        // Verify that previous write using this buffer has finished
-        uint8_t *buf = ((idx & 1) ? buf1 : buf0);
-        uint8_t *bufstart = buf;
-        uint32_t start = millis();
-        while (!scsiIsWriteFinished(buf + result_length - 1) && !scsiDev.resetFlag)
-        {
-            if ((uint32_t)(millis() - start) > 5000)
-            {
-                logmsg("doReadCD() timeout waiting for previous to finish");
-                scsiDev.resetFlag = 1;
-            }
             platform_poll();
             diskEjectButtonUpdate(false);
+
+            uint32_t sectors_this_time = length - idx;
+            if (sectors_this_time > direct_sectors_per_buffer)
+            {
+                sectors_this_time = direct_sectors_per_buffer;
+            }
+            uint32_t transfer_bytes = sectors_this_time * result_length;
+
+            // Verify that previous write using this buffer has finished
+            uint8_t *buf = (((idx / direct_sectors_per_buffer) & 1) ? buf1 : buf0);
+            uint32_t start = millis();
+            while (!scsiIsWriteFinished(buf + transfer_bytes - 1) && !scsiDev.resetFlag)
+            {
+                if ((uint32_t)(millis() - start) > 5000)
+                {
+                    logmsg("doReadCD() timeout waiting for previous to finish");
+                    scsiDev.resetFlag = 1;
+                }
+                platform_poll();
+                diskEjectButtonUpdate(false);
+            }
+            if (scsiDev.resetFlag) break;
+
+            if (img.file.read(buf, transfer_bytes) != transfer_bytes)
+            {
+                failRead("read", lba + idx);
+                return;
+            }
+
+            scsiStartWrite(buf, transfer_bytes);
+            idx += sectors_this_time;
+
+            // Reset the watchdog while the transfer is progressing.
+            // If the host stops transferring, the watchdog will eventually expire.
+            // This is needed to avoid hitting the watchdog if the host performs
+            // a large transfer compared to its transfer speed.
+            platform_reset_watchdog();
         }
-        if (scsiDev.resetFlag) break;
-        if ((g_scsi_settings.getDevice(img.scsiId & S2S_CFG_TARGET_ID_BITS)->vendorExtensions & VENDOR_EXTENSION_OPTICAL_PLEXTOR))
+    }
+    else
+    {
+        uint8_t *buf0 = scsiDev.data;
+        uint8_t *buf1 = scsiDev.data + result_length;
+
+        // Format the sectors for transfer
+        for (uint32_t idx = 0; idx < length; idx++)
         {
-            if (sector_length > 0)
+            platform_poll();
+            diskEjectButtonUpdate(false);
+
+            if (!sequential_file_read && sector_length > 0 &&
+                !img.file.seek(offset + idx * trackinfo.sector_length + skip_begin))
             {
-                // User data
-                if (img.file.read(buf, sector_length) != sector_length)
-                {
-                    failRead("read", lba + idx);
-                    return;
-                }
-                buf += sector_length;
+                failRead("seek", lba + idx);
+                return;
             }
+
+            // Verify that previous write using this buffer has finished
+            uint8_t *buf = ((idx & 1) ? buf1 : buf0);
+            uint8_t *bufstart = buf;
+            uint32_t start = millis();
+            while (!scsiIsWriteFinished(buf + result_length - 1) && !scsiDev.resetFlag)
+            {
+                if ((uint32_t)(millis() - start) > 5000)
+                {
+                    logmsg("doReadCD() timeout waiting for previous to finish");
+                    scsiDev.resetFlag = 1;
+                }
+                platform_poll();
+                diskEjectButtonUpdate(false);
+            }
+            if (scsiDev.resetFlag) break;
+            if ((g_scsi_settings.getDevice(img.scsiId & S2S_CFG_TARGET_ID_BITS)->vendorExtensions & VENDOR_EXTENSION_OPTICAL_PLEXTOR))
+            {
+                if (sector_length > 0)
+                {
+                    // User data
+                    if (img.file.read(buf, sector_length) != sector_length)
+                    {
+                        failRead("read", lba + idx);
+                        return;
+                    }
+                    buf += sector_length;
+                }
+            }
+            else
+            {
+                if (add_fake_headers)
+                {
+                    // 12-byte data sector sync pattern
+                    *buf++ = 0x00;
+                    for (int i = 0; i < 10; i++)
+                    {
+                        *buf++ = 0xFF;
+                    }
+                    *buf++ = 0x00;
+
+                    // 4-byte data sector header
+                    LBA2MSFBCD(lba + idx, buf, false);
+                    buf += 3;
+                    *buf++ = 0x01; // Mode 1
+                }
+
+                if (sector_length > 0)
+                {
+                    // User data
+                    if (img.file.read(buf, sector_length) != sector_length)
+                    {
+                        failRead("read", lba + idx);
+                        return;
+                    }
+                    buf += sector_length;
+                }
+
+                if (add_fake_headers)
+                {
+                    // 288 bytes of ECC
+                    memset(buf, 0, 288);
+                    buf += 288;
+                }
+
+                if (field_q_subchannel)
+                {
+                    // Formatted Q subchannel data
+                    // Refer to table 354 in T10/1545-D MMC-4 Revision 5a
+                    // and ECMA-130 22.3.3
+                    *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
+                    *buf++ = trackinfo.track_number;
+                    *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
+                    int32_t rel = (int32_t)(lba + idx) - (int32_t)trackinfo.data_start;
+                    LBA2MSF(rel, buf, true); buf += 3;
+                    *buf++ = 0;
+                    LBA2MSF(lba + idx, buf, false); buf += 3;
+                    *buf++ = 0; *buf++ = 0; // CRC (optional)
+                    *buf++ = 0; *buf++ = 0; *buf++ = 0; // (pad)
+                    *buf++ = 0; // No P subchannel
+                }
+            }
+            assert(buf == bufstart + result_length);
+            scsiStartWrite(bufstart, result_length);
+
+            // Reset the watchdog while the transfer is progressing.
+            // If the host stops transferring, the watchdog will eventually expire.
+            // This is needed to avoid hitting the watchdog if the host performs
+            // a large transfer compared to its transfer speed.
+            platform_reset_watchdog();
         }
-        else 
-        {
-            if (add_fake_headers)
-            {
-                // 12-byte data sector sync pattern
-                *buf++ = 0x00;
-                for (int i = 0; i < 10; i++)
-                {
-                    *buf++ = 0xFF;
-                }
-                *buf++ = 0x00;
-
-                // 4-byte data sector header
-                LBA2MSFBCD(lba + idx, buf, false);
-                buf += 3;
-                *buf++ = 0x01; // Mode 1
-            }
-
-            if (sector_length > 0)
-            {
-                // User data
-                if (img.file.read(buf, sector_length) != sector_length)
-                {
-                    failRead("read", lba + idx);
-                    return;
-                }
-                buf += sector_length;
-            }
-
-            if (add_fake_headers)
-            {
-                // 288 bytes of ECC
-                memset(buf, 0, 288);
-                buf += 288;
-            }
-
-            if (field_q_subchannel)
-            {
-                // Formatted Q subchannel data
-                // Refer to table 354 in T10/1545-D MMC-4 Revision 5a
-                // and ECMA-130 22.3.3
-                *buf++ = (trackinfo.track_mode == CUETrack_AUDIO ? 0x10 : 0x14); // Control & ADR
-                *buf++ = trackinfo.track_number;
-                *buf++ = (lba + idx >= trackinfo.data_start) ? 1 : 0; // Index number (0 = pregap)
-                int32_t rel = (int32_t)(lba + idx) - (int32_t)trackinfo.data_start;
-                LBA2MSF(rel, buf, true); buf += 3;
-                *buf++ = 0;
-                LBA2MSF(lba + idx, buf, false); buf += 3;
-                *buf++ = 0; *buf++ = 0; // CRC (optional)
-                *buf++ = 0; *buf++ = 0; *buf++ = 0; // (pad)
-                *buf++ = 0; // No P subchannel
-            }
-        }
-        assert(buf == bufstart + result_length);
-        scsiStartWrite(bufstart, result_length);
-
-        // Reset the watchdog while the transfer is progressing.
-        // If the host stops transferring, the watchdog will eventually expire.
-        // This is needed to avoid hitting the watchdog if the host performs
-        // a large transfer compared to its transfer speed.
-        platform_reset_watchdog();
     }
 
     scsiFinishWrite();

--- a/src/ZuluSCSI_cdrom.cpp
+++ b/src/ZuluSCSI_cdrom.cpp
@@ -1898,6 +1898,7 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
     uint32_t result_length = sector_length + (field_q_subchannel ? 16 : 0) + (add_fake_headers ? 304 : 0);
     uint8_t *buf0 = scsiDev.data;
     uint8_t *buf1 = scsiDev.data + result_length;
+    bool sequential_file_read = sector_length > 0 && skip_begin == 0;
     auto failRead = [&](const char *operation, uint32_t failed_lba)
     {
         logmsg("CD-ROM ", operation, " failed at LBA ", (int)failed_lba,
@@ -1909,13 +1910,20 @@ static void doReadCD(uint32_t lba, uint32_t length, uint8_t sector_type,
         scsiDev.phase = STATUS;
     };
 
+    if (sequential_file_read && !img.file.seek(offset))
+    {
+        failRead("seek", lba);
+        return;
+    }
+
     // Format the sectors for transfer
     for (uint32_t idx = 0; idx < length; idx++)
     {
         platform_poll();
         diskEjectButtonUpdate(false);
 
-        if (!img.file.seek(offset + idx * trackinfo.sector_length + skip_begin))
+        if (!sequential_file_read && sector_length > 0 &&
+            !img.file.seek(offset + idx * trackinfo.sector_length + skip_begin))
         {
             failRead("seek", lba + idx);
             return;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -417,6 +417,7 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, in
     img.cuesheetfile.close();
     img.bin_container.close();
     img.cdrom_binfile_index = -1;
+    img.cdrom_track_end_lba = 0;
     scsiDiskSetImageConfig(target_idx);
 
     auto device_config = g_scsi_settings.getDevice(target_idx);
@@ -596,6 +597,7 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, in
                         audio_reset(target_idx);
 #endif
                         memset(&img.cdrom_trackinfo, 0, sizeof(img.cdrom_trackinfo));
+                        img.cdrom_track_end_lba = 0;
                     }
                 }
             }
@@ -631,6 +633,7 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, in
             {
                 img.bin_container.open(foldername);
                 memset(&img.cdrom_trackinfo, 0, sizeof(img.cdrom_trackinfo));
+                img.cdrom_track_end_lba = 0;
 #ifdef ENABLE_AUDIO_OUTPUT                
                 audio_reset(target_idx);
 #endif
@@ -2622,12 +2625,10 @@ int scsiDiskCommand()
         if (unlikely(blocks == 0)) blocks = 256;
         scsiDiskStartWrite(lba, blocks);
     }
-    else if (likely(command == 0x2A) || // WRITE(10)
-        unlikely(command == 0x2E)) // WRITE AND VERIFY
+    else if (likely(command == 0x2A))
     {
+        // WRITE(10)
         // Ignore all cache control bits - we don't support a memory cache.
-        // Don't bother verifying either. The SD card likely stores ECC
-        // along with each flash row.
 
         uint32_t lba =
             (((uint32_t) scsiDev.cdb[2]) << 24) +
@@ -2639,6 +2640,15 @@ int scsiDiskCommand()
             scsiDev.cdb[8];
 
         scsiDiskStartWrite(lba, blocks);
+    }
+    else if (unlikely(command == 0x2E))
+    {
+        // WRITE AND VERIFY
+        // Do not claim success unless verify semantics are actually implemented.
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = INVALID_COMMAND_OPERATION_CODE;
+        scsiDev.phase = STATUS;
     }
     else if (unlikely(command == 0x04))
     {
@@ -2929,4 +2939,3 @@ extern "C" void loadImage()
    g_pendingLoadIndex = -1;
 #endif
 }
-

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2215,6 +2215,36 @@ static void scsiDiskStartVerify(uint32_t lba, uint32_t blocks)
     }
 }
 
+static void scsiDiskHandleVerify(uint64_t lba, uint32_t blocks, bool compareData)
+{
+    if (lba > UINT32_MAX)
+    {
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+        scsiDev.phase = STATUS;
+        return;
+    }
+
+    if (compareData)
+    {
+        scsiDiskStartVerify((uint32_t)lba, blocks);
+        return;
+    }
+
+    // We do not perform a real media scan yet, but still validate the
+    // requested LBA span.
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t capacity = img.file.size() / scsiDev.target->liveCfg.bytesPerSector;
+    if (unlikely(lba + blocks > capacity))
+    {
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+        scsiDev.phase = STATUS;
+    }
+}
+
 static void diskVerifyDataOut()
 {
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
@@ -2930,7 +2960,7 @@ int scsiDiskCommand()
             scsiDiskStartWrite((uint32_t)lba, blocks);
         }
     }
-    else if (unlikely(command == 0x2E))
+    else if (unlikely(command == 0x2E || command == 0xAE || command == 0x8E))
     {
         // WRITE AND VERIFY
         // Do not claim success unless verify semantics are actually implemented.
@@ -3031,7 +3061,7 @@ int scsiDiskCommand()
     else if (unlikely(command == 0x2F))
     {
         // VERIFY
-        uint32_t lba =
+        uint64_t lba =
             (((uint32_t) scsiDev.cdb[2]) << 24) +
             (((uint32_t) scsiDev.cdb[3]) << 16) +
             (((uint32_t) scsiDev.cdb[4]) << 8) +
@@ -3040,24 +3070,43 @@ int scsiDiskCommand()
             (((uint32_t) scsiDev.cdb[7]) << 8) +
             scsiDev.cdb[8];
 
-        if ((scsiDev.cdb[1] & 0x02) == 0)
-        {
-            // They are asking us to do a medium verification with no data
-            // comparison. We don't perform a real media scan yet, but still
-            // validate the requested LBA span.
-            uint32_t capacity = img.file.size() / scsiDev.target->liveCfg.bytesPerSector;
-            if (unlikely(((uint64_t) lba) + blocks > capacity))
-            {
-                scsiDev.status = CHECK_CONDITION;
-                scsiDev.target->sense.code = ILLEGAL_REQUEST;
-                scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
-                scsiDev.phase = STATUS;
-            }
-        }
-        else
-        {
-            scsiDiskStartVerify(lba, blocks);
-        }
+        scsiDiskHandleVerify(lba, blocks, (scsiDev.cdb[1] & 0x02) != 0);
+    }
+    else if (unlikely(command == 0xAF))
+    {
+        // VERIFY(12)
+        uint64_t lba =
+            (((uint32_t) scsiDev.cdb[2]) << 24) +
+            (((uint32_t) scsiDev.cdb[3]) << 16) +
+            (((uint32_t) scsiDev.cdb[4]) << 8) +
+            scsiDev.cdb[5];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[6]) << 24) +
+            (((uint32_t) scsiDev.cdb[7]) << 16) +
+            (((uint32_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+
+        scsiDiskHandleVerify(lba, blocks, (scsiDev.cdb[1] & 0x02) != 0);
+    }
+    else if (unlikely(command == 0x8F))
+    {
+        // VERIFY(16)
+        uint64_t lba =
+            (((uint64_t) scsiDev.cdb[2]) << 56) +
+            (((uint64_t) scsiDev.cdb[3]) << 48) +
+            (((uint64_t) scsiDev.cdb[4]) << 40) +
+            (((uint64_t) scsiDev.cdb[5]) << 32) +
+            (((uint64_t) scsiDev.cdb[6]) << 24) +
+            (((uint64_t) scsiDev.cdb[7]) << 16) +
+            (((uint64_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[10]) << 24) +
+            (((uint32_t) scsiDev.cdb[11]) << 16) +
+            (((uint32_t) scsiDev.cdb[12]) << 8) +
+            scsiDev.cdb[13];
+
+        scsiDiskHandleVerify(lba, blocks, (scsiDev.cdb[1] & 0x02) != 0);
     }
     else if (unlikely(command == 0x37))
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1745,6 +1745,35 @@ static void doFormatUnitHeader(void)
 /* ReadCapacity command */
 /************************/
 
+static uint64_t getCapacityBlocks(image_config_t &img, uint32_t bytesPerSector)
+{
+    if (unlikely(scsiDev.target->cfg->deviceType == S2S_CFG_NETWORK))
+    {
+        return 1;
+    }
+    return img.file.size() / bytesPerSector;
+}
+
+static void storeBe32(uint8_t *dest, uint32_t value)
+{
+    dest[0] = value >> 24;
+    dest[1] = value >> 16;
+    dest[2] = value >> 8;
+    dest[3] = value;
+}
+
+static void storeBe64(uint8_t *dest, uint64_t value)
+{
+    dest[0] = value >> 56;
+    dest[1] = value >> 48;
+    dest[2] = value >> 40;
+    dest[3] = value >> 32;
+    dest[4] = value >> 24;
+    dest[5] = value >> 16;
+    dest[6] = value >> 8;
+    dest[7] = value;
+}
+
 static void doReadCapacity()
 {
     uint32_t lba = (((uint32_t) scsiDev.cdb[2]) << 24) +
@@ -1755,16 +1784,7 @@ static void doReadCapacity()
 
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
-    uint32_t capacity;
-
-    if (unlikely(scsiDev.target->cfg->deviceType == S2S_CFG_NETWORK))
-    {
-        capacity = 1;
-    }
-    else
-    {
-        capacity = img.file.size() / bytesPerSector;
-    }
+    uint64_t capacity = getCapacityBlocks(img, bytesPerSector);
 
     if (!pmi && lba)
     {
@@ -1779,23 +1799,68 @@ static void doReadCapacity()
     }
     else if (capacity > 0)
     {
-        uint32_t highestBlock = capacity - 1;
+        uint32_t highestBlock = capacity - 1 > UINT32_MAX ? UINT32_MAX : (uint32_t)(capacity - 1);
 
 	if (pmi && scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_EWSD)
 	{
 		highestBlock = 0x00001053;
 	}
-        scsiDev.data[0] = highestBlock >> 24;
-        scsiDev.data[1] = highestBlock >> 16;
-        scsiDev.data[2] = highestBlock >> 8;
-        scsiDev.data[3] = highestBlock;
-
-        uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
-        scsiDev.data[4] = bytesPerSector >> 24;
-        scsiDev.data[5] = bytesPerSector >> 16;
-        scsiDev.data[6] = bytesPerSector >> 8;
-        scsiDev.data[7] = bytesPerSector;
+        storeBe32(scsiDev.data, highestBlock);
+        storeBe32(scsiDev.data + 4, bytesPerSector);
         scsiDev.dataLen = 8;
+        scsiDev.phase = DATA_IN;
+    }
+    else
+    {
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = NOT_READY;
+        scsiDev.target->sense.asc = MEDIUM_NOT_PRESENT;
+        scsiDev.phase = STATUS;
+    }
+}
+
+static void doReadCapacity16()
+{
+    uint64_t lba =
+        (((uint64_t) scsiDev.cdb[2]) << 56) +
+        (((uint64_t) scsiDev.cdb[3]) << 48) +
+        (((uint64_t) scsiDev.cdb[4]) << 40) +
+        (((uint64_t) scsiDev.cdb[5]) << 32) +
+        (((uint64_t) scsiDev.cdb[6]) << 24) +
+        (((uint64_t) scsiDev.cdb[7]) << 16) +
+        (((uint64_t) scsiDev.cdb[8]) << 8) +
+        scsiDev.cdb[9];
+    uint32_t allocationLength =
+        (((uint32_t) scsiDev.cdb[10]) << 24) +
+        (((uint32_t) scsiDev.cdb[11]) << 16) +
+        (((uint32_t) scsiDev.cdb[12]) << 8) +
+        scsiDev.cdb[13];
+    int pmi = scsiDev.cdb[14] & 1;
+
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint64_t capacity = getCapacityBlocks(img, bytesPerSector);
+
+    if (!pmi && lba)
+    {
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+        scsiDev.phase = STATUS;
+    }
+    else if (capacity > 0)
+    {
+        uint64_t highestBlock = capacity - 1;
+
+        if (pmi && scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_EWSD)
+        {
+            highestBlock = 0x00001053;
+        }
+
+        memset(scsiDev.data, 0, 32);
+        storeBe64(scsiDev.data, highestBlock);
+        storeBe32(scsiDev.data + 8, bytesPerSector);
+        scsiDev.dataLen = allocationLength < 32 ? allocationLength : 32;
         scsiDev.phase = DATA_IN;
     }
     else
@@ -2614,6 +2679,52 @@ int scsiDiskCommand()
 
         scsiDiskStartRead(lba, blocks);
     }
+    else if (unlikely(command == 0xA8))
+    {
+        // READ(12)
+        uint32_t lba =
+            (((uint32_t) scsiDev.cdb[2]) << 24) +
+            (((uint32_t) scsiDev.cdb[3]) << 16) +
+            (((uint32_t) scsiDev.cdb[4]) << 8) +
+            scsiDev.cdb[5];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[6]) << 24) +
+            (((uint32_t) scsiDev.cdb[7]) << 16) +
+            (((uint32_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+
+        scsiDiskStartRead(lba, blocks);
+    }
+    else if (unlikely(command == 0x88))
+    {
+        // READ(16)
+        uint64_t lba =
+            (((uint64_t) scsiDev.cdb[2]) << 56) +
+            (((uint64_t) scsiDev.cdb[3]) << 48) +
+            (((uint64_t) scsiDev.cdb[4]) << 40) +
+            (((uint64_t) scsiDev.cdb[5]) << 32) +
+            (((uint64_t) scsiDev.cdb[6]) << 24) +
+            (((uint64_t) scsiDev.cdb[7]) << 16) +
+            (((uint64_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[10]) << 24) +
+            (((uint32_t) scsiDev.cdb[11]) << 16) +
+            (((uint32_t) scsiDev.cdb[12]) << 8) +
+            scsiDev.cdb[13];
+
+        if (lba > UINT32_MAX)
+        {
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = ILLEGAL_REQUEST;
+            scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+            scsiDev.phase = STATUS;
+        }
+        else
+        {
+            scsiDiskStartRead((uint32_t)lba, blocks);
+        }
+    }
     else if (likely(command == 0x0A))
     {
         // WRITE(6)
@@ -2640,6 +2751,52 @@ int scsiDiskCommand()
             scsiDev.cdb[8];
 
         scsiDiskStartWrite(lba, blocks);
+    }
+    else if (unlikely(command == 0xAA))
+    {
+        // WRITE(12)
+        uint32_t lba =
+            (((uint32_t) scsiDev.cdb[2]) << 24) +
+            (((uint32_t) scsiDev.cdb[3]) << 16) +
+            (((uint32_t) scsiDev.cdb[4]) << 8) +
+            scsiDev.cdb[5];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[6]) << 24) +
+            (((uint32_t) scsiDev.cdb[7]) << 16) +
+            (((uint32_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+
+        scsiDiskStartWrite(lba, blocks);
+    }
+    else if (unlikely(command == 0x8A))
+    {
+        // WRITE(16)
+        uint64_t lba =
+            (((uint64_t) scsiDev.cdb[2]) << 56) +
+            (((uint64_t) scsiDev.cdb[3]) << 48) +
+            (((uint64_t) scsiDev.cdb[4]) << 40) +
+            (((uint64_t) scsiDev.cdb[5]) << 32) +
+            (((uint64_t) scsiDev.cdb[6]) << 24) +
+            (((uint64_t) scsiDev.cdb[7]) << 16) +
+            (((uint64_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[10]) << 24) +
+            (((uint32_t) scsiDev.cdb[11]) << 16) +
+            (((uint32_t) scsiDev.cdb[12]) << 8) +
+            scsiDev.cdb[13];
+
+        if (lba > UINT32_MAX)
+        {
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = ILLEGAL_REQUEST;
+            scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+            scsiDev.phase = STATUS;
+        }
+        else
+        {
+            scsiDiskStartWrite((uint32_t)lba, blocks);
+        }
     }
     else if (unlikely(command == 0x2E))
     {
@@ -2674,6 +2831,22 @@ int scsiDiskCommand()
     {
         // READ CAPACITY
         doReadCapacity();
+    }
+    else if (unlikely(command == 0x9E))
+    {
+        // SERVICE ACTION IN(16)
+        if ((scsiDev.cdb[1] & 0x1F) == 0x10)
+        {
+            // READ CAPACITY(16)
+            doReadCapacity16();
+        }
+        else
+        {
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = ILLEGAL_REQUEST;
+            scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+            scsiDev.phase = STATUS;
+        }
     }
     else if (unlikely(command == 0x0B))
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1981,8 +1981,9 @@ static struct {
 } g_disk_transfer;
 
 static struct {
-    bool active;
-} g_disk_verify;
+    bool verify;
+    bool write_and_verify;
+} g_disk_data_out;
 
 /***********************************/
 /* Prefetch buffer for read access */
@@ -2152,16 +2153,17 @@ void scsiDiskStartWrite(uint32_t lba, uint32_t blocks)
     }
 }
 
-static void diskVerifyStop()
+static void diskSpecialDataOutStop()
 {
-    g_disk_verify.active = false;
+    g_disk_data_out.verify = false;
+    g_disk_data_out.write_and_verify = false;
     scsiDev.dataPtr = 0;
     scsiDev.dataLen = 0;
 }
 
-static void diskVerifyError(uint8_t sense_code, uint16_t asc)
+static void diskSpecialDataOutError(uint8_t sense_code, uint16_t asc)
 {
-    diskVerifyStop();
+    diskSpecialDataOutStop();
     scsiDev.status = CHECK_CONDITION;
     scsiDev.target->sense.code = sense_code;
     scsiDev.target->sense.asc = asc;
@@ -2195,6 +2197,8 @@ static void scsiDiskStartVerify(uint32_t lba, uint32_t blocks)
     else if (blocks == 0)
     {
         // No data phase and no medium access are required.
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
     }
     else
     {
@@ -2205,12 +2209,82 @@ static void scsiDiskStartVerify(uint32_t lba, uint32_t blocks)
         scsiDev.phase = DATA_OUT;
         scsiDev.dataLen = 0;
         scsiDev.dataPtr = 0;
-        g_disk_verify.active = true;
+        g_disk_data_out.verify = true;
+        g_disk_data_out.write_and_verify = false;
 
         if (!img.file.seek((uint64_t)transfer.lba * bytesPerSector))
         {
             logmsg("Seek to ", transfer.lba, " failed for SCSI ID", (int)scsiDev.target->targetId);
-            diskVerifyError(MEDIUM_ERROR, NO_SEEK_COMPLETE);
+            diskSpecialDataOutError(MEDIUM_ERROR, NO_SEEK_COMPLETE);
+        }
+    }
+}
+
+static void scsiDiskStartWriteAndVerify(uint32_t lba, uint32_t blocks)
+{
+    if (unlikely(scsiDev.target->cfg->deviceType == S2S_CFG_FLOPPY_14MB)) {
+        // Floppies are supposed to be slow. Some systems can't handle a floppy
+        // without an access time
+        s2s_delay_ms(10);
+    }
+
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint32_t capacity = img.file.size() / bytesPerSector;
+
+    dbgmsg("------ Write and verify ", (int)blocks, "x", (int)bytesPerSector, " starting at ", (int)lba);
+
+    if (unlikely(blockDev.state & DISK_WP) ||
+        unlikely(scsiDev.target->cfg->deviceType == S2S_CFG_OPTICAL) ||
+        unlikely(!img.file.isWritable()) ||
+        unlikely(img.ejectFixedDiskWriteBlocked))
+    {
+        logmsg("WARNING: Host attempted WRITE AND VERIFY to read-only drive ID ", (int)(img.scsiId & S2S_CFG_TARGET_ID_BITS));
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = WRITE_PROTECTED;
+        scsiDev.phase = STATUS;
+    }
+    else if (unlikely(((uint64_t) lba) + blocks > capacity))
+    {
+        logmsg("WARNING: Host attempted WRITE AND VERIFY at sector ", (int)lba, "+", (int)blocks,
+              ", exceeding image size ", (int)capacity, " sectors (",
+              (int)bytesPerSector, "B/sector)");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+        scsiDev.phase = STATUS;
+    }
+    else if (blocks == 0)
+    {
+        // No data phase and no medium access are required.
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
+    }
+    else
+    {
+        transfer.multiBlock = true;
+        transfer.lba = lba;
+        transfer.blocks = blocks;
+        transfer.currentBlock = 0;
+        scsiDev.phase = DATA_OUT;
+        scsiDev.dataLen = 0;
+        scsiDev.dataPtr = 0;
+        g_disk_data_out.verify = false;
+        g_disk_data_out.write_and_verify = true;
+
+        scsiDiskPrefetchInvalidate(scsiDev.target->targetId);
+
+        if (img.ejectFixedDiskPending)
+        {
+            // Reset timer due to write access
+            img.ejectFixedDiskTimer = millis();
+        }
+
+        if (!img.file.seek((uint64_t)transfer.lba * bytesPerSector))
+        {
+            logmsg("Seek to ", transfer.lba, " failed for SCSI ID", (int)scsiDev.target->targetId);
+            diskSpecialDataOutError(MEDIUM_ERROR, NO_SEEK_COMPLETE);
         }
     }
 }
@@ -2243,6 +2317,11 @@ static void scsiDiskHandleVerify(uint64_t lba, uint32_t blocks, bool compareData
         scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
         scsiDev.phase = STATUS;
     }
+    else
+    {
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
+    }
 }
 
 static void diskVerifyDataOut()
@@ -2271,7 +2350,7 @@ static void diskVerifyDataOut()
     scsiRead(compareBuffer, chunkBytes, &parityError);
     if (parityError && (scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY))
     {
-        diskVerifyError(ABORTED_COMMAND, SCSI_PARITY_ERROR);
+        diskSpecialDataOutError(ABORTED_COMMAND, SCSI_PARITY_ERROR);
         return;
     }
 
@@ -2279,7 +2358,7 @@ static void diskVerifyDataOut()
     {
         logmsg("SD card read failed during VERIFY at sector ", (int)(transfer.lba + transfer.currentBlock),
               " SCSI ID", (int)scsiDev.target->targetId, " error ", SD.sdErrorCode());
-        diskVerifyError(MEDIUM_ERROR, UNRECOVERED_READ_ERROR);
+        diskSpecialDataOutError(MEDIUM_ERROR, UNRECOVERED_READ_ERROR);
         return;
     }
 
@@ -2292,7 +2371,7 @@ static void diskVerifyDataOut()
             uint32_t failingLba = transfer.lba + transfer.currentBlock + block;
             transfer.lba = failingLba;
             scsiDev.target->sense.info = failingLba;
-            diskVerifyError(MISCOMPARE, MISCOMPARE_DURING_VERIFY_OPERATION);
+            diskSpecialDataOutError(MISCOMPARE, MISCOMPARE_DURING_VERIFY_OPERATION);
             return;
         }
     }
@@ -2302,7 +2381,89 @@ static void diskVerifyDataOut()
 
     if (transfer.currentBlock == transfer.blocks)
     {
-        diskVerifyStop();
+        diskSpecialDataOutStop();
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
+    }
+}
+
+static void diskWriteVerifyDataOut()
+{
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint32_t halfBufferSize = sizeof(scsiDev.data) / 2;
+    uint32_t remainingBlocks = transfer.blocks - transfer.currentBlock;
+    uint32_t maxBlocksPerChunk = halfBufferSize / bytesPerSector;
+    if (maxBlocksPerChunk == 0)
+    {
+        maxBlocksPerChunk = 1;
+    }
+    uint32_t chunkBlocks = remainingBlocks;
+    if (chunkBlocks > maxBlocksPerChunk)
+    {
+        chunkBlocks = maxBlocksPerChunk;
+    }
+    uint32_t chunkBytes = chunkBlocks * bytesPerSector;
+    uint32_t chunkLba = transfer.lba + transfer.currentBlock;
+    uint64_t chunkOffset = (uint64_t)chunkLba * bytesPerSector;
+    uint8_t *writeBuffer = scsiDev.data;
+    uint8_t *verifyBuffer = scsiDev.data + halfBufferSize;
+
+    scsiEnterPhase(DATA_OUT);
+
+    int parityError = 0;
+    scsiRead(writeBuffer, chunkBytes, &parityError);
+    if (parityError && (scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY))
+    {
+        diskSpecialDataOutError(ABORTED_COMMAND, SCSI_PARITY_ERROR);
+        return;
+    }
+
+    if (img.file.write(writeBuffer, chunkBytes) != chunkBytes)
+    {
+        logmsg("SD card write failed during WRITE AND VERIFY at sector ", (int)chunkLba,
+              " SCSI ID", (int)scsiDev.target->targetId, " error ", SD.sdErrorCode());
+        diskSpecialDataOutError(MEDIUM_ERROR, WRITE_ERROR_AUTO_REALLOCATION_FAILED);
+        return;
+    }
+
+    img.file.flush();
+
+    if (!img.file.seek(chunkOffset))
+    {
+        logmsg("Seek to ", chunkLba, " failed during WRITE AND VERIFY for SCSI ID ", (int)scsiDev.target->targetId);
+        diskSpecialDataOutError(MEDIUM_ERROR, NO_SEEK_COMPLETE);
+        return;
+    }
+
+    if (img.file.read(verifyBuffer, chunkBytes) != chunkBytes)
+    {
+        logmsg("SD card read failed during WRITE AND VERIFY at sector ", (int)chunkLba,
+              " SCSI ID", (int)scsiDev.target->targetId, " error ", SD.sdErrorCode());
+        diskSpecialDataOutError(MEDIUM_ERROR, UNRECOVERED_READ_ERROR);
+        return;
+    }
+
+    for (uint32_t block = 0; block < chunkBlocks; block++)
+    {
+        uint8_t *writeSector = writeBuffer + block * bytesPerSector;
+        uint8_t *verifySector = verifyBuffer + block * bytesPerSector;
+        if (memcmp(writeSector, verifySector, bytesPerSector) != 0)
+        {
+            uint32_t failingLba = chunkLba + block;
+            transfer.lba = failingLba;
+            scsiDev.target->sense.info = failingLba;
+            diskSpecialDataOutError(MISCOMPARE, MISCOMPARE_DURING_VERIFY_OPERATION);
+            return;
+        }
+    }
+
+    transfer.currentBlock += chunkBlocks;
+    platform_reset_watchdog();
+
+    if (transfer.currentBlock == transfer.blocks)
+    {
+        diskSpecialDataOutStop();
         scsiDev.status = GOOD;
         scsiDev.phase = STATUS;
     }
@@ -2787,7 +2948,8 @@ int scsiDiskCommand()
     int commandHandled = 1;
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
 
-    g_disk_verify.active = false;
+    g_disk_data_out.verify = false;
+    g_disk_data_out.write_and_verify = false;
 
     uint8_t command = scsiDev.cdb[0];
     if (unlikely(command == 0x1B))
@@ -2963,11 +3125,62 @@ int scsiDiskCommand()
     else if (unlikely(command == 0x2E || command == 0xAE || command == 0x8E))
     {
         // WRITE AND VERIFY
-        // Do not claim success unless verify semantics are actually implemented.
-        scsiDev.status = CHECK_CONDITION;
-        scsiDev.target->sense.code = ILLEGAL_REQUEST;
-        scsiDev.target->sense.asc = INVALID_COMMAND_OPERATION_CODE;
-        scsiDev.phase = STATUS;
+        uint64_t lba = 0;
+        uint32_t blocks = 0;
+
+        if (command == 0x2E)
+        {
+            lba =
+                (((uint32_t) scsiDev.cdb[2]) << 24) +
+                (((uint32_t) scsiDev.cdb[3]) << 16) +
+                (((uint32_t) scsiDev.cdb[4]) << 8) +
+                scsiDev.cdb[5];
+            blocks =
+                (((uint32_t) scsiDev.cdb[7]) << 8) +
+                scsiDev.cdb[8];
+        }
+        else if (command == 0xAE)
+        {
+            lba =
+                (((uint32_t) scsiDev.cdb[2]) << 24) +
+                (((uint32_t) scsiDev.cdb[3]) << 16) +
+                (((uint32_t) scsiDev.cdb[4]) << 8) +
+                scsiDev.cdb[5];
+            blocks =
+                (((uint32_t) scsiDev.cdb[6]) << 24) +
+                (((uint32_t) scsiDev.cdb[7]) << 16) +
+                (((uint32_t) scsiDev.cdb[8]) << 8) +
+                scsiDev.cdb[9];
+        }
+        else
+        {
+            lba =
+                (((uint64_t) scsiDev.cdb[2]) << 56) +
+                (((uint64_t) scsiDev.cdb[3]) << 48) +
+                (((uint64_t) scsiDev.cdb[4]) << 40) +
+                (((uint64_t) scsiDev.cdb[5]) << 32) +
+                (((uint64_t) scsiDev.cdb[6]) << 24) +
+                (((uint64_t) scsiDev.cdb[7]) << 16) +
+                (((uint64_t) scsiDev.cdb[8]) << 8) +
+                scsiDev.cdb[9];
+            blocks =
+                (((uint32_t) scsiDev.cdb[10]) << 24) +
+                (((uint32_t) scsiDev.cdb[11]) << 16) +
+                (((uint32_t) scsiDev.cdb[12]) << 8) +
+                scsiDev.cdb[13];
+        }
+
+        if (lba > UINT32_MAX)
+        {
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = ILLEGAL_REQUEST;
+            scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+            scsiDev.phase = STATUS;
+        }
+        else
+        {
+            scsiDiskStartWriteAndVerify((uint32_t)lba, blocks);
+        }
     }
     else if (unlikely(command == 0x04))
     {
@@ -3153,7 +3366,11 @@ void scsiDiskPoll()
     else if (scsiDev.phase == DATA_OUT &&
         transfer.currentBlock != transfer.blocks)
     {
-        if (g_disk_verify.active)
+        if (g_disk_data_out.write_and_verify)
+        {
+            diskWriteVerifyDataOut();
+        }
+        else if (g_disk_data_out.verify)
         {
             diskVerifyDataOut();
         }
@@ -3201,7 +3418,8 @@ void scsiDiskReset()
     transfer.blocks = 0;
     transfer.currentBlock = 0;
     transfer.multiBlock = 0;
-    g_disk_verify.active = false;
+    g_disk_data_out.verify = false;
+    g_disk_data_out.write_and_verify = false;
 
     scsiDiskPrefetchInvalidate();
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1980,6 +1980,10 @@ static struct {
     int parityError;
 } g_disk_transfer;
 
+static struct {
+    bool active;
+} g_disk_verify;
+
 /***********************************/
 /* Prefetch buffer for read access */
 /***********************************/
@@ -2145,6 +2149,132 @@ void scsiDiskStartWrite(uint32_t lba, uint32_t blocks)
             scsiDev.target->sense.asc = NO_SEEK_COMPLETE;
             scsiDev.phase = STATUS;
         }
+    }
+}
+
+static void diskVerifyStop()
+{
+    g_disk_verify.active = false;
+    scsiDev.dataPtr = 0;
+    scsiDev.dataLen = 0;
+}
+
+static void diskVerifyError(uint8_t sense_code, uint16_t asc)
+{
+    diskVerifyStop();
+    scsiDev.status = CHECK_CONDITION;
+    scsiDev.target->sense.code = sense_code;
+    scsiDev.target->sense.asc = asc;
+    scsiDev.phase = STATUS;
+}
+
+static void scsiDiskStartVerify(uint32_t lba, uint32_t blocks)
+{
+    if (unlikely(scsiDev.target->cfg->deviceType == S2S_CFG_FLOPPY_14MB)) {
+        // Floppies are supposed to be slow. Some systems can't handle a floppy
+        // without an access time
+        s2s_delay_ms(10);
+    }
+
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint32_t capacity = img.file.size() / bytesPerSector;
+
+    dbgmsg("------ Verify ", (int)blocks, "x", (int)bytesPerSector, " starting at ", (int)lba);
+
+    if (unlikely(((uint64_t) lba) + blocks > capacity))
+    {
+        logmsg("WARNING: Host attempted verify at sector ", (int)lba, "+", (int)blocks,
+              ", exceeding image size ", (int)capacity, " sectors (",
+              (int)bytesPerSector, "B/sector)");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+        scsiDev.phase = STATUS;
+    }
+    else if (blocks == 0)
+    {
+        // No data phase and no medium access are required.
+    }
+    else
+    {
+        transfer.multiBlock = true;
+        transfer.lba = lba;
+        transfer.blocks = blocks;
+        transfer.currentBlock = 0;
+        scsiDev.phase = DATA_OUT;
+        scsiDev.dataLen = 0;
+        scsiDev.dataPtr = 0;
+        g_disk_verify.active = true;
+
+        if (!img.file.seek((uint64_t)transfer.lba * bytesPerSector))
+        {
+            logmsg("Seek to ", transfer.lba, " failed for SCSI ID", (int)scsiDev.target->targetId);
+            diskVerifyError(MEDIUM_ERROR, NO_SEEK_COMPLETE);
+        }
+    }
+}
+
+static void diskVerifyDataOut()
+{
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint32_t compareBufferSize = sizeof(scsiDev.data) / 2;
+    uint32_t remainingBlocks = transfer.blocks - transfer.currentBlock;
+    uint32_t maxBlocksPerChunk = compareBufferSize / bytesPerSector;
+    if (maxBlocksPerChunk == 0)
+    {
+        maxBlocksPerChunk = 1;
+    }
+    uint32_t chunkBlocks = remainingBlocks;
+    if (chunkBlocks > maxBlocksPerChunk)
+    {
+        chunkBlocks = maxBlocksPerChunk;
+    }
+    uint32_t chunkBytes = chunkBlocks * bytesPerSector;
+    uint8_t *compareBuffer = scsiDev.data;
+    uint8_t *diskBuffer = scsiDev.data + compareBufferSize;
+
+    scsiEnterPhase(DATA_OUT);
+
+    int parityError = 0;
+    scsiRead(compareBuffer, chunkBytes, &parityError);
+    if (parityError && (scsiDev.boardCfg.flags & S2S_CFG_ENABLE_PARITY))
+    {
+        diskVerifyError(ABORTED_COMMAND, SCSI_PARITY_ERROR);
+        return;
+    }
+
+    if (img.file.read(diskBuffer, chunkBytes) != chunkBytes)
+    {
+        logmsg("SD card read failed during VERIFY at sector ", (int)(transfer.lba + transfer.currentBlock),
+              " SCSI ID", (int)scsiDev.target->targetId, " error ", SD.sdErrorCode());
+        diskVerifyError(MEDIUM_ERROR, UNRECOVERED_READ_ERROR);
+        return;
+    }
+
+    for (uint32_t block = 0; block < chunkBlocks; block++)
+    {
+        uint8_t *compareSector = compareBuffer + block * bytesPerSector;
+        uint8_t *diskSector = diskBuffer + block * bytesPerSector;
+        if (memcmp(compareSector, diskSector, bytesPerSector) != 0)
+        {
+            uint32_t failingLba = transfer.lba + transfer.currentBlock + block;
+            transfer.lba = failingLba;
+            scsiDev.target->sense.info = failingLba;
+            diskVerifyError(MISCOMPARE, MISCOMPARE_DURING_VERIFY_OPERATION);
+            return;
+        }
+    }
+
+    transfer.currentBlock += chunkBlocks;
+    platform_reset_watchdog();
+
+    if (transfer.currentBlock == transfer.blocks)
+    {
+        diskVerifyStop();
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
     }
 }
 
@@ -2627,6 +2757,8 @@ int scsiDiskCommand()
     int commandHandled = 1;
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
 
+    g_disk_verify.active = false;
+
     uint8_t command = scsiDev.cdb[0];
     if (unlikely(command == 0x1B))
     {
@@ -2899,21 +3031,32 @@ int scsiDiskCommand()
     else if (unlikely(command == 0x2F))
     {
         // VERIFY
-        // TODO: When they supply data to verify, we should read the data and
-        // verify it. If they don't supply any data, just say success.
+        uint32_t lba =
+            (((uint32_t) scsiDev.cdb[2]) << 24) +
+            (((uint32_t) scsiDev.cdb[3]) << 16) +
+            (((uint32_t) scsiDev.cdb[4]) << 8) +
+            scsiDev.cdb[5];
+        uint32_t blocks =
+            (((uint32_t) scsiDev.cdb[7]) << 8) +
+            scsiDev.cdb[8];
+
         if ((scsiDev.cdb[1] & 0x02) == 0)
         {
             // They are asking us to do a medium verification with no data
-            // comparison. Assume success, do nothing.
+            // comparison. We don't perform a real media scan yet, but still
+            // validate the requested LBA span.
+            uint32_t capacity = img.file.size() / scsiDev.target->liveCfg.bytesPerSector;
+            if (unlikely(((uint64_t) lba) + blocks > capacity))
+            {
+                scsiDev.status = CHECK_CONDITION;
+                scsiDev.target->sense.code = ILLEGAL_REQUEST;
+                scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+                scsiDev.phase = STATUS;
+            }
         }
         else
         {
-            // TODO. This means they are supplying data to verify against.
-            // Technically we should probably grab the data and compare it.
-            scsiDev.status = CHECK_CONDITION;
-            scsiDev.target->sense.code = ILLEGAL_REQUEST;
-            scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
-            scsiDev.phase = STATUS;
+            scsiDiskStartVerify(lba, blocks);
         }
     }
     else if (unlikely(command == 0x37))
@@ -2961,7 +3104,14 @@ void scsiDiskPoll()
     else if (scsiDev.phase == DATA_OUT &&
         transfer.currentBlock != transfer.blocks)
     {
-        diskDataOut();
+        if (g_disk_verify.active)
+        {
+            diskVerifyDataOut();
+        }
+        else
+        {
+            diskDataOut();
+        }
     }
 
     if (scsiDev.phase == STATUS && scsiDev.target)
@@ -3002,6 +3152,7 @@ void scsiDiskReset()
     transfer.blocks = 0;
     transfer.currentBlock = 0;
     transfer.multiBlock = 0;
+    g_disk_verify.active = false;
 
     scsiDiskPrefetchInvalidate();
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2289,6 +2289,87 @@ static void scsiDiskStartWriteAndVerify(uint32_t lba, uint32_t blocks)
     }
 }
 
+static void scsiDiskVerifyMedium(uint32_t lba, uint32_t blocks)
+{
+    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    uint32_t capacity = img.file.size() / bytesPerSector;
+
+    dbgmsg("------ Verify medium ", (int)blocks, "x", (int)bytesPerSector, " starting at ", (int)lba);
+
+    if (unlikely(((uint64_t) lba) + blocks > capacity))
+    {
+        logmsg("WARNING: Host attempted verify at sector ", (int)lba, "+", (int)blocks,
+              ", exceeding image size ", (int)capacity, " sectors (",
+              (int)bytesPerSector, "B/sector)");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
+        scsiDev.phase = STATUS;
+    }
+    else if (blocks == 0)
+    {
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
+    }
+    else
+    {
+        uint32_t maxBlocksPerChunk = sizeof(scsiDev.data) / bytesPerSector;
+        if (maxBlocksPerChunk == 0)
+        {
+            maxBlocksPerChunk = 1;
+        }
+
+        transfer.lba = lba;
+        if (!img.file.seek((uint64_t)lba * bytesPerSector))
+        {
+            logmsg("Seek to ", lba, " failed during VERIFY for SCSI ID ", (int)scsiDev.target->targetId);
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = MEDIUM_ERROR;
+            scsiDev.target->sense.asc = NO_SEEK_COMPLETE;
+            scsiDev.phase = STATUS;
+            return;
+        }
+
+        for (uint32_t verifiedBlocks = 0; verifiedBlocks < blocks; )
+        {
+            platform_poll();
+            diskEjectButtonUpdate(false);
+            if (scsiDev.resetFlag)
+            {
+                return;
+            }
+
+            uint32_t chunkBlocks = blocks - verifiedBlocks;
+            if (chunkBlocks > maxBlocksPerChunk)
+            {
+                chunkBlocks = maxBlocksPerChunk;
+            }
+            uint32_t chunkBytes = chunkBlocks * bytesPerSector;
+            if (img.file.read(scsiDev.data, chunkBytes) != chunkBytes)
+            {
+                uint32_t failingLba = lba + verifiedBlocks;
+                transfer.lba = failingLba;
+                scsiDev.target->sense.info = failingLba;
+                logmsg("SD card read failed during VERIFY at sector ", (int)failingLba,
+                      " SCSI ID", (int)scsiDev.target->targetId, " error ", SD.sdErrorCode());
+                scsiDev.status = CHECK_CONDITION;
+                scsiDev.target->sense.code = MEDIUM_ERROR;
+                scsiDev.target->sense.asc = UNRECOVERED_READ_ERROR;
+                scsiDev.phase = STATUS;
+                return;
+            }
+
+            verifiedBlocks += chunkBlocks;
+            transfer.lba = lba + verifiedBlocks;
+            platform_reset_watchdog();
+        }
+
+        scsiDev.status = GOOD;
+        scsiDev.phase = STATUS;
+    }
+}
+
 static void scsiDiskHandleVerify(uint64_t lba, uint32_t blocks, bool compareData)
 {
     if (lba > UINT32_MAX)
@@ -2306,22 +2387,7 @@ static void scsiDiskHandleVerify(uint64_t lba, uint32_t blocks, bool compareData
         return;
     }
 
-    // We do not perform a real media scan yet, but still validate the
-    // requested LBA span.
-    image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
-    uint32_t capacity = img.file.size() / scsiDev.target->liveCfg.bytesPerSector;
-    if (unlikely(lba + blocks > capacity))
-    {
-        scsiDev.status = CHECK_CONDITION;
-        scsiDev.target->sense.code = ILLEGAL_REQUEST;
-        scsiDev.target->sense.asc = LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE;
-        scsiDev.phase = STATUS;
-    }
-    else
-    {
-        scsiDev.status = GOOD;
-        scsiDev.phase = STATUS;
-    }
+    scsiDiskVerifyMedium((uint32_t)lba, blocks);
 }
 
 static void diskVerifyDataOut()

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -95,6 +95,7 @@ struct image_config_t: public S2S_TargetCfg
 
     // Previously accessed CD-ROM track, cached for performance
     CUETrackInfo cdrom_trackinfo;
+    uint32_t cdrom_track_end_lba;
 
     // Loaded .bin file index for .cue/.bin with multiple files
     // Matches trackinfo.file_index

--- a/src/ZuluSCSI_tape.cpp
+++ b/src/ZuluSCSI_tape.cpp
@@ -1590,14 +1590,14 @@ extern "C" int scsiTapeCommand()
             // Handle result
             if (result == TAP_END_OF_TAPE) {
                 scsiDev.target->sense.eom = true;
-                scsiDev.status = MEDIUM_ERROR;
+                scsiDev.status = CHECK_CONDITION;
                 scsiDev.target->sense.code = BLANK_CHECK;
                 scsiDev.target->sense.asc = NO_ADDITIONAL_SENSE_INFORMATION;
                 if (set_sense_info)
                     scsiDev.target->sense.info = count - actual;
                 scsiDev.phase = STATUS;
             } else if (result == TAP_BEGINNING_OF_TAPE) {
-                scsiDev.target->sense.eom = true;
+                scsiDev.target->sense.eom = false;
                 scsiDev.status = CHECK_CONDITION;
                 scsiDev.target->sense.code = NO_SENSE;
                 scsiDev.target->sense.asc = NO_ADDITIONAL_SENSE_INFORMATION;


### PR DESCRIPTION
Please help me sort through these and tell me which ones are worth
fixing/pursuing and which ones I should just forget about.

- **Fix tape SPACE status reporting**
- **Fix CD-ROM and disk command correctness**
- **Harden RP2 custom timing overrides**
- **Add 12-byte and 16-byte disk commands**
- **Align RP2 sync negotiation with target timing**
- **Reduce seek overhead in CD sector reads**
- **Fix RP2 timing log build error**
- **rp2mcu: allow Wi-Fi scans while already connected**
- **Calibrate RP2 short bus delays**
- **Implement disk VERIFY compare semantics**
- **Extend VERIFY command support**
- **Batch direct CD read transfers**
- **Implement WRITE AND VERIFY commands**
- **Implement medium VERIFY scans**
- **Implement target disconnect and reselection core support**
