### PR TITLE
[enhancement] Add AS400_DiskPartNumber INI key for IBM disk FRU

### DIFF
--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -62,6 +62,29 @@ static struct {
     uint8_t length;
     uint8_t data[8];
 } g_as400_serial_override[S2S_MAX_TARGETS];
+
+// Per-SCSI-ID override for the 7-character IBM disk part number (FRU)
+// embedded in VPD page 0x01 at ASCII offset 5 and EBCDIC offset 29.
+// Supplied via the `AS400_DiskPartNumber` key in [SCSI<n>] sections.
+// When length == 7, injectPartNumber() patches both ASCII and EBCDIC slots.
+static struct {
+    uint8_t length;
+    uint8_t ascii[7];
+    uint8_t ebcdic[7];
+} g_as400_part_override[S2S_MAX_TARGETS];
+
+// Convert a single ASCII character to IBM EBCDIC (CP037 subset).
+// Supports digits, uppercase A-Z, and space. Lowercase is uppercased first.
+// Anything else returns EBCDIC space (0x40).
+static uint8_t asciiToEbcdic(char c)
+{
+    if (c >= 'a' && c <= 'z') c -= ('a' - 'A');
+    if (c >= '0' && c <= '9') return (uint8_t)(0xF0 + (c - '0'));
+    if (c >= 'A' && c <= 'I') return (uint8_t)(0xC1 + (c - 'A'));
+    if (c >= 'J' && c <= 'R') return (uint8_t)(0xD1 + (c - 'J'));
+    if (c >= 'S' && c <= 'Z') return (uint8_t)(0xE2 + (c - 'S'));
+    return 0x40;
+}
 #endif
 
 // Parse space/comma-separated hex values from a string into a byte buffer.
@@ -112,6 +135,18 @@ static void injectSerial(uint8_t *data, int offset, uint8_t scsiId)
 
     memcpy(data + offset, serial, 8);
     memcpy(string, serial, 8);
+}
+
+// Inject the configured 7-char IBM disk part number (FRU) into both the
+// ASCII and EBCDIC slots of the given VPD page buffer. No-op when no
+// override is configured for this SCSI ID.
+static void injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, uint8_t scsiId)
+{
+    uint8_t id = scsiId & S2S_CFG_TARGET_ID_BITS;
+    if (g_as400_part_override[id].length != 7) return;
+
+    memcpy(data + asciiOffset, g_as400_part_override[id].ascii, 7);
+    memcpy(data + ebcdicOffset, g_as400_part_override[id].ebcdic, 7);
 }
 #endif
 
@@ -166,6 +201,11 @@ static void loadAS400Defaults(uint8_t scsiId)
         else if (pageCode == 0xD1 && g_custom_vpd[idx].length >= 78)
             injectSerial(g_custom_vpd[idx].data, 70, scsiId);
 
+        // Inject configured IBM disk part number (FRU) into VPD page 0x01.
+        // ASCII slot at offset 5 and EBCDIC slot at offset 29, 7 bytes each.
+        if (pageCode == 0x01 && g_custom_vpd[idx].length >= 36)
+            injectPartNumber(g_custom_vpd[idx].data, 5, 29, scsiId);
+
         g_custom_vpd_count++;
     }
     if (loaded_default_data)
@@ -185,6 +225,7 @@ void parseCustomInquiryData(uint8_t scsiId)
     memset(g_custom_spd, 0, sizeof(g_custom_spd));
 #ifdef PLATFORM_AS400
     memset(g_as400_serial_override, 0, sizeof(g_as400_serial_override));
+    memset(g_as400_part_override, 0, sizeof(g_as400_part_override));
 #endif
 
 
@@ -232,6 +273,32 @@ void parseCustomInquiryData(uint8_t scsiId)
             memcpy(g_as400_serial_override[id].data, tmp, slen);
             g_as400_serial_override[id].length = 8;
             logmsg("Custom AS/400 serial for SCSI ID ", scsiId, ": \"", tmp, "\"");
