### PR TITLE
Import initiator VHD support for hard drives and add VHD support to CREATE image generator

### DIFF
--- a/src/COWStorage.cpp
+++ b/src/COWStorage.cpp
@@ -26,7 +26,7 @@ static void allocateCOWBuffer()
 }
 
 //	Helper function: create a new image file of specified size if needed
-static bool createDirtyFile(const char *dirty_filename, uint64_t size)
+static bool createDirtyFile(char *dirty_filename, uint64_t size)
 {
     //  If file already exists and is same size or larger, do nothing
     FsFile file;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -64,6 +64,7 @@
 #include "ZuluSCSI_buffer_control.h"
 #include "ZuluSCSI_audio.h"
 #include "ROMDrive.h"
+#include "vhd_support.h"
 
 #include "ui.h"
 
@@ -249,7 +250,7 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
   return true;
 }
 
-bool createImageFile(const char *imgname, uint64_t size)
+bool createImageFile(char *imgname, uint64_t size)
 {
   int namelen = strlen(imgname);
 
@@ -262,9 +263,17 @@ bool createImageFile(const char *imgname, uint64_t size)
 
   // Create file, try to preallocate contiguous sectors
   LED_ON();
+  bool is_vhd_image = false;
+  uint64_t footer_size = 0;
+  // Check for vhd extention and add footer
+  if (namelen >= 4 && strncasecmp(imgname + namelen - 4, ".vhd", 4) == 0)
+  {
+    is_vhd_image = true;
+    footer_size = VHD_FOOTER_SIZE;
+  }
   FsFile file = SD.open(imgname, O_WRONLY | O_CREAT);
 
-  if (!file.preAllocate(size))
+  if (!file.preAllocate(size + footer_size))
   {
     logmsg("---- Preallocation didn't find contiguous set of clusters, continuing anyway");
   }
@@ -336,11 +345,53 @@ bool createImageFile(const char *imgname, uint64_t size)
 
   UICreateProgress(0, block);
 
-  file.close();
+  bool vhd_success = false;
+  if (is_vhd_image)
+  {
+
+    dbgmsg("---- Adding VHD footer");
+    int8_t id = scsiParseId(imgname[2]);
+    if (id >= 0)
+    {
+      uint32_t block_size = getBlockSize(imgname, id);
+      vhd_build_fixed_footer(scsiDev.data, size,
+                            size / block_size, 0,
+                            id);
+      if (file.write(scsiDev.data, VHD_FOOTER_SIZE) == VHD_FOOTER_SIZE)
+      {
+        vhd_success = true;
+      }
+    }
+  }
+
   uint32_t time = millis() - start;
   int kb_per_s = size / time;
-  logmsg("---- Image creation successful, write speed ", kb_per_s, " kB/s");
-
+  if (!is_vhd_image || vhd_success)
+  {
+    if (is_vhd_image && vhd_success)
+    {
+      logmsg("---- Image saved as VHD format");
+    }
+    logmsg("---- Image creation successful, write speed ", kb_per_s, " kB/s");
+  }
+  else
+  {
+    logmsg("---- Failed to write VHD footer");
+    if (file.truncate(size))
+    {
+      logmsg("---- Successfully recovered raw image without vhd footer, write speed was ", kb_per_s, " kB/s");
+      strncpy(imgname + namelen - 3, "raw", 3);
+      if (file.rename(imgname))
+      {
+        logmsg("---- Renamed image to \"", imgname, "\" to indicated the image is raw and doesn't contain a VHD footer");
+      }
+      else
+      {
+        logmsg("---- Warning: Unable to rename image \"", imgname, "\" to .raw, operation failed.");
+      }
+    }
+  }
+  file.close();
   LED_OFF();
   return true;
 }

--- a/src/ZuluSCSI.h
+++ b/src/ZuluSCSI.h
@@ -8,6 +8,7 @@ extern bool g_sdcard_present;
 extern SdFs SD;
 
 // Create an zero-filled image file of specified size -- update UI with progress
+//  If .vhd file footer fails to write renames extension to .raw
 //	Returns true if image created
 //	Returns false if file already exists or on error
