### PR TITLE
ZuluSCSI Wide: Fix bug with MSGOUT data with odd number of bytes

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
@@ -256,8 +256,7 @@ static uint32_t *scsi_generate_parity_8bit(uint8_t *src, uint32_t count, uint32_
 
         while (count > 0)
         {
-            // We invert the bits in hardware but normal SCSI_OUT does not.
-            *dest++ = scsi_generate_parity(*src++) ^ 0xFFFF;
+            *dest++ = scsi_generate_parity(*src++);
             count -= 1;
         }
     }
@@ -338,15 +337,14 @@ static uint32_t *scsi_generate_parity_16bit(uint8_t *src, uint32_t count, uint32
 
         while (count >= 2)
         {
-            // We invert the bits in hardware but normal SCSI_OUT does not.
-            *dest++ = scsi_generate_parity(*(uint16_t*)src) ^ 0xFFFF;
+            *dest++ = scsi_generate_parity(*(uint16_t*)src);
             src += 2;
             count -= 2;
         }
 
         if (count > 0)
         {
-            *dest++ = scsi_generate_parity(*src++) ^ 0xFFFF;
+            *dest++ = scsi_generate_parity(*src++);
             count -= 1;
         }
     }

--- a/utils/sigrok_scsi_decoder/pd.py
+++ b/utils/sigrok_scsi_decoder/pd.py
@@ -255,7 +255,7 @@ class Decoder(srd.Decoder):
 
     def push_cmd(self, end_sample):
         if not self.cmd_bytes:
-            self.put(self.ss_cmd, end_sample, self.out_ann, [Annotations.cmd, ["NO COMMAND"]])
+            self.put(self.ss_cmd, end_sample, self.out_ann, [Annotations.cmd_special, ["NO COMMAND"]])
         else:
             cmdclass, cmdname = SCSI_COMMANDS.get(self.cmd_bytes[0], (3,"UNKNOWN COMMAND"))
             texts = [cmdname + ": " + ' '.join('%02x' % x for x in self.cmd_bytes), cmdname]


### PR DESCRIPTION
The code branch for odd number of bytes was inverting the data even though after 9f4727f5 it shouldn't be inverted.

This caused failure in synchronous mode negotiation on Linux with Adaptec cards.