### PR TITLE
fix #846: Tape Emulation - can't read variable block tapes that were just written

### DIFF
--- a/src/ZuluSCSI_tape.cpp
+++ b/src/ZuluSCSI_tape.cpp
@@ -652,6 +652,10 @@ static void doTapRead(image_config_t &img, uint32_t blocks, bool fixed, bool sup
                     dbgmsg("------ TAP variable read hit filemark after ", (int) bytes_read,
                             " bytes(s), residual=", (int)(info),
                             " file_pos=", (int)tape_info->file_pos);
+		    // Tape Emulation - can't read variable block tapes that were just written #846
+		    // because of variable readt, file_pos may be > bytes_read,
+		    // but should be the "rewound" to bytes_read for the next read
+		    tape_info->file_pos = (int) bytes_read;
                 }
                 scsiDev.target->sense.filemark = true;
                 scsiDev.status = CHECK_CONDITION;

--- a/src/ZuluSCSI_tape.cpp
+++ b/src/ZuluSCSI_tape.cpp
@@ -653,8 +653,8 @@ static void doTapRead(image_config_t &img, uint32_t blocks, bool fixed, bool sup
                             " bytes(s), residual=", (int)(info),
                             " file_pos=", (int)tape_info->file_pos);
 		    // Tape Emulation - can't read variable block tapes that were just written #846
-		    // because of variable readt, file_pos may be > bytes_read,
-		    // but should be the "rewound" to bytes_read for the next read
+		    // because of variable reads, file_pos may be > bytes_read,
+		    // but should be "rewound" to bytes_read for the next read otherwise we skip data
 		    tape_info->file_pos = (int) bytes_read;
                 }
                 scsiDev.target->sense.filemark = true;


### PR DESCRIPTION
When encountering a tape mark during variable reads, the firmware can read data beyond the tape mark, then stop processing at the tape mark. this results in `tape_info->file_pos` being greater than `bytes_read`.

The next read starts from file_pos when it should start from bytes_read, in this case there are sum number of bytes (file_pos-bytes_read) in the file that are skipped, so we're into reading the wrong data.

This patch "rewinds" file_pos back to bytes_read if they are different.

This situation never happens in the case of fixed reads, only in variable reads.