### PR TITLE
Fix AS400 Inquiry and move Report LUNs

### DIFF
--- a/lib/SCSI2SD/src/firmware/disk.h
+++ b/lib/SCSI2SD/src/firmware/disk.h
@@ -54,6 +54,7 @@ void scsiDiskInit(void);
 void scsiDiskReset(void);
 void scsiDiskPoll(void);
 int scsiDiskCommand(void);
+void scsiDiskReportLUNs(void);
 int doTestUnitReady();
 
 #endif

--- a/lib/SCSI2SD/src/firmware/inquiry.c
+++ b/lib/SCSI2SD/src/firmware/inquiry.c
@@ -107,7 +107,9 @@ void s2s_scsiInquiry()
 {
 	uint8_t evpd = scsiDev.cdb[1] & 1; // enable vital product data.
 	uint8_t pageCode = scsiDev.cdb[2];
-	uint32_t allocationLength = scsiDev.cdb[4];
+	uint16_t allocationLength = 
+		(((uint16_t) scsiDev.cdb[4]) << 8) +
+		scsiDev.cdb[5];
 
 	// SASI standard, X3T9.3_185_RevE  states that 0 == 256 bytes
 	// BUT SCSI 2 standard says 0 == 0.

--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -623,6 +623,11 @@ static void process_Command()
 		// This is a good time to clear out old sense information.
 		memset(&scsiDev.target->sense, 0, sizeof(ScsiSense));
 	}
+	else if (command == 0xA0)
+	{
+		// Report LUNs
+		scsiDiskReportLUNs();
+	}
 	// Some old SCSI drivers do NOT properly support
 	// unitAttention. eg. the Mac Plus would trigger a SCSI reset
 	// on receiving the unit attention response on boot, thus

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -679,8 +679,7 @@ bool findHDDImages()
           g_scsi_settings.getDevice(id)->blockSize = is_cd ?  DEFAULT_BLOCKSIZE_OPTICAL : DEFAULT_BLOCKSIZE;
         }
         int blk = getBlockSize(name, id);
-
-        parseCustomInquiryData(id);
+        parseCustomInquiryData(id, type);
 
         scsiDiskGetImageConfig(id).tapeDensity = g_scsi_settings.getDevice(id)->tapeDensity;
         // Open the image file
@@ -696,7 +695,7 @@ bool findHDDImages()
         else if(id < S2S_MAX_TARGETS && lun < NUM_SCSILUN) {
           logmsg("---- Opening ", fullname, " for id:", id, " lun:", lun);
 
-           imageReady = scsiDiskOpenHDDImage(id, fullname, lun, blk, type, use_prefix);
+          imageReady = scsiDiskOpenHDDImage(id, fullname, lun, blk, type, use_prefix);
           if(imageReady)
           {
             foundImage = true;

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -120,7 +120,8 @@
 #define APPLE_DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",         "2.0f",            ""}
 #define APPLE_DRIVEINFO_TAPE      {"ZULUSCSI", "APPLE_TAPE",        PLATFORM_REVISION, ""}
 
-#define AS400_DRIVEINFO_OPTICAL   {"IBM",      "CDRM00203",         PLATFORM_REVISION, ""}
+#define AS400_DRIVEINFO_DGVS09U_FIXED  {"IBMAS400", "DGVS09U",      "02A1",             ""}
+#define AS400_DRIVEINFO_OPTICAL        {"IBM",      "CDRM00203",     PLATFORM_REVISION, ""}
 
 // Default Iomega ZIP drive information
 #define IOMEGA_DRIVEINFO_ZIP100     {"IOMEGA", "ZIP 100", "D.13", ""}

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3353,6 +3353,31 @@ void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length,uint8_t ski
 }
 #endif
 
+
+extern "C"
+void scsiDiskReportLUNs()
+{
+    uint8_t select_report = scsiDev.cdb[2];
+    uint32_t allocationLength =
+        (((uint32_t) scsiDev.cdb[6]) << 24) +
+        (((uint32_t) scsiDev.cdb[7]) << 16) +
+        (((uint32_t) scsiDev.cdb[8]) << 8) +
+        scsiDev.cdb[9];
+    if (select_report != 0x00 || allocationLength < 16)
+    {
+        if (select_report != 0x00)
+            dbgmsg("---- Report LUNs report ", select_report, " not supported yet");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+        scsiDev.phase = STATUS;
+    }
+    memset(scsiDev.data, 0, 16);
+    scsiDev.data[3] = 0x08;// (uint32_t)(msb_data[0] - lsb_data[3]) = 8
+    scsiDev.dataLen = 16;
+    scsiDev.phase = DATA_IN;
+}
+
 /********************/
 /* Command dispatch */
 /********************/
@@ -3875,29 +3900,6 @@ int scsiDiskCommand()
         }
     }
 #endif