-bool createImageFile(const char *imgname, uint64_t size);
+bool createImageFile(char *imgname, uint64_t size);

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1281,7 +1281,7 @@ void scsiDiskLoadConfig(int target_idx)
     }
 }
 
-uint32_t getBlockSize(char *filename, uint8_t scsi_id)
+uint32_t getBlockSize(const char *filename, uint8_t scsi_id)
 {
     // Parse block size (HD00_NNNN)
     uint32_t block_size = g_scsi_settings.getDevice(scsi_id)->blockSize;

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -151,7 +151,7 @@ void scsiDiskResetImages();
 void scsiDiskCloseSDCardImages();
 
 // Get blocksize from filename or use device setting in ini file
-uint32_t getBlockSize(char *filename, uint8_t scsi_id);
+uint32_t getBlockSize(const char *filename, uint8_t scsi_id);
 
 // AS/400 Related
 int16_t skip_next(int max);

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -1,5 +1,6 @@
 /**
- * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
+ * BlueSCSI - Copyright (c) 2026 Eric Helgeson, Androda*
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
  *
@@ -32,7 +33,7 @@
 #include <ZuluSCSI_platform.h>
 #include <minIni.h>
 #include "SdFat.h"
-
+#include "vhd_support.h"
 #include "ui.h"
 
 #include <scsi2sd.h>
@@ -103,6 +104,9 @@ static struct {
 
     uint32_t removable_count[8];
 
+    // VHD output format (opt-in via InitiatorVHD=1)
+    bool use_vhd_format;
+
     // Negotiated bus width for targets
     int targetBusWidth[S2S_MAX_TARGETS];
 
@@ -129,6 +133,7 @@ void scsiInitiatorInit()
     }
     g_initiator_state.max_retry_count = ini_getl("SCSI", "InitiatorMaxRetry", 5, CONFIGFILE);
     g_initiator_state.use_read10 = ini_getbool("SCSI", "InitiatorUseRead10", false, CONFIGFILE);
+    g_initiator_state.use_vhd_format = ini_getbool("SCSI", "InitiatorVHD", false, CONFIGFILE);
 
     // treat initiator id as already imaged drive so it gets skipped
     g_initiator_state.drives_imaged = 1 << g_initiator_state.initiator_id;
@@ -230,6 +235,14 @@ static int scsiTypeToIniType(int scsi_type, bool removable)
             break;
     }
     return ini_type;
+}
+
+// Check if VHD output should be used for the current target
+static bool initiatorShouldWriteVhd()
+{
+    return g_initiator_state.use_vhd_format &&
+           g_initiator_state.device_type == SCSI_DEVICE_TYPE_DIRECT_ACCESS &&
+           !g_initiator_state.removable;
 }
 
 // High level logic of the initiator mode
@@ -454,6 +467,12 @@ void scsiInitiatorMainLoop()
                     strncpy(filename_base, "RM00_imaged", sizeof(filename_base));
                     filename_extension = ".img";
                 }
+
+                if (initiatorShouldWriteVhd())
+                {
+                    filename_extension = ".vhd";
+                    logmsg("VHD output enabled for SCSI ID ", g_initiator_state.target_id);
+                }
             }
 
             if (g_initiator_state.eject_when_done && g_initiator_state.removable_count[g_initiator_state.target_id] == 0)
@@ -547,8 +566,9 @@ void scsiInitiatorMainLoop()
                     return;
                 }
 
+                uint64_t vhd_overhead = initiatorShouldWriteVhd() ? VHD_FOOTER_SIZE : 0;
                 uint64_t sd_card_free_bytes = (uint64_t)SD.vol()->freeClusterCount() * SD.vol()->bytesPerCluster();
-                if (sd_card_free_bytes < total_bytes)
+                if (sd_card_free_bytes < total_bytes + vhd_overhead)
                 {
                     // GT TODO
                     logmsg("SD Card only has ", (int)(sd_card_free_bytes / (1024 * 1024)),
@@ -569,7 +589,9 @@ void scsiInitiatorMainLoop()
                     // Only preallocate on exFAT, on FAT32 preallocating can result in false garbage data in the
                     // file if write is interrupted.
                     logmsg("Preallocating image file");
-                    g_initiator_state.target_file.preAllocate((uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize);
+                    g_initiator_state.target_file.preAllocate(
+                        (uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize + vhd_overhead
+                    );
                 }
 
                 UIInitiatorTargetFilename(g_initiator_state.target_id, filename);
@@ -610,6 +632,26 @@ void scsiInitiatorMainLoop()
                 logmsg("Marking SCSI ID, ", g_initiator_state.target_id, ", as imaged, wont ask it again.");
                 g_initiator_state.drives_imaged |= (1 << g_initiator_state.target_id);
             }
+
+            // Write VHD footer if enabled for this target
+            if (initiatorShouldWriteVhd())
+            {
+                uint64_t raw_bytes = (uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize;
+                uint8_t vhd_footer[VHD_FOOTER_SIZE];
+                // Use 0 for timestamp — embedded device has no RTC epoch reference
+                vhd_build_fixed_footer(vhd_footer, raw_bytes,
+                                       g_initiator_state.sectorcount, 0,
+                                       g_initiator_state.target_id);
+                if (g_initiator_state.target_file.write(vhd_footer, VHD_FOOTER_SIZE) == VHD_FOOTER_SIZE)
+                {
+                    logmsg("VHD footer written successfully");
+                }
+                else
+                {
+                    logmsg("WARNING: Failed to write VHD footer");
+                }
+            }
+
 
             g_initiator_state.imaging = false;
             g_initiator_state.target_file.close();

--- a/src/vhd_support.cpp
+++ b/src/vhd_support.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 Eric Helgeson
+ *
+ * BlueSCSI - Fixed VHD footer generation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#include "vhd_support.h"
+#include <string.h>
+
+/* Write a big-endian uint16 to buffer */
+static void write_be16(uint8_t *p, uint16_t val) {
+    p[0] = (uint8_t)(val >> 8);
+    p[1] = (uint8_t)(val);
+}
+
+/* Write a big-endian uint32 to buffer */
+static void write_be32(uint8_t *p, uint32_t val) {
+    p[0] = (uint8_t)(val >> 24);
+    p[1] = (uint8_t)(val >> 16);
+    p[2] = (uint8_t)(val >> 8);
+    p[3] = (uint8_t)(val);
+}
+
+/* Write a big-endian uint64 to buffer */
+static void write_be64(uint8_t *p, uint64_t val) {
+    write_be32(p, (uint32_t)(val >> 32));
+    write_be32(p + 4, (uint32_t)(val));
+}
+
+uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len)
+{
+    uint32_t sum = 0;
+    for (size_t i = 0; i < len; i++) {
+        sum += footer[i];
+    }
+    return ~sum;
+}
+
+vhd_geometry_t vhd_compute_geometry(uint64_t total_bytes)
+{
+    /*
+     * Microsoft VHD Specification geometry algorithm.
+     * Input: total disk size in bytes.
+     * The algorithm works on 512-byte sector count.
+     */
+    vhd_geometry_t geo;
+    uint32_t totalSectors = (uint32_t)(total_bytes / 512);
+
+    /* Cap at maximum CHS addressable sectors */
+    if (totalSectors > 65535U * 16 * 255) {
+        totalSectors = 65535U * 16 * 255;
+    }
+
+    uint32_t cylinderTimesHeads;
+    uint32_t heads;
+    uint32_t sectorsPerTrack;
+
+    if (totalSectors >= 65535U * 16 * 63) {
+        sectorsPerTrack = 255;
+        heads = 16;
+        cylinderTimesHeads = totalSectors / sectorsPerTrack;
+    } else {
+        sectorsPerTrack = 17;
+        cylinderTimesHeads = totalSectors / sectorsPerTrack;
+
+        heads = (cylinderTimesHeads + 1023) / 1024;
+        if (heads < 4) {
+            heads = 4;
+        }
+
+        if (cylinderTimesHeads >= (heads * 1024) || heads > 16) {
+            sectorsPerTrack = 31;
+            heads = 16;
+            cylinderTimesHeads = totalSectors / sectorsPerTrack;
+        }
+
+        if (cylinderTimesHeads >= (heads * 1024)) {
+            sectorsPerTrack = 63;
+            heads = 16;
+            cylinderTimesHeads = totalSectors / sectorsPerTrack;
+        }
+    }
+
+    uint32_t cyl32 = cylinderTimesHeads / heads;
+    if (cyl32 > 65535) {
+        cyl32 = 65535;
+    }
+
+    geo.cylinders = (uint16_t)cyl32;
+    geo.heads = (uint8_t)heads;
+    geo.sectors_per_track = (uint8_t)sectorsPerTrack;
+    return geo;
+}
+
+/*
+ * Simple deterministic hash for UUID generation.
+ * Mixes timestamp, SCSI ID, and disk size into 16 bytes.
+ * Uses a basic multiplicative hash (FNV-1a inspired).
+ */
+static void vhd_generate_uuid(uint8_t *uuid, uint32_t timestamp,
+                               uint8_t scsi_id, uint64_t total_bytes)
+{
+    /* Seed with input data packed into a buffer */
+    uint8_t seed[16];
+    memset(seed, 0, sizeof(seed));
+    write_be32(&seed[0], timestamp);
+    seed[4] = scsi_id;
+    write_be64(&seed[5], total_bytes);
+    /* seed[13..15] remain zero, providing padding */
+
+    /* FNV-1a-like mixing to produce 16 bytes */
+    uint32_t h0 = 0x811C9DC5U;
+    uint32_t h1 = 0x01000193U;
+    uint32_t h2 = 0xDEADBEEFU;
+    uint32_t h3 = 0xCAFEBABEU;
+
+    for (int i = 0; i < 16; i++) {
+        h0 ^= seed[i];
+        h0 *= 0x01000193U;
+        h1 ^= seed[(i + 3) % 16];
+        h1 *= 0x01000193U;
+        h2 ^= seed[(i + 7) % 16];
+        h2 *= 0x01000193U;
+        h3 ^= seed[(i + 11) % 16];
+        h3 *= 0x01000193U;
+    }
+
+    write_be32(&uuid[0], h0);
+    write_be32(&uuid[4], h1);
+    write_be32(&uuid[8], h2);
+    write_be32(&uuid[12], h3);
+}
+
+void vhd_build_fixed_footer(uint8_t *footer, uint64_t total_bytes,
+                             uint32_t sectorcount, uint32_t timestamp,
+                             uint8_t scsi_id)
+{
+    (void)sectorcount; /* Reserved for future use / geometry fallback */
+
+    /* Zero entire footer first */
+    memset(footer, 0, VHD_FOOTER_SIZE);
+
+    /* Offset 0: Cookie "conectix" */
+    memcpy(&footer[0], "conectix", 8);
+
+    /* Offset 8: Features (0x00000002 = reserved, always set) */
+    write_be32(&footer[8], 0x00000002);
+
+    /* Offset 12: File Format Version (1.0) */
+    write_be32(&footer[12], 0x00010000);
+
+    /* Offset 16: Data Offset (fixed disk = no dynamic header) */
+    write_be64(&footer[16], 0xFFFFFFFFFFFFFFFFULL);
+
+    /* Offset 24: Time Stamp */
+    write_be32(&footer[24], timestamp);
+
+    /* Offset 28: Creator Application */
+    memcpy(&footer[28], "bsci", 4);
+
+    /* Offset 32: Creator Version (1.0) */
+    write_be32(&footer[32], 0x00010000);
+
+    /* Offset 36: Creator Host OS ("Wi2k" = Windows) */
+    memcpy(&footer[36], "Wi2k", 4);
+
+    /* Offset 40: Original Size */
+    write_be64(&footer[40], total_bytes);
+
+    /* Offset 48: Current Size */
+    write_be64(&footer[48], total_bytes);
+
+    /* Offset 56: Disk Geometry (CHS) */
+    vhd_geometry_t geo = vhd_compute_geometry(total_bytes);
+    write_be16(&footer[56], geo.cylinders);
+    footer[58] = geo.heads;
+    footer[59] = geo.sectors_per_track;
+
+    /* Offset 60: Disk Type (2 = Fixed) */
+    write_be32(&footer[60], 0x00000002);
+
+    /* Offset 64: Checksum — must be computed last */
+    /* Leave as zero for now */
+
+    /* Offset 68: Unique Id (16 bytes) */
+    vhd_generate_uuid(&footer[68], timestamp, scsi_id, total_bytes);
+
+    /* Offset 84: Saved State = 0 (already zeroed) */
+    /* Offset 85-511: Reserved = 0 (already zeroed) */
+
+    /* Now compute and store checksum */
+    uint32_t checksum = vhd_compute_checksum(footer, VHD_FOOTER_SIZE);
+    write_be32(&footer[64], checksum);
+}

