### PR TITLE
Fix AS/400 Skip Read/Write parameter handling to match IBM spec

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3049,6 +3049,17 @@ static void start_dataInTransfer(uint8_t *buffer, uint32_t count)
             }
         }
 
+        // The skip mask must cover every sector the host expects. If the
+        // loop exits with sectors unfilled, those bytes in `buffer` are
+        // stale from the previous transfer — shipping them to the host
+        // would silently corrupt the read. Fail the command instead.
+        if (read_ok && sectors_remaining > 0)
+        {
+            logmsg("Skip Read mask exhausted with ", (int)sectors_remaining,
+                   " sectors unfilled");
+            read_ok = false;
+        }
+
         if (!read_ok)
         {
             logmsg("SD card read failed during Skip Read: ", SD.sdErrorCode());
@@ -3320,7 +3331,27 @@ int16_t skip_next(int max) {
     }
 }
 
+// AS/400 Skip Read/Write entry point
+//
+// Per IBM ESS SCSI Command Reference SC26-7297-01 §"Skip Read"/"Skip Write"
+// (opcodes X'E8' / X'EA', pages 66-67):
+//   - Mask Length=0 specifies a mask length of 256.
+//   - Transfer Length=0 specifies that no data is to be transferred. This
+//     is not an error.
+//   - Maximum transfer length is 256 blocks; larger values return Check
+//     Condition / Illegal Request - Invalid Field in CDB.
 void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length,uint8_t skip_command) {
+
+    if (blocks > 256)
+    {
+        logmsg("Skip command rejected: transfer length ", (int)blocks, " > 256");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+        scsiDev.phase = STATUS;
+        g_disk_transfer.skip_command = 0;
+        return;
+    }
 
     g_disk_transfer.skip_lba = lba;
     g_disk_transfer.skip_blocks = blocks;


### PR DESCRIPTION
### Linked Issue
Tracked in fork: https://github.com/p0dalirius/ZuluSCSI-firmware/issues/4

### Root Cause
`scsiDiskSkip()` historically accepted any 8-bit transfer length passed via the CDB without bound-checking it against the spec maximum, and the Skip Read execution branch in `start_dataInTransfer()` treated `skip_next() == 0` (mask exhausted) as a normal loop termination. Both paths assumed callers would supply well-formed inputs:
- The first assumption violates the IBM ESS SCSI Command Reference SC26-7297-01 (pages 66-67), which mandates that transfer lengths greater than 256 blocks return Check Condition / Illegal Request / Invalid Field in CDB.
- The second assumption is unsafe because `scsiDev.data` is reused across transfers; if the mask runs out before all sectors are produced, the unfilled tail of the buffer still contains bytes from the previous I/O. Forwarding that buffer to the host silently corrupts the read.

### Fix Description
1. In `scsiDiskSkip()` (`src/ZuluSCSI_disk.cpp`), add an early `blocks > 256` guard that sets `CHECK_CONDITION` / `ILLEGAL_REQUEST` / `INVALID_FIELD_IN_CDB`, clears `g_disk_transfer.skip_command`, and returns before any DATA_OUT phase is entered. Document the spec-derived rules for Mask Length=0, Transfer Length=0, and the 256-block ceiling in a leading comment block.
2. In the Skip Read branch of `start_dataInTransfer()`, after the `while` loop, check `read_ok && sectors_remaining > 0`. If true, log the residual sector count and flip `read_ok = false` so the existing error path raises `CHECK_CONDITION` / `MEDIUM_ERROR` / `UNRECOVERED_READ_ERROR`.

The existing `mask_length == 0 → 256` handling and the `skip_total_true_bits` mask-bit-count check are unchanged.

### How Verified
**Build:** `pio run -e ZuluSCSI_Pico` succeeds with no new warnings on `src/ZuluSCSI_disk.cpp`. RAM 51.2% / Flash 13.0%, unchanged in shape from baseline. The `PLATFORM_AS400` macro is unconditionally defined for RP2MCU envs, so the modified code path is exercised by the build.

**Static:** Walked the corrected paths against the IBM spec.
- `scsiDiskSkip` (`src/ZuluSCSI_disk.cpp` L3334–L3344): a `blocks` value of 257 now hits the new guard, sets sense to Illegal Request / Invalid Field in CDB, and returns without entering DATA_OUT — matches the spec's required response.
- `start_dataInTransfer` skip-read branch (`src/ZuluSCSI_disk.cpp` L3052–L3062): if the mask exhausts the position before `sectors_remaining` reaches zero, the new check converts what was previously a silent partial read into the existing CHECK CONDITION / MEDIUM ERROR / UNRECOVERED READ ERROR sense path, preventing stale buffer bytes from being shipped to the host.

### Test Coverage
**None:** the AS/400 Skip Read/Write code path is gated by `PLATFORM_AS400` and exercised by AS/400 host hardware; the repo has no host-side test harness that drives X'E8'/X'EA' CDBs against `scsiDev` state. Validation here is by code analysis against the cited IBM spec, matching how prior changes in this area have been validated.

### Scope of Change
- **Files changed:** `src/ZuluSCSI_disk.cpp`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local change confined to the AS/400 Skip Read/Write path (`PLATFORM_AS400` only). The new transfer-length guard rejects out-of-spec CDBs that previously proceeded; well-formed AS/400 hosts will not hit it. The new sectors-unfilled check converts a silent corruption into a clean CHECK CONDITION, which is strictly safer for hosts.

### Notes
Equivalent fix shipped for BlueSCSI: BlueSCSI/BlueSCSI-v2@6c23a0aa339cc1eb3d4b14727c5e4d433d4525d3.