### PR TITLE
Set vendor/product strings for AS400 CD-ROM drives

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -678,7 +678,6 @@ bool findHDDImages()
         if (is_re) type = S2S_CFG_REMOVABLE;
         if (is_tp) type = S2S_CFG_SEQUENTIAL;
         if (is_zp) type = S2S_CFG_ZIP100;
-
         g_scsi_settings.initDevice(id, type);
         parseCustomInquiryData(id);
 

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -120,6 +120,8 @@
 #define APPLE_DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",         "2.0f",            ""}
 #define APPLE_DRIVEINFO_TAPE      {"ZULUSCSI", "APPLE_TAPE",        PLATFORM_REVISION, ""}
 
+#define AS400_DRIVEINFO_OPTICAL   {"IBM",      "CDRM00203",         PLATFORM_REVISION, ""}
+
 // Default Iomega ZIP drive information
 #define IOMEGA_DRIVEINFO_ZIP100     {"IOMEGA", "ZIP 100", "D.13", ""}
 #define IOMEGA_DRIVEINFO_ZIP250     {"IOMEGA", "ZIP 250", "42.S", ""}

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -814,6 +814,7 @@ static void scsiDiskCheckDir(char * dir_name, int target_idx, image_config_t* im
             logmsg("SCSI", target_idx, " searching default ", type_name, " image directory '", dir_name, "'");
 
             setRootFolder(target_idx, false, dir_name);
+            g_scsi_settings.initDevice(target_idx, type, true);
         }
     }
 }
@@ -891,8 +892,6 @@ static void scsiDiskSetConfig(int target_idx)
         }
     }
 #endif
-
-    g_scsi_settings.initDevice(target_idx, (S2S_CFG_TYPE)img.deviceType, true);
 }
 
 // Compares the prefix of both files and the scsi ID

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -309,6 +309,10 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
     static const char * const apl_driveinfo_network[4]   = APPLE_DRIVEINFO_NETWORK;
     static const char * const apl_driveinfo_tape[4]      = APPLE_DRIVEINFO_TAPE;
 
+#ifdef PLATFORM_AS400
+    static const char * const as400_driveinfo_optical[4] = AS400_DRIVEINFO_OPTICAL;
+#endif
+
     static const char * const iomega_driveinfo_removeable[4] = IOMEGA_DRIVEINFO_ZIP100;
     
     const char * const * driveinfo = NULL;
@@ -335,9 +339,10 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
         {
             case SYS_PRESET_AS400:
             // For the AS400 preset, we want to set the device preset to the block size 520
-                [[fall_through]];
+                [[fallthrough]];
             case SYS_PRESET_AS400_BS520:
                 m_devPreset[scsiId] = DEV_PRESET_AS400_BS520;
+                logmsg("---- Setting device preset to AS400_BS520 based on system preset ", systemPresetName[m_sysPreset]);
                 break;
             case SYS_PRESET_AS400_BS522:
                 m_devPreset[scsiId] = DEV_PRESET_AS400_BS522;
@@ -414,6 +419,13 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
                 default:                    driveinfo = driveinfo_fixed; break;
             }
         }
+
+        #ifdef PLATFORM_AS400
+        if ((cfgSys.quirks & S2S_CFG_QUIRKS_AS400) && type == S2S_CFG_OPTICAL)
+        {
+            driveinfo = as400_driveinfo_optical;
+        }
+        #endif
     }
 
     // If the scsi string has not been set system wide use default scsi string


### PR DESCRIPTION
When AS400 quirks is enabled directly or by system presets, the ZuluSCSI uses "IBM" as the vendor string and "CDRM00203" as the product string defaults.

These values are specific to an AS/400e series test machine we have and may not be valid for other AS/400e models or other series AS/400 machines.