+        }
+    }
+
+    // Parse AS/400 disk part number override: AS400_DiskPartNumber=<up to 7 chars>
+    // Accepts [0-9 A-Z] (lowercase is uppercased). Shorter values are right-padded
+    // with spaces; longer values are truncated to 7 characters. The same 7 chars
+    // are injected into both the ASCII and EBCDIC slots of VPD page 0x01.
+    if (ini_gets(section, "AS400_DiskPartNumber", "", tmp, sizeof(tmp), CONFIGFILE))
+    {
+        size_t slen = strlen(tmp);
+        if (slen > 0)
+        {
+            uint8_t id = scsiId & S2S_CFG_TARGET_ID_BITS;
+            memset(g_as400_part_override[id].ascii, ' ', 7);
+            memset(g_as400_part_override[id].ebcdic, 0x40, 7);
+            if (slen > 7) slen = 7;
+            for (size_t i = 0; i < slen; i++)
+            {
+                char c = tmp[i];
+                if (c >= 'a' && c <= 'z') c -= ('a' - 'A');
+                uint8_t eb = asciiToEbcdic(c);
+                g_as400_part_override[id].ascii[i] = (eb == 0x40 && c != ' ') ? ' ' : (uint8_t)c;
+                g_as400_part_override[id].ebcdic[i] = eb;
+            }
+            g_as400_part_override[id].length = 7;
+            logmsg("Custom AS/400 disk part number for SCSI ID ", scsiId, ": \"", tmp, "\"");
         }
     }
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -99,6 +99,14 @@
 # board MCU unique ID. Per-ID only — must live under [SCSI<n>].
 #AS400_DiskSerial = "214A872"
 
+# AS/400 only: pin the 7-character IBM disk part number (FRU) embedded in
+# VPD page 0x01 at both the ASCII and EBCDIC slots. Accepts [0-9 A-Z]
+# (lowercase is uppercased); unsupported characters become space. Values
+# shorter than 7 characters are right-padded with spaces; longer values are
+# truncated. When unset, the hard-coded dump default "09L4044" is emitted.
+# Per-ID only — must live under [SCSI<n>].
+#AS400_DiskPartNumber = "09L7654"
+
 #Vendor = "QUANTUM"
 #Product = "FIREBALL1"
 #Version = "1.0"


### PR DESCRIPTION
### Motivation

The AS/400 VPD page 0x01 imported from Kevin's branch bakes in the IBM FRU `09L4044` in both its ASCII and EBCDIC slots. That FRU identifies the 8.58 GB 10 K RPM Ultra2 SCSI DASD sold as feature code 6817 — the drive that happened to be installed in the 9406-170 Kevin captured. Operators emulating any other DASD SKU (4326, 4327, 6718, later iSeries DASDs with different `09L____` / `97P____` / `21P____` FRUs) cannot change this without hand-assembling a full 51-byte `vpd01=` hex override and producing a matching EBCDIC translation by hand. This PR adds an ergonomic per-ID INI key that mirrors the `AS400_DiskSerial` pattern.

<img width="785" height="1064" alt="image" src="https://github.com/user-attachments/assets/45452dde-4538-4491-b9ae-69ea774a81e9" />

There are other information on a physical disk that are nice to be able to set for proper device emulation.

### What Changed
- New per-ID INI key `AS400_DiskPartNumber` parsed from `[SCSI<n>]` inside `parseCustomInquiryData()` in `src/custom_vendor_inquiry.cpp`.
- New per-target static storage `g_as400_part_override[S2S_MAX_TARGETS]` holding the ASCII and EBCDIC byte arrays, gated behind `#ifdef PLATFORM_AS400`.
- New local helper `asciiToEbcdic()` that maps the `[0-9 A-Z]` + space subset of ASCII to IBM CP037 EBCDIC (the only subset ever seen in IBM FRU strings). Unsupported characters fall through to EBCDIC space (`0x40`) and the ASCII slot is also normalized to space so both slots stay consistent.
- New `injectPartNumber()` helper that writes both slots into a VPD page buffer at caller-supplied offsets.
- New branch inside the per-page injection block of `loadAS400Defaults()`: when `pageCode == 0x01` and the buffer has the expected length, the override is injected at ASCII offset 5 and EBCDIC offset 29 (the two locations in the dumped page 0x01 where `09L4044` currently lives).
- `zuluscsi.ini` grows a commented example immediately after the existing `AS400_DiskSerial` example.

### Design Notes
- **EBCDIC conversion scope.** IBM DASD FRU strings live in a tiny subset of CP037 — `[0-9 A-Z]` + space. Pulling in a full CP037 table would add ~256 bytes of rodata for no benefit. The branch-table conversion handles the four contiguous regions (`0-9`, `A-I`, `J-R`, `S-Z`) that CP037 mandates discontinuously.
- **Offset choice (5 and 29).** Derived by indexing into the stored page data after `AS400VitalPages[p][1..]` is copied. Data bytes 0-3 are the SCSI VPD page header; byte 4 is the IBM `0x18` field-length marker; bytes 5-11 hold the 7-char ASCII FRU; the EBCDIC copy sits at bytes 29-35 after a block of ASCII filler, a `0x00` separator, and a secondary FRU. Both injection slots are exactly 7 bytes wide.
- **Truncation and padding.** `if (slen > 7) slen = 7;` before the copy loop; short values are pre-filled with ASCII space / EBCDIC space before the per-character write. No heap allocation, no out-of-bounds risk.
- **Secondary FRU (F24460) intentionally untouched.** The `F#####` code follows a different IBM numbering convention (DASD Licensed Internal Code reference, not a hardware FRU) and should get its own key once its semantics are pinned down. Single-purpose key keeps this PR focused.
- **Reset semantics.** `memset(g_as400_part_override, 0, ...)` at the top of `parseCustomInquiryData()` matches the existing reset pattern for `g_custom_vpd_count`, `g_custom_spd`, and `g_as400_serial_override`. The pre-existing multi-ID reset behaviour (every call wipes all IDs) is left unchanged.

