### PR TITLE
Fix analyze crash logs

### DIFF
--- a/.github/workflows/analyze_crashlogs.yml
+++ b/.github/workflows/analyze_crashlogs.yml
@@ -15,7 +15,7 @@ jobs:
         contains(github.event.comment.body, 'CRASH!') ||
         contains(github.event.comment.body, 'WATCHDOG TIMEOUT'))) ||
       (github.event_name == 'issues' && (
-          contains(github.event.issue.body, 'CRASH!') || contains(github.event.comment.body, 'Crash') || contains(github.event.comment.body, 'crash') || 
+          contains(github.event.issue.body, 'CRASH!')  ||
           contains(github.event.issue.body, 'WATCHDOG TIMEOUT')))
     permissions:
       issues: write

--- a/utils/analyze_crashlog.sh
+++ b/utils/analyze_crashlog.sh
@@ -31,7 +31,7 @@ if [ "x$fwfile" = "x" ]; then
     echo "Searching on Github"
     enddate=$(date "+%Y-%m-%dT%H:%M" -d "$fwtime 600 seconds")
     runid=$(gh api repos/$repo/actions/artifacts \
-        --jq ".artifacts[] | select(.created_at <= \"$enddate\") | .workflow_run.id" | head -n 1)
+        --jq ".artifacts[] | select(.name == \"ZuluSCSI ELFs\") | select(.created_at <= \"$enddate\") | .workflow_run.id" | head -n 1)
     if [ "x$runid" != "x" ]; then
         tmpdir=$(mktemp -d /tmp/crashlog-XXXXXXX)
         echo "Workflow run: https://github.com/$repo/actions/runs/$runid"


### PR DESCRIPTION
Analyze crash logs in Github issues were failing after compiled artifacts were separated into different zip files. Adding a filter in utils/analyze_crash.sh took look for the name "ZuluSCSI ELFs" should select the correct artifact file.