### PR TITLE
If platform has dedicated hardware eject button, don't use I2C eject buttons

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1452,10 +1452,8 @@ uint8_t platform_get_buttons()
             if (!gpio_get(GPIO_I2C_SCL)) buttons |= 2;
         }
     #elif defined(GPIO_EJECT_BTN)
-        // EJECT_BTN = 1, SDA = button 2, SCL = button 4
+        // EJECT_BTN = 1
         if (!gpio_get(GPIO_EJECT_BTN)) buttons |= 1;
-        if (!gpio_get(GPIO_I2C_SDA))   buttons |= 2;
-        if (!gpio_get(GPIO_I2C_SCL))   buttons |= 4;
     #elif defined(GPIO_I2C_SDA)
         // SDA = button 1, SCL = button 2
         if (!gpio_get(GPIO_I2C_SDA)) buttons |= 1;


### PR DESCRIPTION
On the wide SCA board, phantom I2C button presses were occurring. Since the board has a physical eject button. Removed checking the I2C lines for buttons presses to avoid the phantom button presses.