### PR TITLE
Fix wide parity errors

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_target_wide.cpp
@@ -726,7 +726,7 @@ static void process_dma_readbuf()
                 uint32_t word = *src++;
                 *(uint16_t*)dst = (uint16_t)word;
                 dst += 2;
-                if (!scsi_check_parity_16bit(word)) parity_error = true;
+                if (!scsi_check_parity_16bit(~word)) parity_error = true;
             }
         }
 
@@ -735,7 +735,7 @@ static void process_dma_readbuf()
             uint32_t word = *src++;
             *(uint16_t*)dst = (uint16_t)word;
             dst += 2;
-            if (!scsi_check_parity_16bit(word)) parity_error = true;
+            if (!scsi_check_parity_16bit(~word)) parity_error = true;
         }
 
         if (parity_error)
@@ -755,7 +755,7 @@ static void process_dma_readbuf()
             {
                 uint32_t word = *src++;
                 *dst++ = (uint8_t)word;
-                if (!scsi_check_parity(word)) parity_error = true;
+                if (!scsi_check_parity(~word)) parity_error = true;
             }
         }
 
@@ -763,7 +763,7 @@ static void process_dma_readbuf()
         {
             uint32_t word = *src++;
             *dst++ = (uint8_t)word;
-            if (!scsi_check_parity(word)) parity_error = true;
+            if (!scsi_check_parity(~word)) parity_error = true;
         }
 
         if (parity_error)


### PR DESCRIPTION
The parity calculations for 8 bit and 16 bit transfers on wide board seem to assume the actual signal levels on the SCSI bus. Since the wide board inverts input data signals, the data sent to the parity calculations had to be bitwise negated.

In initiator mode, the parity check still uses an accumulator, this should probably be changed to avoid the same parity issues that occurred in target mode listed here:
https://github.com/ZuluSCSI/ZuluSCSI-firmware/pull/839