### PR TITLE
Add a warning to zuluscsi_timings.ini SDIO timings

### DIFF
--- a/zuluscsi_timings.ini
+++ b/zuluscsi_timings.ini
@@ -99,6 +99,10 @@ max_sync = 50
 
 
 [sdio]
+###############################################################################
+#  The SDIO settings only affect RP2040 based boards                          #
+#  RP2350 uses the https://github.com/rabbitholecomputing/SDIO_RP2350 library #
+###############################################################################
 # These settings determine the clock setting and duty cycle of the SDIO clock
 clk_div_pio = 5 # clk_hz / clk_div_pio should be between 25MHz and 50MHz
 # SDIO first communicates to the SD card at 1MHz, clk_div_1mhz divides the SDIO clock down to 1MHz


### PR DESCRIPTION
As the timings only apply to RP2040s a warning is added to that effect and a link to the RP2350 SDIO library has been added.