-    else if (command == 0xA0)
-    {
-        // Rerport LUNs
-        uint8_t select_report = scsiDev.cdb[2];
-        uint32_t allocationLength =
-            (((uint32_t) scsiDev.cdb[6]) << 24) +
-            (((uint32_t) scsiDev.cdb[7]) << 16) +
-            (((uint32_t) scsiDev.cdb[8]) << 8) +
-            scsiDev.cdb[9];
-        if (select_report != 0x00 || allocationLength < 16)
-        {
-            if (select_report != 0x00)
-                dbgmsg("---- Report LUNs report ", select_report, " not supported yet");
-            scsiDev.status = CHECK_CONDITION;
-            scsiDev.target->sense.code = ILLEGAL_REQUEST;
-            scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
-            scsiDev.phase = STATUS;
-        }
-        memset(scsiDev.data, 0, 16);
-        scsiDev.data[3] = 0x08;// (uint32_t)(msb_data[0] - lsb_data[3]) = 8
-        scsiDev.dataLen = 16;
-        scsiDev.phase = DATA_IN;
-	}
     else
     {
         commandHandled = 0;

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -310,6 +310,7 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
     static const char * const apl_driveinfo_tape[4]      = APPLE_DRIVEINFO_TAPE;
 
 #ifdef PLATFORM_AS400
+    static const char * const as400_driveinfo_dgvs09u_fixed[4] = AS400_DRIVEINFO_DGVS09U_FIXED;
     static const char * const as400_driveinfo_optical[4] = AS400_DRIVEINFO_OPTICAL;
 #endif
 
@@ -363,14 +364,12 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
         case DEV_PRESET_AS400_BS520:
             deviceInitAS400(scsiId);
             cfgDev.blockSize = 520;
-            static const char *as400_bs520[4] = {"IBM", devicePresetName[DEV_PRESET_AS400_BS520], PLATFORM_REVISION, ""};
-            driveinfo = as400_bs520;
+            driveinfo = as400_driveinfo_dgvs09u_fixed;
             break;
         case DEV_PRESET_AS400_BS522:
             deviceInitAS400(scsiId);
             cfgDev.blockSize = 522;
-            static const char *as400_bs522[4] = {"IBM", devicePresetName[DEV_PRESET_AS400_BS522], PLATFORM_REVISION, ""};
-            driveinfo = as400_bs522;
+            driveinfo = as400_driveinfo_dgvs09u_fixed;
             break;
 #endif
         default:

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -156,15 +156,15 @@ static void injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, u
 #ifdef PLATFORM_AS400
 // Populate default AS/400 inquiry and VPD data
 // Only fills in data that wasn't already provided via INI.
-static void loadAS400Defaults(uint8_t scsiId)
+static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
 {
     bool loaded_default_data = false;
 
     const S2S_TargetCfg *config = scsiDev.targets[scsiId].cfg;
-    if (!((config->quirks & S2S_CFG_QUIRKS_AS400) && config->deviceType == S2S_CFG_FIXED))
+    if (!((g_scsi_settings.getSystem()->quirks & S2S_CFG_QUIRKS_AS400) && type== S2S_CFG_FIXED))
         return;
 
-    // Default standard inquiry (SPD) with serial and part number injected.
+        // Default standard inquiry (SPD) with serial and part number injected.
     // The SPD carries only an ASCII copy of the 7-char IBM disk part number
     // at offsets 114-120 — there is no EBCDIC slot here, unlike VPD page 0x01.
     if (g_custom_spd[scsiId].length == 0)
@@ -217,12 +217,12 @@ static void loadAS400Defaults(uint8_t scsiId)
     }
     if (loaded_default_data)
     {
-        logmsg("-- Loaded default AS/400 inquiry data for SCSI ID ", (int) scsiId);
+        logmsg("---- Loaded default AS/400 inquiry data for SCSI ID ", (int) scsiId);
     }
 }
 #endif
 
-void parseCustomInquiryData(uint8_t scsiId)
+void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
 {
     char tmp[512];
     char section[6] = "SCSI0";
@@ -250,7 +250,7 @@ void parseCustomInquiryData(uint8_t scsiId)
             g_custom_vpd[idx].length = parseHexString(tmp, g_custom_vpd[idx].data, MAX_VPD_DATA_SIZE);
             if (g_custom_vpd[idx].length > 0)
             {
-                logmsg("Custom VPD page 0x", key + 3, " for SCSI ID ", scsiId,
+                logmsg("---- Custom VPD page 0x", key + 3, " for SCSI ID ", scsiId,
                         ": ", (int)g_custom_vpd[idx].length, " bytes");
                 g_custom_vpd_count++;
             }
@@ -263,7 +263,7 @@ void parseCustomInquiryData(uint8_t scsiId)
         g_custom_spd[scsiId].length = parseHexString(tmp, g_custom_spd[scsiId].data, MAX_SPD_SIZE);
         if (g_custom_spd[scsiId].length > 0)
         {
-            logmsg("Custom SPD for SCSI ID ", scsiId, ": ", (int)g_custom_spd[scsiId].length, " bytes");
+            logmsg("---- Custom SPD for SCSI ID ", scsiId, ": ", (int)g_custom_spd[scsiId].length, " bytes");
         }
     }
 #ifdef PLATFORM_AS400
@@ -310,7 +310,7 @@ void parseCustomInquiryData(uint8_t scsiId)
     }
 
     // Load AS/400 defaults for any IDs that don't have INI overrides
-    loadAS400Defaults(scsiId);
+    loadAS400Defaults(scsiId, type);
 #endif
 }
 

--- a/src/custom_vendor_inquiry.h
+++ b/src/custom_vendor_inquiry.h
@@ -24,15 +24,17 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <scsi2sd.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+
 // Parse custom inquiry data from zuluscsi.ini for all SCSI IDs.
 // Called once during initialization.
 // INI format: [SCSI<id>] vpd00=XX XX XX, spd=XX XX XX (hex values)
-void parseCustomInquiryData(uint8_t scsiId);
+void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type);
 
 // Check if custom VPD (Vital Product Data) exists for a given SCSI ID and page code.
 // If found, copies data into buf and sets *length. Returns true if custom data exists.


### PR DESCRIPTION
Fixed the test that disabled the setting the values AS400 inquiry values. It was accidentally disabled when it was moved to a different location in the initialization process.

Moved Report LUNs SCSI command above the handling of check condition in the SCSI command handler. Check Condition normally stops the command from completing. The Report LUNs command, like Inquiry and Request Sense, complete even if the Check Condition state is issued.