### PR TITLE
Fix VPD/SPD buffer truncation losing AS/400 EC data (#834)

### DIFF
--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -37,8 +37,13 @@
 
 // Storage for custom VPD pages: up to 16 entries across all SCSI IDs
 // Each entry: [0]=scsiId, [1]=pageCode, [2]=length, [3..]=data
+//
+// MAX_VPD_DATA_SIZE is 255 -- the maximum representable in the `length`
+// field below (uint8_t). The largest AS/400 disk-profile capture in tree
+// today is XCPR036 page 0xC3 at 250 bytes; pages 0xD1 / 0xD2 are 244 B.
+// Going to 255 leaves a few bytes of headroom without widening `length`.
 #define MAX_CUSTOM_VPD_ENTRIES 16
-#define MAX_VPD_DATA_SIZE 128
+#define MAX_VPD_DATA_SIZE 255
 static struct {
     uint8_t scsiId;
     uint8_t pageCode;
@@ -48,7 +53,10 @@ static struct {
 static int g_custom_vpd_count = 0;
 
 // Storage for custom standard inquiry data per SCSI ID
-#define MAX_SPD_SIZE 128
+//
+// MAX_SPD_SIZE is sized to fit the AS/400 standard INQUIRY captures
+// (DGVS09U and XCPR036 are both 164 bytes) with headroom.
+#define MAX_SPD_SIZE 192
 static struct {
     uint8_t length;
     uint8_t data[MAX_SPD_SIZE];


### PR DESCRIPTION
### Linked Issue

Closes #834

### Root Cause

`MAX_SPD_SIZE` and `MAX_VPD_DATA_SIZE` in `src/custom_vendor_inquiry.cpp` were both hardcoded to 128 bytes when `parseCustomInquiryData()` was first written. At that time the only AS/400 inquiry data the firmware could emit was a small hand-tabulated table whose used portion fit comfortably within 128 bytes per page. Subsequent profile-driven captures committed to `src/as400_profiles/{dgvs09u,xcpr036}/` carry pages and standard-INQUIRY blobs that exceed the cap, but the constants were not adjusted, so the new bytes are silently dropped at the copy points in `loadAS400Defaults()`.

The standard-INQUIRY case is additionally a SCSI protocol violation: the `additional_length` byte at INQUIRY offset 4 still advertises the full uncapped size (`0x9F` = 159 -> total 164 B for AS/400 captures) while only 128 B are actually returned to the host.

### Fix Description

Two-line constant bump in `src/custom_vendor_inquiry.cpp`:

```diff
-#define MAX_VPD_DATA_SIZE 128
+#define MAX_VPD_DATA_SIZE 255
...
-#define MAX_SPD_SIZE 128
+#define MAX_SPD_SIZE 192
```

The new sizes are chosen to be the maximum representable in the existing `uint8_t length` field (255) for VPD pages, and 192 B for standard INQUIRY (164 B captured + 28 B headroom). No struct-layout changes, no API changes, no `length`-field type changes.

Alternatives considered:

- *Keep the current cap and add a runtime warning when truncation happens.* Rejected: the truncated data is genuine on-the-wire content the host expects to see; warning rather than fixing leaves the disk emulation incorrect.
- *Widen `length` to `uint16_t` and allow buffers larger than 255 B.* Deferred: every AS/400 capture currently in tree fits in 255 B (largest is XCPR036 page 0xC3 at 250 B). A `uint16_t` migration touches more code paths and can be done if/when a larger page is captured.

### How Verified

- **Static:** Walked through the truncation sites in `loadAS400Defaults()` (the SPD and VPD page copy loops) and confirmed both now copy the full captured length without clamping. The `length` field still holds the actual emitted size; consumers (`getCustomVPD()` / `getCustomSPD()`) already honour it.
- **Build:** `pio run -e ZuluSCSI_Pico` succeeds with no warnings. RAM utilisation went from 134,388 B to 136,708 B (+2,320 B / +0.9 percentage point of total RAM), matching the predicted RAM impact.
- **Cross-platform check before push:** the change is platform-agnostic (no MCU-specific code, just two `#define`s in shared firmware code), so a single env build is representative.

### Test Coverage

**None.** The firmware has no on-target unit tests for the AS/400 inquiry path; behavioural verification on real hardware is by SCSI-level capture against an emulated target. Adding a host-side test harness for `getCustomVPD` / `getCustomSPD` is out of scope for this fix.

### Scope of Change

- **Files changed:** `src/custom_vendor_inquiry.cpp` (1 file, 10 insertions, 2 deletions)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The same byte sequences are emitted as before for any capture that fit within the old caps; captures that exceeded the caps now emit their full content.

### Risk and Rollout

Low blast radius. The change only affects the size of two static buffers and the truncation predicate that clamps the copy length. RAM cost is +2.5 KB total across `g_custom_vpd[16]` + `g_custom_spd[8]`, well within every default env's RAM budget (smallest target is RP2040 with 256 KB; current usage on Pico is 51% pre-fix, 52% post-fix). No new failure modes introduced.

If a deployment was relying on the 128-byte truncation for some specific behaviour (extremely unlikely -- the truncation was silent and not part of any contract), that behaviour changes. The expected semantic -- "emit captured profile data verbatim" -- is now correct.

### Notes

The two affected captures already in tree are:

- `src/as400_profiles/dgvs09u/standard_inquiry.bin` (164 B)
- `src/as400_profiles/xcpr036/standard_inquiry.bin` (164 B)
- `src/as400_profiles/xcpr036/page_c3.bin` (250 B)
- `src/as400_profiles/xcpr036/page_d1.bin` (244 B)
- `src/as400_profiles/xcpr036/page_d2.bin` (244 B)

Out of scope for this PR but worth tracking: no log message is emitted today even when truncation does occur. If a future capture exceeds the new 255 B cap, it will silently truncate again. A follow-up enhancement could log a warning at boot when any profile page or std INQUIRY blob exceeds the buffer size.