### PR TITLE
Implement ability to create image files with size defined by bytes or blocks

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -279,7 +279,7 @@ bool createImageFile(char *imgname, uint64_t size)
   }
 
   // Create file, try to preallocate contiguous sectors
-  LED_ON();
+
   bool is_vhd_image = false;
   uint64_t footer_size = 0;
   // Check for vhd extention and add footer
@@ -288,15 +288,33 @@ bool createImageFile(char *imgname, uint64_t size)
     is_vhd_image = true;
     footer_size = VHD_FOOTER_SIZE;
   }
+
+  uint32_t fat_type = SD.fatType();
+  switch (fat_type)
+  {
+      break;
+    case FAT_TYPE_FAT32:
+      if (size > 0xFFFFFFFF)
+      {
+        logmsg("---- Requested image size ", (int)(size / (1024 * 1024)), " MB is too large for FAT32 volume - maximum is 4GB");
+        return false;
+      }
+      break;
+    case FAT_TYPE_EXFAT:
+      //exFat supports very large files, so no need to check size here
+      break;
+    default:
+      logmsg("---- FAT type not FAT32 or exFAT, not limiting file size, but be aware of limitation of FAT12 and FAT16 are under 4GB");
+  }
+
   uint64_t free_space = (uint64_t)SD.freeClusterCount() * SD.bytesPerCluster();
   if (size + footer_size > free_space)
   {
     logmsg("---- Requested image size ", (int)((size + footer_size) / (1024 * 1024)) ," MB is too large, free space is ", (int)(free_space / (1024 * 1024)), " MB");
-    LED_OFF();
     return false;
   }
+  LED_ON();
   FsFile file = SD.open(imgname, O_WRONLY | O_CREAT);
-
   if (!file.preAllocate(size + footer_size))
   {
     logmsg("---- Preallocation didn't find contiguous set of clusters, continuing anyway");

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -187,7 +187,7 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
   }
 
   char *unit = nullptr;
-  size = strtoul(p, &unit, 10);
+  size = strtoull(p, &unit, 10);
 
   if (size <= 0 || unit <= p)
   {
@@ -197,7 +197,12 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
 
   // Parse k/M/G unit
   char unitchar = tolower(*unit);
-  if (unitchar == 'k')
+  if (unitchar == 'b')
+  {
+    // value in bytes, leave size unchanged
+    p = unit + 1;
+  }
+  else if (unitchar == 'k')
   {
     size *= 1024;
     p = unit + 1;
@@ -211,6 +216,18 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
   {
     size *= 1024 * 1024 * 1024;
     p = unit + 1;
+  }
+  else if (unitchar == 'x')
+  {
+    p = unit + 1;
+    uint64_t sector_size = strtoull(p, &unit, 10);
+    if (sector_size <= 0 || unit <= p)
+    {
+      logmsg("---- Could not parse sector size in filename '", cmd_filename, "'");
+      return false;
+    }
+    size *= sector_size;
+    p = unit;
   }
   else
   {
@@ -270,6 +287,13 @@ bool createImageFile(char *imgname, uint64_t size)
   {
     is_vhd_image = true;
     footer_size = VHD_FOOTER_SIZE;
+  }
+  uint64_t free_space = (uint64_t)SD.freeClusterCount() * SD.bytesPerCluster();
+  if (size + footer_size > free_space)
+  {
+    logmsg("---- Requested image size ", (int)((size + footer_size) / (1024 * 1024)) ," MB is too large, free space is ", (int)(free_space / (1024 * 1024)), " MB");
+    LED_OFF();
+    return false;
   }
   FsFile file = SD.open(imgname, O_WRONLY | O_CREAT);
 


### PR DESCRIPTION
Two new size specifiers have been added to the create image syntax `b` for bytes and `x` for blocks.

 - Bytes: "CREATE 5551234**b** hd1 image.txt" creates an image of 5,551,234 bytes with the filename "hd1 image.bin".

 - Blocks: "CREATE 522**x**36578 hd2_522 as400.img" creates an image of 36578 blocks, where the block size is 522 bytes, the total image size is 522 * 36578 = 19,093,716 bytes and the filename is "hd2_522 as400.img". Also the numbers can be reversed for example "CREATE 36578**x**522 hd2_522 as400.img" creates the same image.

The CREATE command now checks if the requested image size is larger than the free space on the SD card and writes an error message to the log. It also checks for the 4GB limit on FAT32 formatted SD cards.