--- a/src/vhd_support.h
+++ b/src/vhd_support.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Eric Helgeson
+ *
+ * BlueSCSI - Fixed VHD footer generation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define VHD_FOOTER_SIZE 512
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* CHS geometry as returned by vhd_compute_geometry */
+typedef struct {
+    uint16_t cylinders;
+    uint8_t heads;
+    uint8_t sectors_per_track;
+} vhd_geometry_t;
+
+/**
+ * Build a complete 512-byte Fixed VHD footer.
+ *
+ * @param footer      Output buffer, must be at least VHD_FOOTER_SIZE bytes
+ * @param total_bytes Raw disk data size in bytes
+ * @param sectorcount Number of SCSI sectors (used for geometry fallback)
+ * @param timestamp   Seconds since 2000-01-01 00:00:00 UTC
+ * @param scsi_id     SCSI target ID (used in UUID generation)
+ */
+void vhd_build_fixed_footer(uint8_t *footer, uint64_t total_bytes,
+                             uint32_t sectorcount, uint32_t timestamp,
+                             uint8_t scsi_id);
+
+/**
+ * Compute CHS geometry per the Microsoft VHD specification algorithm.
+ *
+ * @param total_bytes Raw disk data size in bytes
+ * @return CHS geometry struct
+ */
+vhd_geometry_t vhd_compute_geometry(uint64_t total_bytes);
+
+/**
+ * Compute the VHD one's complement checksum over a 512-byte footer.
+ * The 4 checksum bytes at offset 64-67 must be zero during computation.
+ *
+ * @param footer Footer buffer (512 bytes)
+ * @param len    Length of footer (should be VHD_FOOTER_SIZE)
+ * @return One's complement of the sum of all bytes
+ */
+uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -62,7 +62,7 @@
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
 #InitiatorMSCStatusInterval = 5000 # Periodically report access status to log
 #InitiatorMSCInitDelay = 500 # In milliseconds, gives time for USB serial to configure itself
