### PR TITLE
Upload artifacts to github actions by file type

### DIFF
--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ZuluSCSI
           fetch-depth: "0"
@@ -44,10 +44,31 @@ jobs:
           utils/create_bin_package_zip.sh
 
       - name: Upload binaries into build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          path: ZuluSCSI/distrib/*
+          path: ZuluSCSI/distrib/*.bin
           name: ZuluSCSI binaries
+
+      - name: Upload UF2s into build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: ZuluSCSI/distrib/*.uf2
+          name: ZuluSCSI UF2s
+
+      - name: Upload ELFs into build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: ZuluSCSI/distrib/*.elf
+          name: ZuluSCSI ELFs
+
+      - name: Upload FW package into build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: ZuluSCSI/distrib/*.zip
+          name: ZuluSCSI FW package
+          archive: false
+
+
 
       - name: Upload to latest release
         env:


### PR DESCRIPTION
Separating github action artifacts by type will minimize the amount of data needed to be download when testing builds
Uploading is by extension elf, bin, uf2, and zip.