### PR TITLE
Clear device on SD reinsert

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -651,13 +651,6 @@ bool findHDDImages()
           continue;
         }
 
-        // set the default block size now that we know the device type
-        if (g_scsi_settings.getDevice(id)->blockSize == 0)
-        {
-          g_scsi_settings.getDevice(id)->blockSize = is_cd ?  DEFAULT_BLOCKSIZE_OPTICAL : DEFAULT_BLOCKSIZE;
-        }
-        int blk = getBlockSize(name, id);
-
 #ifdef ZULUSCSI_NETWORK
         if ((is_ne || is_am) && !platform_network_supported())
         {
@@ -678,7 +671,15 @@ bool findHDDImages()
         if (is_re) type = S2S_CFG_REMOVABLE;
         if (is_tp) type = S2S_CFG_SEQUENTIAL;
         if (is_zp) type = S2S_CFG_ZIP100;
+
         g_scsi_settings.initDevice(id, type);
+        // set the default block size now that we know the device type
+        if (g_scsi_settings.getDevice(id)->blockSize == 0)
+        {
+          g_scsi_settings.getDevice(id)->blockSize = is_cd ?  DEFAULT_BLOCKSIZE_OPTICAL : DEFAULT_BLOCKSIZE;
+        }
+        int blk = getBlockSize(name, id);
+
         parseCustomInquiryData(id);
 
         scsiDiskGetImageConfig(id).tapeDensity = g_scsi_settings.getDevice(id)->tapeDensity;
@@ -981,13 +982,6 @@ static void reinitSCSI()
   scsiPhyReset();
   scsiDiskInit();
   scsiInit();
-  for (int8_t scsiId = 0; scsiId < S2S_MAX_TARGETS; scsiId++)
-  {
-      if (scsiDev.targets[scsiId].cfg->scsiId & S2S_CFG_TARGET_ENABLED)
-      {
-          parseCustomInquiryData(scsiId);
-      }
-  }
 
 #ifdef ZULUSCSI_NETWORK
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -194,6 +194,7 @@ void image_config_t::clear()
     }
     this->~image_config_t();
     new (this) image_config_t();
+    memset((S2S_TargetCfg*)this, 0, sizeof(image_config_t));
 }
 
 uint32_t image_config_t::get_capacity_lba()

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -342,7 +342,6 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
                 [[fallthrough]];
             case SYS_PRESET_AS400_BS520:
                 m_devPreset[scsiId] = DEV_PRESET_AS400_BS520;
-                logmsg("---- Setting device preset to AS400_BS520 based on system preset ", systemPresetName[m_sysPreset]);
                 break;
             case SYS_PRESET_AS400_BS522:
                 m_devPreset[scsiId] = DEV_PRESET_AS400_BS522;

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -272,7 +272,7 @@ void parseCustomInquiryData(uint8_t scsiId)
             if (slen > 8) slen = 8;
             memcpy(g_as400_serial_override[id].data, tmp, slen);
             g_as400_serial_override[id].length = 8;
-            logmsg("Custom AS/400 serial for SCSI ID ", scsiId, ": \"", tmp, "\"");
+            logmsg("---- Custom AS/400 serial for SCSI ID ", (int) scsiId, ": \"", tmp, "\"");
         }
     }
 
@@ -298,7 +298,7 @@ void parseCustomInquiryData(uint8_t scsiId)
                 g_as400_part_override[id].ebcdic[i] = eb;
             }
             g_as400_part_override[id].length = 7;
-            logmsg("Custom AS/400 disk part number for SCSI ID ", scsiId, ": \"", tmp, "\"");
+            logmsg("---- Custom AS/400 disk part number for SCSI ID ", (int) scsiId, ": \"", tmp, "\"");
         }
     }
 


### PR DESCRIPTION
On SD card reinsert with an image using the same SCSI ID as before, after an SD card was ejected, the log would message that the SCSI ID was already configured.

This resets the configuration structure on a SCSI reinit to clear the enable bit on the SCSI ID allowing the SCSI ID to be reconfigured.

The changes move some function calls around because AS400 block sizes were not being respected on initialization. They also clear up AS400 log messages on custom part and serial numbers.