### PR TITLE
Enable logging of raw sense data for AS400s

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -293,6 +293,7 @@ static void doModeSense(int sixByteCmd, int dbd, int pc, int pageCode, int alloc
 	{
 		scsiDev.dataLen = as400_mode_sense_all_pages_len > allocLength ? allocLength : as400_mode_sense_all_pages_len;
 		memcpy(scsiDev.data, as400_mode_sense_all_pages, scsiDev.dataLen); 
+		modeLogData(scsiDev.target->cfg->scsiId & S2S_CFG_TARGET_ID_BITS, "Mode Sense AS400 data: ", scsiDev.data, scsiDev.dataLen);
 		scsiDev.phase = DATA_IN;
 		return;
 	}
@@ -633,6 +634,8 @@ static void doModeSense(int sixByteCmd, int dbd, int pc, int pageCode, int alloc
 		}
 
 		scsiDev.dataLen = idx > allocLength ? allocLength : idx;
+		modeLogData(scsiDev.target->cfg->scsiId & S2S_CFG_TARGET_ID_BITS, "Mode Sense Generic data: ",  scsiDev.data, scsiDev.dataLen);
+
 		scsiDev.phase = DATA_IN;
 	}
 }
@@ -645,6 +648,7 @@ static void doModeSelect(void)
 	{
 		// scsiDev.dataLen bytes are in scsiDev.data
 
+		modeLogData(scsiDev.target->cfg->scsiId & S2S_CFG_TARGET_ID_BITS,  "Raw Mode Select data: ", scsiDev.data, scsiDev.dataLen);
 		int idx;
 		int blockDescLen;
 		if (scsiDev.cdb[0] == 0x55)

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -145,6 +145,17 @@ void log_raw(bytearray array)
     }
 }
 
+void log_raw(fullbytearray array)
+{
+    for (size_t i = 0; i < array.len; i++)
+    {
+        log_raw(array.data[i]);
+        log_raw(" ");
+    }
+}
+
+
+
 void logmsg_start()
 {
     log_raw("[", (int)millis(), "ms] ");

--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -70,7 +70,16 @@ struct bytearray {
     const uint8_t *data;
     size_t len;
 };
+
+struct fullbytearray {
+    fullbytearray(const uint8_t *data, size_t len): data(data), len(len) {}
+    const uint8_t *data;
+    size_t len;
+};
+
 void log_raw(bytearray array);
+
+void log_raw(fullbytearray array);
 
 inline void log_raw()
 {

--- a/src/ZuluSCSI_mode.cpp
+++ b/src/ZuluSCSI_mode.cpp
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include <string.h>
-
+#include <minIni.h>
 #ifdef ENABLE_AUDIO_OUTPUT
 #include "ZuluSCSI_audio.h"
 #endif
@@ -238,4 +238,19 @@ int modeMinSectorSize()
         return scsiTapeMinSectorSize();
     }
     return MIN_SECTOR_SIZE;
+}
+
+extern "C"
+void modeLogData(uint8_t scsi_id, const char* msg, const uint8_t *buf, size_t len)
+{
+    static int8_t log_data = -1;
+    if (log_data == -1)
+    {
+        log_data = ini_getbool("SCSI", "LogModeData", 0, CONFIGFILE);
+    }
+
+    if (log_data)
+    {
+        logmsg("SCSIID: ", (int)scsi_id, " ", msg , "\n", fullbytearray(buf, len));
+    }
 }

--- a/src/ZuluSCSI_mode.h
+++ b/src/ZuluSCSI_mode.h
@@ -29,3 +29,5 @@ int modeSelectCDAudioControlPage(int pageLen, int idx);
 
 int modeMaxSectorSize();
 int modeMinSectorSize();
+
+void modeLogData(uint8_t scsi_id, const char* msg, const uint8_t *buf, size_t len);

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -12,6 +12,7 @@
 #DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card
+#LogModeData = 0 # Set to 1 to Log raw Mode Select and and Mode Sense data
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9


### PR DESCRIPTION
Setting `LogModeData = 1` under `[SCSI]` will log the raw mode sense and select data even with debug turned off.

This is an attempt to help users debug issues with the AS400, but could be valuable in other settings.