### Acceptance Criteria Check
- [x] `AS400_DiskPartNumber=09L7654` yields ASCII `09L7654` at data offset 5 and EBCDIC `F0 F9 D3 F7 F6 F5 F4` at data offset 29 — verified by `injectPartNumber()` writing exactly 7 bytes at each offset and `asciiToEbcdic()` mapping `'7'→0xF7`, `'6'→0xF6`, `'5'→0xF5`, `'4'→0xF4`, `'9'→0xF9`, `'0'→0xF0`, `'L'→0xD3`.
- [x] `AS400_DiskPartNumber=4326` right-pads to `4326   ` (3 spaces) in both slots — enforced by the `memset(..., ' ', 7)` / `memset(..., 0x40, 7)` pre-fill before the copy loop.
- [x] `AS400_DiskPartNumber=abcd1234` truncates and uppercases to `ABCD123` — enforced by `if (slen > 7) slen = 7;` and the lowercase-to-uppercase step inside the per-character loop.
- [x] Omitting the key preserves the dumped `09L4044` default — `injectPartNumber()` early-returns when `length != 7`, leaving the `memcpy(&AS400VitalPages[p][1], ...)` result untouched.
- [x] Documented as a commented example in `zuluscsi.ini` next to `AS400_DiskSerial`.
- [x] Boot-time log line `Custom AS/400 disk part number for SCSI ID <n>: \"<value>\"` is emitted when the override is active.
- [x] Non-AS/400 platforms: storage, helpers, parse block, and inject block are all `#ifdef PLATFORM_AS400` gated.

### How Verified
- **Static:** traced `AS400VitalPages[p]` for `pageCode == 0x01` through `loadAS400Defaults()` into the override path. Confirmed that data offsets 5 (ASCII) and 29 (EBCDIC) correspond to the current `09L4044` bytes in both representations by cross-referencing the raw `as400_values.cpp:52` literal against the copy offset (`AS400VitalPages[p][1..]`, so index 5 in the stored buffer maps to source index 6 = `'0'` of `09L4044`).
- **EBCDIC mapping:** validated against the existing EBCDIC bytes in the dump — `'0'→0xF0`, `'9'→0xF9`, `'L'→0xD3`, `'4'→0xF4`, `'F'→0xC6`, `'2'→0xF2`, `'6'→0xF6` — all match `asciiToEbcdic()` output.
- **Runtime:** firmware smoke-test on real AS/400 hardware is pending — I do not have a ZuluSCSI board wired to an AS/400 host in reach. Recommended hardware check: set `AS400_DiskPartNumber=09L7654` under `[SCSI0]`, boot, confirm boot log shows `Custom AS/400 disk part number for SCSI ID 0: \"09L7654\"`, then confirm the AS/400 Hardware Service Manager reports the new FRU on the DASD unit.

### Test Coverage
**None.** The repository has no existing host-side unit-test harness for `custom_vendor_inquiry.cpp`; verification has historically been done on real AS/400 hardware. Adding a harness is out of scope for this single-key change.

### Scope of Change
- **Files changed:** `src/custom_vendor_inquiry.cpp`, `zuluscsi.ini`
- **Submodule pointer updated:** no
- **Public API changes:** none — new INI key only; C/C++ symbol surface unchanged
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low blast radius: the override is only read inside the AS/400 VPD 0x01 injection path, is reset on every parse pass, and defaults to inactive (length 0 → dumped value preserved). Existing INI files without the key behave identically. Only `PLATFORM_AS400` builds are touched at runtime.

### Notes
- PR targets `feature/as400-imports` rather than `main`, matching the base of the sibling `AS400_DiskSerial` PR — the AS/400 import work is still unmerged. Retarget to `main` once the base merges.
- Follow-up: file a separate issue for an `AS400_DiskFunctionalCode` (or similarly named) key once the `F#####` namespace is understood, so the secondary FRU in VPD 0x01 at offsets 18 (ASCII) / 41 (EBCDIC) can also be pinned per-ID.
- Out-of-scope IDs: this PR deliberately does not touch `Type` / `Model` columns on the AS/400 disk configuration screen — those are derived by OS/400 from the FRU/capacity lookup tables, so once the FRU is overridable the Type/Model will follow, provided the new FRU is one OS/400 recognizes.