### PR TITLE
Initiator on wide, clone SCSI IDs 8-15

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -35,6 +35,7 @@
 #include "SdFat.h"
 #include "vhd_support.h"
 #include "ui.h"
+#include "ZuluSCSI_disk.h"
 
 #include <scsi2sd.h>
 extern "C" {
@@ -213,30 +214,6 @@ void delay_with_poll(uint32_t ms)
     }
 }
 
-static int scsiTypeToIniType(int scsi_type, bool removable)
-{
-    int ini_type = -1;
-    switch (scsi_type)
-    {
-        case SCSI_DEVICE_TYPE_DIRECT_ACCESS:
-            ini_type = removable ? S2S_CFG_REMOVABLE : S2S_CFG_FIXED;
-            break;
-        case SCSI_DEVICE_TYPE_SEQUENTIAL:
-            ini_type = S2S_CFG_SEQUENTIAL;
-            break;
-        case SCSI_DEVICE_TYPE_CD:
-            ini_type = S2S_CFG_OPTICAL;
-            break;
-        case SCSI_DEVICE_TYPE_MO:
-            ini_type = S2S_CFG_MO;
-            break;
-        default:
-            ini_type = -1;
-            break;
-    }
-    return ini_type;
-}
-
 // Check if VHD output should be used for the current target
 static bool initiatorShouldWriteVhd()
 {
@@ -310,7 +287,7 @@ void scsiInitiatorMainLoop()
     if (!g_initiator_state.imaging)
     {
         // Scan for SCSI drives one at a time
-        g_initiator_state.target_id = (g_initiator_state.target_id + 1) % 8;
+        g_initiator_state.target_id = (g_initiator_state.target_id + 1) % S2S_MAX_TARGETS;
         g_initiator_state.sectorsize = 0;
         g_initiator_state.sectorcount = 0;
         g_initiator_state.sectors_done = 0;
@@ -508,7 +485,7 @@ void scsiInitiatorMainLoop()
             if (g_initiator_state.sectorcount > 0)
             {
                 char filename[32] = {0};
-                filename_base[2] += g_initiator_state.target_id;
+                filename_base[2] = scsiEncodeID(g_initiator_state.target_id);
                 if (g_initiator_state.eject_when_done)
                 {
                     auto removable_count = g_initiator_state.removable_count[g_initiator_state.target_id];


### PR DESCRIPTION
Scan SCSI IDs 8-15 and encode their ID in the filename for those 10 and above as hex, e.g. a hard drive with SCSI 11 would be `HDB0_imaged.hda`.