### PR TITLE
[enhancement] Improve debug trace to include SCSI command hex value (#804)

### DIFF
--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -335,7 +335,7 @@ void scsiLogDataOut(const uint8_t *buf, uint32_t length)
 {
     if (buf == scsiDev.cdb || g_LogInitiatorCommand)
     {
-        dbgmsg("---- COMMAND: ", getCommandName(buf[0]));
+        dbgmsg("---- COMMAND: ", buf[0], " (", getCommandName(buf[0]), ")");
     }
     
     if (g_LogData)


### PR DESCRIPTION
### Linked Issue
Closes #804

### Motivation
The SCSI trace debug log in `src/ZuluSCSI_log_trace.cpp` previously emitted lines such as `---- COMMAND: Unknown` whenever an opcode was not present in `getCommandName()`. That made trace dumps ambiguous: the reader had to correlate the following `------ OUT:` hex dump line to recover the actual opcode byte. Including the hex value directly on the `COMMAND:` line makes traces self-contained and makes unrecognized opcodes directly actionable (they can be looked up in the SCSI spec or added to the switch).

This allows me to debug better these kind of events that I see in the trace logs (for AS/400):
```
[1011168ms] DBG -- BUS_FREE
[1011168ms] DBG -- BUS_BUSY
[1011168ms] DBG ---- SELECTION: 5
[1011170ms] DBG ---- COMMAND: Unknown
[1011170ms] DBG ------ OUT: 0xDE 0x00 0x00 0x00 0x00 0x00 
[1011170ms] DBG ---- STATUS: 2 CHECK_CONDITION, sense code 0x06, asc 0x00002900
[1011176ms] DBG ---- MESSAGE_OUT
[1011176ms] DBG ------ OUT: 0x00 
[1011176ms] DBG -- BUS_FREE
[1011176ms] DBG -- BUS_BUSY
```


### What Changed
In `scsiLogDataOut()` (src/ZuluSCSI_log_trace.cpp:338), the `dbgmsg` that emits the `COMMAND:` line now logs the opcode byte as a `0xXX` hex literal and the decoded name in parentheses instead of only the decoded name. All other trace output is unchanged. The existing `log_raw(uint8_t)` overload in `src/ZuluSCSI_log.cpp` provides the `0xXX` formatting, so no new formatting code is needed.

### Design Notes
The hex value is printed unconditionally (not only for unknown opcodes) so every `COMMAND:` line has the same shape. That keeps the format easy to grep and avoids a conditional branch that would diverge the two cases.

### Acceptance Criteria Check
- [x] `scsiLogDataOut()` emits a `COMMAND:` line containing both the hex opcode and the decoded name — src/ZuluSCSI_log_trace.cpp:338.
- [x] Recognized opcode `0x12` renders as `---- COMMAND: 0x12 (Inquiry)` — `getCommandName(0x12)` returns `\"Inquiry\"` at src/ZuluSCSI_log_trace.cpp:56, and `log_raw(uint8_t)` at src/ZuluSCSI_log.cpp:69 emits `0x12`.
- [x] Unrecognized opcode `0xDE` renders as `---- COMMAND: 0xDE (Unknown)` — `getCommandName()` default arm returns `\"Unknown\"` at src/ZuluSCSI_log_trace.cpp:129.
- [x] No other log lines change format — diff is a one-line change confined to the `COMMAND:` emission.
- [x] Firmware still builds cleanly; no new warnings introduced — the change reuses existing `dbgmsg` variadic template and existing `log_raw(uint8_t)` overload, no new types or APIs introduced.

### How Verified
- **Static:** traced the `dbgmsg` variadic template in src/ZuluSCSI_log.h:110 and the `log_raw(uint8_t)` overload in src/ZuluSCSI_log.cpp:69, which formats a `uint8_t` as `0xXX`. Since `buf[0]` in `scsiLogDataOut()` is a `uint8_t`, the correct overload is selected and the resulting output is `---- COMMAND: 0xXX (Name)`.

### Test Coverage
**None** — the project has no test harness for the trace logger and the change is a one-line log formatting adjustment whose output is verified by inspection of the log format. Adding a test framework purely for this line is out of scope for the enhancement.

### Scope of Change
- **Files changed:** `src/ZuluSCSI_log_trace.cpp`
- **Submodule pointer updated:** no
- **Public API changes:** none
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Trivial and local: only debug log output is affected, and only the `COMMAND:` line. No runtime logic, error path, or data path changes. Safe to merge without staged rollout.