### PR TITLE
RP2MCU: Fix FAST-20 regression by reverting fd45a1e

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -87,8 +87,6 @@ extern "C" {
 extern bool g_rebooting;
 const char *g_platform_name = PLATFORM_NAME;
 bool g_scsi_initiator = false;
-uint32_t g_platform_sys_clock_hz = 125000000;
-uint32_t g_platform_delay_100ns_cycles = 13;
 static uint32_t g_flash_chip_size = 0;
 static bool g_uart_initialized = false;
 static bool g_led_blinking = false;
@@ -196,13 +194,6 @@ static void reclock() {
         uart_init(uart0, 1000000);
 }
 
-void platform_update_delay_calibration(void)
-{
-    g_platform_sys_clock_hz = platform_sys_clock_in_hz();
-    uint64_t cycles = ((uint64_t)g_platform_sys_clock_hz * 100ULL + 999999999ULL) / 1000000000ULL;
-    g_platform_delay_100ns_cycles = cycles > 0 ? (uint32_t)cycles : 1;
-}
-
 uint32_t platform_sys_clock_in_hz()
 {
     return clock_get_hz(clk_sys);
@@ -220,7 +211,8 @@ bool platform_reclock(zuluscsi_speed_grade_t speed_grade)
             {
 
                 logmsg("Using custom timings found in \"", CUSTOM_TIMINGS_FILE, "\" for reclocking");
-                do_reclock = ct.set_timings_from_file();
+                ct.set_timings_from_file();
+                do_reclock = true;
             }
             else
             {
@@ -245,7 +237,6 @@ bool platform_reclock(zuluscsi_speed_grade_t speed_grade)
 #endif
             usb_log_poll();
             reclock();
-            platform_update_delay_calibration();
             logmsg("After reclocking, system reports clock set to ", (int) platform_sys_clock_in_hz(), "Hz");
         }
     }
@@ -404,12 +395,6 @@ void platform_init()
 {
     // Make sure second core is stopped
     multicore_reset_core1();
-
-    platform_update_delay_calibration();
-
-    // Keep negotiated sync limits aligned with the currently selected timing set
-    // even when no explicit reclocking profile is applied.
-    update_sync_period_limits();
 
 #ifdef ZULUSCSI_MCU_RP23XX
     // Set stack overflow limit, with space reserved for exception entry

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -25,7 +25,6 @@
 
 #include <stdint.h>
 #include <Arduino.h>
-#include <pico/platform.h>
 #include "ZuluSCSI_config.h"
 #include "ZuluSCSI_platform_network.h"
 #include <ZuluSCSI_settings.h>
@@ -73,29 +72,17 @@ bool platform_emergency_log_save();
 // Arduino platform already provides these
 unsigned long millis(void);
 void delay(unsigned long ms);
-extern uint32_t g_platform_sys_clock_hz;
-extern uint32_t g_platform_delay_100ns_cycles;
-void platform_update_delay_calibration(void);
 
 // Short delays, can be called from interrupt mode
 static inline void delay_ns(unsigned long ns)
 {
-    if (ns >= 1000000UL)
-    {
-        delayMicroseconds((ns + 999) / 1000);
-        return;
-    }
-
-    uint64_t cycles = ((uint64_t)g_platform_sys_clock_hz * ns + 999999999ULL) / 1000000000ULL;
-    if (cycles > 0)
-    {
-        busy_wait_at_least_cycles((uint32_t)cycles);
-    }
+    delayMicroseconds((ns + 999) / 1000);
 }
 
+// Approximate fast delay
 static inline void delay_100ns()
 {
-    busy_wait_at_least_cycles(g_platform_delay_100ns_cycles);
+    asm volatile ("nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop");
 }
 
 // Initialize SD card and GPIO configuration

--- a/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/custom_timings.cpp
@@ -31,21 +31,6 @@ extern "C"
     #include <timings.h>
 }
 
-static bool readIniIntRange(const char *section, const char *key, int32_t current,
-    int32_t min_value, int32_t max_value, int32_t *out)
-{
-    int32_t value = ini_getl(section, key, current, CUSTOM_TIMINGS_FILE);
-    if (value < min_value || value > max_value)
-    {
-        logmsg("Invalid value for [", section, "] ", key, " in ", CUSTOM_TIMINGS_FILE,
-            ": ", (int)value, " (expected ", (int)min_value, "..", (int)max_value, ")");
-        return false;
-    }
-
-    *out = value;
-    return true;
-}
-
 bool CustomTimings::use_custom_timings()
 {
     return SD.exists(CUSTOM_TIMINGS_FILE) && !ini_getbool("settings", "disable", 0, CUSTOM_TIMINGS_FILE);
@@ -62,161 +47,83 @@ bool CustomTimings::set_timings_from_file()
     const char sdio_section[] = "sdio";
     const char audio_section[] = "audio";
 
+    // pll
+    int32_t vco = ini_getl(pll_section, "vco_freq_hz", g_zuluscsi_timings->pll.vco_freq, CUSTOM_TIMINGS_FILE);
+    int32_t post_div1 = ini_getl(pll_section, "pd1", g_zuluscsi_timings->pll.post_div1, CUSTOM_TIMINGS_FILE);
+    int32_t post_div2 = ini_getl(pll_section, "pd2", g_zuluscsi_timings->pll.post_div2, CUSTOM_TIMINGS_FILE);
+
+    if (vco > 0 && post_div1 > 0 && post_div2 > 0)
+    {
+        if (vco / post_div1 / post_div2 > 252000000)
+        {
+            logmsg("Reclocking over 252MHz with the PLL settings is not allowed using ", CUSTOM_TIMINGS_FILE);
+            return false;
+        }
+    }
+    else
+    {
+        logmsg("Reclocking failed because 0 or negative PLL settings values");
+        return false;
+    }
+
+    g_zuluscsi_timings->pll.vco_freq = vco;
+    g_zuluscsi_timings->pll.post_div1 = post_div1;
+    g_zuluscsi_timings->pll.post_div2 = post_div2;
+    g_zuluscsi_timings->pll.refdiv =  ini_getl(pll_section, "refdiv", g_zuluscsi_timings->pll.refdiv, CUSTOM_TIMINGS_FILE);
+
     char speed_grade_str[10];
     ini_gets(settings_section, "extends_speed_grade", "Default", speed_grade_str, sizeof(speed_grade_str), CUSTOM_TIMINGS_FILE);
     zuluscsi_speed_grade_t speed_grade =  g_scsi_settings.stringToSpeedGrade(speed_grade_str, sizeof(speed_grade_str));
     set_timings(speed_grade);
 
-    zuluscsi_timings_t candidate = *g_zuluscsi_timings;
-    uint8_t force_sync = g_force_sync;
-    uint8_t force_offset = g_force_offset;
-
-    int32_t number_setting = 0;
-    if (!readIniIntRange(settings_section, "boot_with_sync_value", 0, 0, 255, &number_setting))
-    {
-        return false;
-    }
+    int32_t number_setting = ini_getl(settings_section, "boot_with_sync_value", 0, CUSTOM_TIMINGS_FILE);
 
     if (number_setting > 0)
     {
-        force_sync = number_setting;
-        if (!readIniIntRange(settings_section, "boot_with_offset_value", 15, 0, 15, &number_setting))
-        {
-            return false;
-        }
-        force_offset = number_setting;
+        g_force_sync = number_setting;
+        number_setting = ini_getl(settings_section, "boot_with_offset_value", 15, CUSTOM_TIMINGS_FILE);
+        g_force_offset = number_setting > 15 ? 15 : number_setting;
+        logmsg("Forcing sync of ", (int) g_force_sync, " and offset of ", (int) g_force_offset);
     }
-    if (!readIniIntRange(settings_section, "clk_hz", candidate.clk_hz, 1, 252000000, &number_setting))
-    {
-        return false;
-    }
-    candidate.clk_hz = number_setting;
-    if (!readIniIntRange(pll_section, "refdiv", candidate.pll.refdiv, 1, 63, &number_setting))
-    {
-        return false;
-    }
-    candidate.pll.refdiv = number_setting;
-    if (!readIniIntRange(pll_section, "vco_freq_hz", candidate.pll.vco_freq, 1, 2000000000, &number_setting))
-    {
-        return false;
-    }
-    candidate.pll.vco_freq = number_setting;
-    if (!readIniIntRange(pll_section, "pd1", candidate.pll.post_div1, 1, 7, &number_setting))
-    {
-        return false;
-    }
-    candidate.pll.post_div1 = number_setting;
-    if (!readIniIntRange(pll_section, "pd2", candidate.pll.post_div2, 1, 7, &number_setting))
-    {
-        return false;
-    }
-    candidate.pll.post_div2 = number_setting;
-    uint32_t pll_output_hz = candidate.pll.vco_freq / candidate.pll.post_div1 / candidate.pll.post_div2;
-    if (pll_output_hz > 252000000)
-    {
-        logmsg("Reclocking over 252MHz with the PLL settings is not allowed using ", CUSTOM_TIMINGS_FILE);
-        return false;
-    }
-    if (pll_output_hz != candidate.clk_hz)
-    {
-        logmsg("PLL output clock ", (int)pll_output_hz, "Hz does not match clk_hz ",
-            (int)candidate.clk_hz, "Hz in ", CUSTOM_TIMINGS_FILE);
-        return false;
-    }
+    g_zuluscsi_timings->clk_hz = ini_getl(settings_section, "clk_hz", g_zuluscsi_timings->clk_hz, CUSTOM_TIMINGS_FILE);
 
 
     // scsi
-    if (!readIniIntRange(scsi_section, "clk_period_ps", candidate.scsi.clk_period_ps, 1, 1000000, &number_setting))
-    {
-        return false;
-    }
-    candidate.scsi.clk_period_ps = number_setting;
-    if (!readIniIntRange(scsi_section, "req_delay_cc", candidate.scsi.req_delay, 2, 31, &number_setting))
-    {
-        return false;
-    }
-    candidate.scsi.req_delay = number_setting;
+    g_zuluscsi_timings->scsi.clk_period_ps = ini_getl(scsi_section, "clk_period_ps", g_zuluscsi_timings->scsi.clk_period_ps, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi.req_delay = ini_getl(scsi_section, "req_delay_cc", g_zuluscsi_timings->scsi.req_delay, CUSTOM_TIMINGS_FILE);
 
     // scsi 20
-    if (!readIniIntRange(scsi_20_section, "delay0_cc", candidate.scsi_20.delay0, 0, 31, &number_setting)) return false;
-    candidate.scsi_20.delay0 = number_setting;
-    if (!readIniIntRange(scsi_20_section, "delay1_cc", candidate.scsi_20.delay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_20.delay1 = number_setting;
-    if (!readIniIntRange(scsi_20_section, "total_period_adjust_cc", candidate.scsi_20.total_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_20.total_period_adjust = number_setting;
-    if (!readIniIntRange(scsi_20_section, "max_sync", candidate.scsi_20.max_sync, 1, 255, &number_setting)) return false;
-    candidate.scsi_20.max_sync = number_setting;
-    if (!readIniIntRange(scsi_20_section, "read_delay1_cc", candidate.scsi_20.rdelay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_20.rdelay1 = number_setting;
-    if (!readIniIntRange(scsi_20_section, "read_total_period_adjust_cc", candidate.scsi_20.rtotal_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_20.rtotal_period_adjust = number_setting;
+    g_zuluscsi_timings->scsi_20.delay0 = ini_getl(scsi_20_section, "delay0_cc", g_zuluscsi_timings->scsi_20.delay0, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_20.delay1 = ini_getl(scsi_20_section, "delay1_cc", g_zuluscsi_timings->scsi_20.delay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_20.total_period_adjust = ini_getl(scsi_20_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_20.total_period_adjust, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_20.max_sync = ini_getl(scsi_20_section, "max_sync", g_zuluscsi_timings->scsi_20.max_sync, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_20.rdelay1 = ini_getl(scsi_20_section, "read_delay1_cc", g_zuluscsi_timings->scsi_20.rdelay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_20.rtotal_period_adjust = ini_getl(scsi_20_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_20.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
 
     // scsi 10
-    if (!readIniIntRange(scsi_10_section, "delay0_cc", candidate.scsi_10.delay0, 0, 31, &number_setting)) return false;
-    candidate.scsi_10.delay0 = number_setting;
-    if (!readIniIntRange(scsi_10_section, "delay1_cc", candidate.scsi_10.delay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_10.delay1 = number_setting;
-    if (!readIniIntRange(scsi_10_section, "total_period_adjust_cc", candidate.scsi_10.total_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_10.total_period_adjust = number_setting;
-    if (!readIniIntRange(scsi_10_section, "max_sync", candidate.scsi_10.max_sync, 1, 255, &number_setting)) return false;
-    candidate.scsi_10.max_sync = number_setting;
-    if (!readIniIntRange(scsi_10_section, "read_delay1_cc", candidate.scsi_10.rdelay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_10.rdelay1 = number_setting;
-    if (!readIniIntRange(scsi_10_section, "read_total_period_adjust_cc", candidate.scsi_10.rtotal_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_10.rtotal_period_adjust = number_setting;
+    g_zuluscsi_timings->scsi_10.delay0 = ini_getl(scsi_10_section, "delay0_cc", g_zuluscsi_timings->scsi_10.delay0, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_10.delay1 = ini_getl(scsi_10_section, "delay1_cc", g_zuluscsi_timings->scsi_10.delay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_10.total_period_adjust = ini_getl(scsi_10_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_10.total_period_adjust, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_10.max_sync = ini_getl(scsi_10_section, "max_sync", g_zuluscsi_timings->scsi_10.max_sync, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_10.rdelay1 = ini_getl(scsi_10_section, "read_delay1_cc", g_zuluscsi_timings->scsi_10.rdelay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_10.rtotal_period_adjust = ini_getl(scsi_10_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_10.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
 
     // scsi 5
-    if (!readIniIntRange(scsi_5_section, "delay0_cc", candidate.scsi_5.delay0, 0, 31, &number_setting)) return false;
-    candidate.scsi_5.delay0 = number_setting;
-    if (!readIniIntRange(scsi_5_section, "delay1_cc", candidate.scsi_5.delay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_5.delay1 = number_setting;
-    if (!readIniIntRange(scsi_5_section, "total_period_adjust_cc", candidate.scsi_5.total_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_5.total_period_adjust = number_setting;
-    if (!readIniIntRange(scsi_5_section, "max_sync", candidate.scsi_5.max_sync, 1, 255, &number_setting)) return false;
-    candidate.scsi_5.max_sync = number_setting;
-    if (!readIniIntRange(scsi_5_section, "read_delay1_cc", candidate.scsi_5.rdelay1, 0, 31, &number_setting)) return false;
-    candidate.scsi_5.rdelay1 = number_setting;
-    if (!readIniIntRange(scsi_5_section, "read_total_period_adjust_cc", candidate.scsi_5.rtotal_period_adjust, -128, 127, &number_setting)) return false;
-    candidate.scsi_5.rtotal_period_adjust = number_setting;
+    g_zuluscsi_timings->scsi_5.delay0 = ini_getl(scsi_5_section, "delay0_cc", g_zuluscsi_timings->scsi_5.delay0, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_5.delay1 = ini_getl(scsi_5_section, "delay1_cc", g_zuluscsi_timings->scsi_5.delay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_5.total_period_adjust = ini_getl(scsi_5_section, "total_period_adjust_cc", g_zuluscsi_timings->scsi_5.total_period_adjust, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_5.max_sync = ini_getl(scsi_5_section, "max_sync", g_zuluscsi_timings->scsi_5.max_sync, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_5.rdelay1 = ini_getl(scsi_5_section, "read_delay1_cc", g_zuluscsi_timings->scsi_5.rdelay1, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->scsi_5.rtotal_period_adjust = ini_getl(scsi_5_section, "read_total_period_adjust_cc", g_zuluscsi_timings->scsi_5.rtotal_period_adjust, CUSTOM_TIMINGS_FILE);
 
     // sdio
-    if (!readIniIntRange(sdio_section, "clk_div_pio", candidate.sdio.clk_div_pio, 1, 255, &number_setting)) return false;
-    candidate.sdio.clk_div_pio = number_setting;
-    if (!readIniIntRange(sdio_section, "clk_div_1mhz", candidate.sdio.clk_div_1mhz, 1, 255, &number_setting)) return false;
-    candidate.sdio.clk_div_1mhz = number_setting;
-    if (!readIniIntRange(sdio_section, "delay0", candidate.sdio.delay0, 0, 255, &number_setting)) return false;
-    candidate.sdio.delay0 = number_setting;
-    if (!readIniIntRange(sdio_section, "delay1", candidate.sdio.delay1, 0, 255, &number_setting)) return false;
-    candidate.sdio.delay1 = number_setting;
+    g_zuluscsi_timings->sdio.clk_div_pio = ini_getl(sdio_section, "clk_div_pio", g_zuluscsi_timings->sdio.clk_div_pio, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->sdio.clk_div_1mhz = ini_getl(sdio_section, "clk_div_1mhz", g_zuluscsi_timings->sdio.clk_div_1mhz, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->sdio.delay0 = ini_getl(sdio_section, "delay0", g_zuluscsi_timings->sdio.delay0, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->sdio.delay1 = ini_getl(sdio_section, "delay1", g_zuluscsi_timings->sdio.delay1, CUSTOM_TIMINGS_FILE);
 
     // audio
-    if (!readIniIntRange(audio_section, "clk_div_pio", candidate.audio.clk_div_pio, 1, 255, &number_setting))
-    {
-        return false;
-    }
-    candidate.audio.clk_div_pio = number_setting;
-    candidate.audio.audio_clocked = ini_getbool(audio_section, "clk_for_audio", candidate.audio.audio_clocked, CUSTOM_TIMINGS_FILE);
-
-    *g_zuluscsi_timings = candidate;
-    update_sync_period_limits();
-
-    if (force_sync > 0)
-    {
-        uint8_t adjusted_force_sync = calculate_sync_period_limit(g_zuluscsi_timings, force_sync);
-        if (adjusted_force_sync != force_sync)
-        {
-            logmsg("Adjusting forced sync period from ", (int)force_sync, " to ",
-                (int)adjusted_force_sync, " to match the RP2 DATA OUT timing floor");
-        }
-        force_sync = adjusted_force_sync;
-    }
-
-    g_force_sync = force_sync;
-    g_force_offset = force_offset;
-
-    if (g_force_sync > 0)
-    {
-        logmsg("Forcing sync of ", (int) g_force_sync, " and offset of ", (int) g_force_offset);
-    }
+    g_zuluscsi_timings->audio.clk_div_pio = ini_getl(audio_section, "clk_div_pio", g_zuluscsi_timings->audio.clk_div_pio, CUSTOM_TIMINGS_FILE);
+    g_zuluscsi_timings->audio.audio_clocked = ini_getbool(audio_section, "clk_for_audio", g_zuluscsi_timings->audio.audio_clocked, CUSTOM_TIMINGS_FILE);
     return true;
 }

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -687,62 +687,6 @@ zuluscsi_timings_t *g_zuluscsi_timings = &predefined_timings[1];
 zuluscsi_timings_t *g_zuluscsi_timings = &predefined_timings[0];
 #endif
 
-static uint32_t effective_sync_period_ps(const zuluscsi_timings_t *timings, uint8_t sync_period)
-{
-    uint32_t delay_in_ps = (uint32_t)sync_period * 4000U;
-    uint32_t up_rounder = timings->scsi.clk_period_ps / 2 + 1;
-    int totalPeriod = (delay_in_ps + up_rounder) / timings->scsi.clk_period_ps;
-    int rtotalPeriod = totalPeriod;
-    int clkdiv = 1;
-
-    if (sync_period < 25)
-    {
-        rtotalPeriod += timings->scsi_20.rtotal_period_adjust;
-    }
-    else if (sync_period < 50)
-    {
-        rtotalPeriod += timings->scsi_10.rtotal_period_adjust;
-    }
-    else
-    {
-        clkdiv = timings->scsi_5.clkdiv > 0 ? timings->scsi_5.clkdiv : 1;
-        totalPeriod /= clkdiv;
-        rtotalPeriod /= clkdiv;
-        rtotalPeriod += timings->scsi_5.rtotal_period_adjust;
-    }
-
-#ifdef RP2MCU_SCSI_ACCEL_WIDE
-    // The wide target path does not apply the narrow DMA read-pacer floor.
-#elif defined(ZULUSCSI_MCU_RP23XX)
-    if (rtotalPeriod < 14) rtotalPeriod = 14;
-#else
-    if (rtotalPeriod < 18) rtotalPeriod = 18;
-#endif
-
-    return (uint32_t)rtotalPeriod * (uint32_t)clkdiv * timings->scsi.clk_period_ps;
-}
-
-uint8_t calculate_sync_period_limit(const zuluscsi_timings_t *timings, uint8_t requested_min_period)
-{
-    uint16_t sync_period = requested_min_period;
-    while (sync_period <= UINT8_MAX)
-    {
-        if (effective_sync_period_ps(timings, sync_period) <= (uint32_t)sync_period * 4000U)
-        {
-            return sync_period;
-        }
-        sync_period++;
-    }
-    return UINT8_MAX;
-}
-
-void update_sync_period_limits(void)
-{
-    g_max_sync_20_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_20.max_sync);
-    g_max_sync_10_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_10.max_sync);
-    g_max_sync_5_period = calculate_sync_period_limit(g_zuluscsi_timings, g_zuluscsi_timings->scsi_5.max_sync);
-}
-
 
 bool set_timings(zuluscsi_speed_grade_t speed_grade)
 {
@@ -856,7 +800,9 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
     {
         g_zuluscsi_timings = &current_timings;
         memcpy(g_zuluscsi_timings, &predefined_timings[timings_index], sizeof(*g_zuluscsi_timings));
-        update_sync_period_limits();
+        g_max_sync_10_period = g_zuluscsi_timings->scsi_10.max_sync;
+        g_max_sync_20_period = g_zuluscsi_timings->scsi_20.max_sync;
+        g_max_sync_5_period = g_zuluscsi_timings->scsi_5.max_sync;
         return true;
     }
     return false;

--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.h
@@ -135,13 +135,6 @@ typedef struct
 
 extern  zuluscsi_timings_t *g_zuluscsi_timings;
 
-// Return the fastest sync period this timing set can honestly advertise
-// without the DATA OUT read pacer stretching beyond the negotiated period.
-uint8_t calculate_sync_period_limit(const zuluscsi_timings_t *timings, uint8_t requested_min_period);
-
-// Refresh g_max_sync_* from the current timing set after applying runtime constraints.
-void update_sync_period_limits(void);
-
 // Sets timings to the speed_grade, returns false on SPEED_GRADE_DEFAULT and SPEED_GRADE_CUSTOM
 bool set_timings(zuluscsi_speed_grade_t speed_grade);
 


### PR DESCRIPTION
Commit fd45a1e1bc6d5a0b9007cb6a187b8e7d7ea1ce16 broke the ability to successfully negotiate at FAST-20 speeds. This is bad.

This reverts commit fd45a1e1bc6d5a0b9007cb6a187b8e7d7ea1ce16, reversing changes made to c8f9aa7f0da59acc9a5ef2cc2ecddf5b35f5c28e.

 The dynamic calculation seems too conservative, going back to static values.
