### PR TITLE
Respond to Report LUNs SCSI command

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3875,6 +3875,29 @@ int scsiDiskCommand()
         }
     }
 #endif
+    else if (command == 0xA0)
+    {
+        // Rerport LUNs
+        uint8_t select_report = scsiDev.cdb[2];
+        uint32_t allocationLength =
+            (((uint32_t) scsiDev.cdb[6]) << 24) +
+            (((uint32_t) scsiDev.cdb[7]) << 16) +
+            (((uint32_t) scsiDev.cdb[8]) << 8) +
+            scsiDev.cdb[9];
+        if (select_report != 0x00 || allocationLength < 16)
+        {
+            if (select_report != 0x00)
+                dbgmsg("---- Report LUNs report ", select_report, " not supported yet");
+            scsiDev.status = CHECK_CONDITION;
+            scsiDev.target->sense.code = ILLEGAL_REQUEST;
+            scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+            scsiDev.phase = STATUS;
+        }
+        memset(scsiDev.data, 0, 16);
+        scsiDev.data[3] = 0x08;// (uint32_t)(msb_data[0] - lsb_data[3]) = 8
+        scsiDev.dataLen = 16;
+        scsiDev.phase = DATA_IN;
+	}
     else
     {
         commandHandled = 0;

--- a/src/ZuluSCSI_log_trace.cpp
+++ b/src/ZuluSCSI_log_trace.cpp
@@ -103,6 +103,7 @@ static const char *getCommandName(uint8_t cmd)
         case 0xB9: return "ReadCDMSF";
         case 0x55: return "ModeSelect10";
         case 0x5A: return "ModeSense10";
+        case 0xA0: return "Report LUNs";
         case 0xA8: return "Read12";
         case 0xAA: return "Write12";
         case 0xAC: return "Erase12";


### PR DESCRIPTION
An AS400 system was issuing this command to a hard drive. Cloning the response from a real  IBM hard drive. Besides the list length, all values are zero.

The IBM ESS document reports that the Select Report field in the CDB is reserved. If the Select Report field is anything other than zero, it report a debug message stating that it isn't supported and throws a Invalid Field in CDB check condition.