-
+#InitiatorVHD = 0 # Set to 1 for hard drives to be imaged as fixed VHD images
 # On RP2040 based boards and v1.2 the audio disabled by default
 # On Blasters audio is enabled by default
 #EnableCDAudio = 0 # 1: Enable CD audio


### PR DESCRIPTION
### Initiator VHD Support
Setting `InitiatorVHD = 1` in the `[SCSI]` section of zuluide.ini will cause any imaged hard drives to be created as a Microsoft fixed VHD (version1) image file. This will allow the resulting VHD image to be mounted in systems and emulators that support VHD disk images, including modern versions of Windows, without the need of additional or third-party software. 

### VHD support for the CREATE image generator 

It is possible to create an image by making a zero byte filename
like "CREATE 123M HD1 - my file.txt" to create a 123 MB image file named "CREATE 123M HD1 - my file.img".

Now if the same file with the extension `.vhd` is made ("CREATE 123M HD1 - my file.vhd") the ZuluSCSI will create a VHD file called "HD1 - myfile.vhd".

If for some reason the footer can not be added, the ZuluSCSI will attempt to rename the file to "HD1 - my file.raw" indicating the file does not have a VHD footer. The error will be logged in the `zululog.txt` file. This is done because large images can take a while to create and the image can still be converted to a VHD with other software.