### PR TITLE
Fix no vendor/product strings detected when imgX is used

### DIFF
--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -891,6 +891,7 @@ static void scsiDiskSetConfig(int target_idx)
         }
     }
 #endif
+    g_scsi_settings.initDevice(target_idx, (S2S_CFG_TYPE)img.deviceType, true);
 }
 
 // Compares the prefix of both files and the scsi ID


### PR DESCRIPTION
In zuluscsi.ini file if `ImgX = image_name.bin` (where X is a number 0-9) is used for a device type besides a hard drive the vendor/product strings were not being sent to the host.

Adding back a moved g_scsi_settings.initDevice() call to it original location fixes the issue.