### PR TITLE
[bugfix] AS400_DiskPartNumber not patched into standard INQUIRY (#808)

### DIFF
--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -137,16 +137,19 @@ static void injectSerial(uint8_t *data, int offset, uint8_t scsiId)
     memcpy(string, serial, 8);
 }
 
-// Inject the configured 7-char IBM disk part number (FRU) into both the
-// ASCII and EBCDIC slots of the given VPD page buffer. No-op when no
-// override is configured for this SCSI ID.
+// Inject the configured 7-char IBM disk part number (FRU) into the ASCII slot
+// at `asciiOffset`, and optionally into an EBCDIC slot at `ebcdicOffset`. Pass
+// a negative `ebcdicOffset` when the target buffer carries only an ASCII copy
+// (e.g. the standard INQUIRY response). No-op when no override is configured
+// for this SCSI ID.
 static void injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, uint8_t scsiId)
 {
     uint8_t id = scsiId & S2S_CFG_TARGET_ID_BITS;
     if (g_as400_part_override[id].length != 7) return;
 
     memcpy(data + asciiOffset, g_as400_part_override[id].ascii, 7);
-    memcpy(data + ebcdicOffset, g_as400_part_override[id].ebcdic, 7);
+    if (ebcdicOffset >= 0)
+        memcpy(data + ebcdicOffset, g_as400_part_override[id].ebcdic, 7);
 }
 #endif
 
@@ -161,7 +164,9 @@ static void loadAS400Defaults(uint8_t scsiId)
     if (!((config->quirks & S2S_CFG_QUIRKS_AS400) && config->deviceType == S2S_CFG_FIXED))
         return;
 
-    // Default standard inquiry (SPD) with serial injected
+    // Default standard inquiry (SPD) with serial and part number injected.
+    // The SPD carries only an ASCII copy of the 7-char IBM disk part number
+    // at offsets 114-120 — there is no EBCDIC slot here, unlike VPD page 0x01.
     if (g_custom_spd[scsiId].length == 0)
     {
         size_t len = AS400VendorInquiryLen;
@@ -169,6 +174,8 @@ static void loadAS400Defaults(uint8_t scsiId)
         memcpy(g_custom_spd[scsiId].data, AS400VendorInquiry, len);
         if (len >= 46)
             injectSerial(g_custom_spd[scsiId].data, 38, scsiId);
+        if (len >= 121)
+            injectPartNumber(g_custom_spd[scsiId].data, 114, -1, scsiId);
         g_custom_spd[scsiId].length = len;
         loaded_default_data = true;
     }


### PR DESCRIPTION
### Linked Issue
Closes #808

### Root Cause
When `AS400_DiskPartNumber` support was added to `loadAS400Defaults()`, the injection call was wired only into the VPD-page loop (`src/custom_vendor_inquiry.cpp:206-207`), which invokes `injectPartNumber(..., 5, 29, scsiId)` against VPD page 0x01. The standard INQUIRY (SPD) branch of the same function (src/custom_vendor_inquiry.cpp:165-174) already injects the serial into `g_custom_spd[scsiId].data` but does not inject the part number. However, `AS400VendorInquiry` in `src/as400_values.cpp:44` contains an ASCII copy of the 7-char IBM disk part number \`09L4044\` at offsets 114-120 — the same value the VPD page 0x01 blob carries at its own ASCII offset 5 and EBCDIC offset 29. So the standard INQUIRY kept returning the literal \`09L4044\` regardless of the user's `AS400_DiskPartNumber` value, while VPD page 0x01 returned the override. A host that reads both places sees inconsistent identifiers.

### Fix Description
Two small changes in `src/custom_vendor_inquiry.cpp`:

1. Extend \`injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, uint8_t scsiId)\` so that a negative \`ebcdicOffset\` means \"this buffer has no EBCDIC slot — skip the EBCDIC write.\" The ASCII write is always performed when an override is configured; when the override is unset the function remains a no-op, exactly as before. This avoids introducing a separate ASCII-only helper for the one call site that needs it.
2. In \`loadAS400Defaults()\`, right after the existing \`injectSerial\` call against the default SPD, call \`injectPartNumber(g_custom_spd[scsiId].data, 114, -1, scsiId)\` guarded by \`len >= 121\` (the 7-byte ASCII slot spans offsets 114-120). The guard mirrors the pre-existing \`len >= 46\` check on the serial injection.

The VPD page 0x01 path (\`injectPartNumber(..., 5, 29, scsiId)\`) is unchanged — its call already passes a valid non-negative EBCDIC offset, so the new conditional has no effect on it.

An ASCII-only-injector helper was considered (e.g. \`injectPartNumberAscii\`) but rejected because it would duplicate the override-length check and the \`memcpy\` for ASCII, at no readability gain over the negative-offset sentinel.

### How Verified
- **Static:** traced the control flow in \`loadAS400Defaults()\`. Before the fix, the default SPD branch (src/custom_vendor_inquiry.cpp:165-174) only called \`injectSerial\`; after the fix, it also calls \`injectPartNumber\` at offset 114 (ASCII only). The VPD page 0x01 branch (src/custom_vendor_inquiry.cpp:206-207) is unchanged. With an AS/400 target configured and \`AS400_DiskPartNumber = \"09L7654\"\` under a \`[SCSI<n>]\` section, the default SPD data returned by \`getCustomSPD\` will now contain \`09L7654\` at offsets 114-120 instead of the literal \`09L4044\`.
- **Offset confirmation:** bytes 114-120 of \`AS400VendorInquiry\` are \`'0','9','L','4','0','4','4'\` (src/as400_values.cpp:44, which is the 8th 16-byte line of the buffer starting at offset 112). No other \`09L4044\` occurrence exists in the SPD, so one injection call covers the full surface.
- **No-override safety:** \`injectPartNumber\` returns early when \`g_as400_part_override[id].length != 7\`, so users who do not set the INI key see byte-identical SPD output to before this patch.
- **Custom SPD safety:** the part-number injection only runs inside the \`g_custom_spd[scsiId].length == 0\` guard (src/custom_vendor_inquiry.cpp:167). Users who supply their own \`spd=\` hex string under \`[SCSI<n>]\` are not overwritten — the override path exits before the injection, same as the existing serial injection.

### Test Coverage
**None** — the project has no test harness for AS/400 INQUIRY generation. The change is exercised at runtime by: setting \`AS400_DiskPartNumber = \"09L7654\"\` under a \`[SCSI<n>]\` section with an AS/400-quirked target, issuing a standard INQUIRY and a VPD page 0x01 request, and confirming both return \`09L7654\` at their respective offsets.

### Scope of Change
- **Files changed:** \`src/custom_vendor_inquiry.cpp\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low: the fix is guarded by the existing \"default SPD only\" branch (\`g_custom_spd[scsiId].length == 0\`), the existing \"override configured\" early return in \`injectPartNumber\`, and a new \`len >= 121\` bounds check on the SPD buffer. Users who do not set \`AS400_DiskPartNumber\` see byte-identical output. Users who do set it now get the override reflected consistently in both the standard INQUIRY and VPD page 0x01.

### Notes
The hardcoded part number at SPD offset 114-120 is the only known place in \`AS400VendorInquiry\` that carries \`09L4044\`. The broader set of hardcoded AS/400 identifiers (drive model \`DGVS09U\`, firmware revision \`02A1\`, and EC/microcode strings in VPD pages 0x03/0xD1/0xD2) is outside the scope of this PR — those have no INI overrides today and would require separate enhancements.