### PR TITLE
[DO NOT MERGE] Port BlueSCSI fix: align AS/400 Skip Read/Write with IBM spec

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3049,6 +3049,17 @@ static void start_dataInTransfer(uint8_t *buffer, uint32_t count)
             }
         }
 
+        // The skip mask must cover every sector the host expects. If the
+        // loop exits with sectors unfilled, those bytes in `buffer` are
+        // stale from the previous transfer — shipping them to the host
+        // would silently corrupt the read. Fail the command instead.
+        if (read_ok && sectors_remaining > 0)
+        {
+            logmsg("Skip Read mask exhausted with ", (int)sectors_remaining,
+                   " sectors unfilled");
+            read_ok = false;
+        }
+
         if (!read_ok)
         {
             logmsg("SD card read failed during Skip Read: ", SD.sdErrorCode());
@@ -3320,7 +3331,27 @@ int16_t skip_next(int max) {
     }
 }
 
-void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length,uint8_t skip_command) {
+// AS/400 Skip Read/Write entry point
+//
+// Per IBM ESS SCSI Command Reference SC26-7297-01 §"Skip Read"/"Skip Write"
+// (opcodes X'E8' / X'EA', pages 66-67):
+//   - Mask Length=0 specifies a mask length of 256.
+//   - Transfer Length=0 specifies that no data is to be transferred. This
+//     is not an error.
+//   - Maximum transfer length is 256 blocks; larger values return Check
+//     Condition / Illegal Request - Invalid Field in CDB.
+void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length, uint8_t skip_command) {
+
+    if (blocks > 256)
+    {
+        logmsg("Skip command rejected: transfer length ", (int)blocks, " > 256");
+        scsiDev.status = CHECK_CONDITION;
+        scsiDev.target->sense.code = ILLEGAL_REQUEST;
+        scsiDev.target->sense.asc = INVALID_FIELD_IN_CDB;
+        scsiDev.phase = STATUS;
+        g_disk_transfer.skip_command = 0;
+        return;
+    }
 
     g_disk_transfer.skip_lba = lba;
     g_disk_transfer.skip_blocks = blocks;


### PR DESCRIPTION
## Summary

Backports [BlueSCSI commit `6c23a0a`](https://github.com/BlueSCSI/BlueSCSI-v2/commit/6c23a0aa339cc1eb3d4b14727c5e4d433d4525d3) by Eric Helgeson, with conflict resolution for ZuluSCSI's diverged AS/400 code path.

Two changes to `scsiDiskSkip` and the skip-read execution path, validated against IBM ESS SCSI Command Reference SC26-7297-01 §"Skip Read"/"Skip Write" (opcodes X'E8' / X'EA', pages 66–67):

1. **`scsiDiskSkip` rejects `transfer_length > 256`** with Check Condition / Illegal Request / Invalid Field in CDB. The 8-bit field cannot encode 256 directly; the spec maximum is 256 blocks.

2. **`start_dataInTransfer` skip-read branch raises Check Condition / Medium Error / Unrecovered Read Error** if the skip mask is exhausted while sectors are still unfilled, instead of shipping stale buffer bytes to the host (silent host-side data corruption).

## Conflict resolution notes

- ZuluSCSI's `scsiDiskSkip` already had the `mask_length == 0 → 256` fix from the BlueSCSI patch. That hunk was a no-op.
- BlueSCSI calls the field `g_disk_transfer.skip_direction`; ZuluSCSI calls it `g_disk_transfer.skip_command`. Adapted accordingly.
- BlueSCSI's `scsiDiskSkip` is `static`; ZuluSCSI's is plain `void` (called from a different translation unit). Linkage left as-is.

## Status: untested

> [!WARNING]
> **DO NOT MERGE.** This is a code-only port; the changes have not been exercised on real AS/400 hardware. The Skip Read/Write code path is only reachable from an IBM AS/400 host issuing `X'E8'`/`X'EA'` CDBs, which I do not currently have access to. Marking as draft until verified.

## Test plan

- [ ] Build all default envs (Blaster / Wide / RP2040 / Pico / Pico_DaynaPORT / Pico_2 / Pico_2_DaynaPORT) — done locally, all 7 SUCCESS in ~53s
- [ ] Verify `transfer_length > 256` is rejected with correct sense data on real AS/400 host
- [ ] Verify a malformed (under-filled) skip mask now raises Medium Error instead of returning stale bytes
- [ ] Verify normal Skip Read/Write paths still work (regression check)
- [ ] Confirm with @erichelgeson that the BlueSCSI port preserves the original semantics