### PR TITLE
Backport SCSI spec fixes

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -1,8 +1,9 @@
 //	Copyright (C) 2013 Michael McMaster <michael@codesrc.com>
 //  Copyright (C) 2014 Doug Brown <doug@downtowndougbrown.com>
 //  Copyright (C) 2019 Landon Rodgers <g.landon.rodgers@gmail.com>
-//	Copyright (c) 2024-2025 Rabbit Hole Computing™
+//	Copyright (c) 2024-2026 Rabbit Hole Computing™
 //	Copyright (C) 2024 jokker <jokker@gmail.com>
+//	Copyright (c) 2026 Eric Helgeson <erichelgeson@gmail.com>
 //	This file is part of SCSI2SD.
 //
 //	SCSI2SD is free software: you can redistribute it and/or modify
@@ -226,6 +227,32 @@ static const uint8_t ControlModePage[] =
 0x00, // No async event notifications
 0x00, // Reserved
 0x00, 0x00 // AEN holdoff period.
+};
+
+// SCSI-2 section 9.3.3.8, Table 173
+static const uint8_t VerifyErrorRecoveryPage[] =
+{
+0x07, // Page code
+0x0A, // Page length
+0x00, // EER=0, PER=0, DTE=0, DCR=0
+0x01, // Verify retry count
+0x00, // Verify correction span
+0x00, 0x00, 0x00, 0x00, 0x00, // Reserved (bytes 5-9)
+0x00, 0x00  // Verify recovery time limit (MSB, LSB)
+};
+
+// SCSI-2 section 9.3.3.5, Table 167
+static const uint8_t NotchPage[] =
+{
+0x0C, // Page code
+0x16, // Page length
+0x00, 0x00, // ND=0 (not notched), LP=0
+0x00, 0x00, // Maximum number of notches
+0x00, 0x00, // Active notch
+0x00, 0x00, 0x00, 0x00, // Starting boundary
+0x00, 0x00, 0x00, 0x00, // Ending boundary
+0x00, 0x00, 0x00, 0x00, // Pages notched (MSB)
+0x00, 0x00, 0x00, 0x00  // Pages notched (LSB)
 };
 
 static const uint8_t SequentialDeviceConfigPage[] =
