### PR TITLE
Fix logging of SCSI phases for SCSI IDs 8-15 on wide

### DIFF
--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -30,13 +30,8 @@
 #include <stddef.h>
 #include <scsiPhy.h>
 
-#if   S2S_MAX_TARGETS == 8
- # define ZULUSCSI_DEFAULT_LOG_MASK 0xFF
-#elif S2S_MAX_TARGETS == 16
-# define ZULUSCSI_DEFAULT_LOG_MASK 0xFFFF
-#elif S2S_MAX_TARGETS == 32
-# define ZULUSCSI_DEFAULT_LOG_MASK 0xFFFFFFFF
-#endif
+ # define ZULUSCSI_DEFAULT_LOG_MASK S2S_CFG_TARGET_ID_BITS
+
 
 // Get total number of bytes that have been written to log
 uint32_t log_get_buffer_len();

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -516,12 +516,12 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
 
 
 
-    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", 0xFF, CONFIGFILE) & 0xFF;
+    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE) & ZULUSCSI_DEFAULT_LOG_MASK;
     if (g_scsi_log_mask == 0)
     {
       dbgmsg("DebugLogMask set to 0x00, this will silence all debug messages when a SCSI ID has been selected");
     }
-    else if (g_scsi_log_mask != 0xFF)
+    else if (g_scsi_log_mask != ZULUSCSI_DEFAULT_LOG_MASK)
     {
       dbgmsg("DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
     }


### PR DESCRIPTION
The ZuluSCSI firmware was not logging phase changes on SCSI IDs 8-15. This was due to a bug in the DebugLogMask, which has been resolved.