@@ -531,6 +558,14 @@ static void doModeSense(int sixByteCmd, int dbd, int pc, int pageCode, int alloc
 
 
 	if ((scsiDev.compatMode >= COMPAT_SCSI2) &&
+		(pageCode == 0x07 || pageCode == 0x3F))
+	{
+		pageFound = 1;
+		pageIn(pc, idx, VerifyErrorRecoveryPage, sizeof(VerifyErrorRecoveryPage));
+		idx += sizeof(VerifyErrorRecoveryPage);
+	}
+
+	if ((scsiDev.compatMode >= COMPAT_SCSI2) &&
 		(pageCode == 0x08 || pageCode == 0x3F))
 	{
 		pageFound = 1;
@@ -544,6 +579,16 @@ static void doModeSense(int sixByteCmd, int dbd, int pc, int pageCode, int alloc
 		pageFound = 1;
 		pageIn(pc, idx, ControlModePage, sizeof(ControlModePage));
 		idx += sizeof(ControlModePage);
+	}
+
+	if ((scsiDev.compatMode >= COMPAT_SCSI2) &&
+		(pageCode == 0x0C || pageCode == 0x3F) &&
+		(scsiDev.target->cfg->deviceType != S2S_CFG_OPTICAL) &&
+		(scsiDev.target->cfg->deviceType != S2S_CFG_SEQUENTIAL))
+	{
+		pageFound = 1;
+		pageIn(pc, idx, NotchPage, sizeof(NotchPage));
+		idx += sizeof(NotchPage);
 	}
 
 	idx += modeSenseCDDevicePage(pc, idx, pageCode, &pageFound);
@@ -786,7 +831,20 @@ int scsiModeCommand()
 		// SCSI1 standard: (CCS X3T9.2/86-52)
 		// "An Allocation Length of zero indicates that no MODE SENSE data shall
 		// be transferred. This condition shall not be considered as an error."
-		doModeSense(1, dbd, pc, pageCode, allocLength);
+		
+		// SCSI-2 sections 8.2.10/8.2.11: CDB byte 3 is Reserved.
+		// SPC-3+ redefines it as SUBPAGE CODE. Reject non-zero.
+		if (scsiDev.cdb[3] != 0)
+		{
+			scsiDev.status = CHECK_CONDITION;
+			scsiDev.target->sense.code = ILLEGAL_REQUEST;
+			scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+			scsiDev.phase = STATUS;
+		}
+		else
+		{
+			doModeSense(1, dbd, pc, pageCode, allocLength);
+		}
 	}
 	else if (command == 0x5A)
 	{
@@ -798,6 +856,17 @@ int scsiModeCommand()
 			(((uint16_t) scsiDev.cdb[7]) << 8) +
 			scsiDev.cdb[8];
 		doModeSense(0, dbd, pc, pageCode, allocLength);
+		if (scsiDev.cdb[3] != 0)
+		{
+			scsiDev.status = CHECK_CONDITION;
+			scsiDev.target->sense.code = ILLEGAL_REQUEST;
+			scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+			scsiDev.phase = STATUS;
+		}
+		else
+		{
+			doModeSense(0, dbd, pc, pageCode, allocLength);
+		}
 	}
 	else if (command == 0x15)
 	{

--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -578,10 +578,11 @@ static void process_Command()
 			if (allocLength == 0) allocLength = 4;
 
 			memset(scsiDev.data, 0, 256); // Max possible alloc length
-			scsiDev.data[0] = 0xF0;
+			scsiDev.data[0] = 0x70; // error code, Valid=0 by default
 			scsiDev.data[2] = scsiDev.target->sense.code & 0x0F;
 			if (cfg->deviceType == S2S_CFG_SEQUENTIAL)
 			{
+				scsiDev.data[0] = 0xF0; // Valid=1, tape always has meaningful info
 				scsiDev.data[2] |= scsiDev.target->sense.filemark ? 1 << 7 : 0;
 				scsiDev.data[2] |= scsiDev.target->sense.eom ? 1 << 6 : 0;
 				scsiDev.data[2] |= scsiDev.target->sense.ili ? 1 << 5 : 0;
@@ -593,8 +594,12 @@ static void process_Command()
 				// Byte 9 bit 3: BOM (Beginning of Medium)
 				scsiDev.data[9] = scsiDev.target->tapeBOM ? (1 << 3) : 0;
 			}
-			else
+			else if (scsiDev.target->sense.code == MEDIUM_ERROR
+				|| scsiDev.target->sense.code == HARDWARE_ERROR
+				|| scsiDev.target->sense.code == ABORTED_COMMAND)
 			{
+			// Valid=1 + LBA only for block-related errors
+				scsiDev.data[0] = 0xF0;
 				scsiDev.data[3] = transfer.lba >> 24;
 				scsiDev.data[4] = transfer.lba >> 16;
 				scsiDev.data[5] = transfer.lba >> 8;

--- a/lib/minIni/minGlue.h
+++ b/lib/minIni/minGlue.h
@@ -1,4 +1,5 @@
 /*  Glue functions for the minIni library to the cache functions in minIni_cache.cpp */
+#pragma once
 
 #include <SdFat.h>
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2155,7 +2155,9 @@ void scsiDiskStartWrite(uint32_t lba, uint32_t blocks)
     {
         logmsg("WARNING: Host attempted write to read-only drive ID ", (int)(img.scsiId & S2S_CFG_TARGET_ID_BITS));
         scsiDev.status = CHECK_CONDITION;
-        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        // SCSI-2 §9.1.12: WRITE PROTECTED (ASC 0x2700) pairs with sense key
+        // DATA PROTECT (0x07), not ILLEGAL REQUEST.
+        scsiDev.target->sense.code = DATA_PROTECT;
         scsiDev.target->sense.asc = WRITE_PROTECTED;
         scsiDev.phase = STATUS;
     }
@@ -2287,7 +2289,8 @@ static void scsiDiskStartWriteAndVerify(uint32_t lba, uint32_t blocks)
     {
         logmsg("WARNING: Host attempted WRITE AND VERIFY to read-only drive ID ", (int)(img.scsiId & S2S_CFG_TARGET_ID_BITS));
         scsiDev.status = CHECK_CONDITION;
-        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        // SCSI-2 §9.1.12: WRITE PROTECTED pairs with sense key DATA PROTECT.
+        scsiDev.target->sense.code = DATA_PROTECT;
         scsiDev.target->sense.asc = WRITE_PROTECTED;
         scsiDev.phase = STATUS;
     }


### PR DESCRIPTION
Manually imported these patches, which originated from https://github.com/BlueSCSI/BlueSCSI-v2/commit/14985797f31eb6425d620cfac53a51418ada7218
---

From f7feb1db0d43b99194410d083b8cbc8ea436a320 Mon Sep 17 00:00:00 2001
From: Eric Helgeson <erichelgeson@gmail.com>
Date: Mon, 13 Apr 2026 10:20:22 -0500
Subject: [PATCH 1/8] scsi: only set Valid bit in REQUEST SENSE when
 Information field is meaningful

Previously the Valid bit (0x80) was unconditionally set and the Information field always populated with transfer.lba, even for sense keys like ILLEGAL_REQUEST or UNIT_ATTENTION where no block address is relevant. Per SPC-2 section 7.20, Valid should only be set when the Information field contains valid data.

Now only MEDIUM_ERROR, HARDWARE_ERROR, and ABORTED_COMMAND (block- related errors) report Valid=1 with the LBA. Other sense keys return error code 0x70 (Valid=0) with a zeroed Information field. ---

From f914e04cc9229f51babe305696d038844573f10f Mon Sep 17 00:00:00 2001
From: Eric Helgeson <erichelgeson@gmail.com>
Date: Mon, 13 Apr 2026 15:32:38 -0500
Subject: [PATCH 2/8] MODE SENSE: Reject non-zero reserved CDB byte 3

Per SCSI-2 (X3.131-1994) sections 8.2.10 and 8.2.11, CDB byte 3 of MODE SENSE(6) and MODE SENSE(10) is Reserved. Non-zero values in reserved fields should be rejected with CHECK CONDITION / ILLEGAL REQUEST / INVALID FIELD IN CDB.

SPC-2 (T10/1236-D r20) sections 7.8 and 7.9 confirm the same, and SPC-3+ redefines this byte as the SUBPAGE CODE field, which must also be rejected when subpages are not supported.

---

From 318a1c142b820eee41ec587ebbb1b17fcccb35b2 Mon Sep 17 00:00:00 2001
From: Eric Helgeson <erichelgeson@gmail.com>
Date: Mon, 13 Apr 2026 15:33:54 -0500
Subject: [PATCH 3/8] MODE SENSE: Add Verify Error Recovery page (07h)

Add mode page 07h (Verify Error Recovery) per SCSI-2 section 9.3.3.8, Table 173. This optional page specifies error recovery parameters for VERIFY, WRITE AND VERIFY, and COPY AND VERIFY commands.

Page data matches the SCSI-2 spec format: page length 0Ah, verify retry count of 1, all other fields zero. Only returned for SCSI-2 mode hosts. Some vintage operating systems expect this page when requesting all pages (0x3F).

---

From 1e1a1a5143f203ca9f509e9f8bb94747d36b07fe Mon Sep 17 00:00:00 2001
From: Eric Helgeson <erichelgeson@gmail.com>
Date: Mon, 13 Apr 2026 15:35:17 -0500
Subject: [PATCH 4/8] MODE SENSE: Add Notch and Partition page (0Ch)

Add mode page 0Ch (Notch and Partition) per SCSI-2 section 9.3.3.5, Table 167. This optional page defines notch parameters for rigid disk drives with variable blocks per cylinder.

All fields are zero, indicating a non-notched drive, which provides maximum compatibility. Only returned for SCSI-2 mode direct-access devices (excluded from optical and sequential).

---

From b9bd4af57d3c8ea116c3f4c8356ea52acc663c74 Mon Sep 17 00:00:00 2001
From: Eric Helgeson <erichelgeson@gmail.com>
Date: Fri, 17 Apr 2026 17:38:27 -0500
Subject: [PATCH 7/8] scsi: WRITE to read-only media returns DATA_PROTECT sense
 key
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Per SCSI-2 §9.1.12 (Error reporting) and Table 69, WRITE PROTECTED (ASC 0x2700) pairs with sense key DATA_PROTECT (0x07), not ILLEGAL_REQUEST (0x05). Some hosts branch on the sense key to distinguish 'you passed a bad CDB' from 'the media is write-protected' and will retry incorrectly if we report the former. 