### PR TITLE
Log zuluscsi.ini settings from image directory

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -693,7 +693,7 @@ bool findHDDImages()
           }
         }
         else if(id < S2S_MAX_TARGETS && lun < NUM_SCSILUN) {
-          logmsg("---- Opening ", fullname, " for id:", id, " lun:", lun);
+          logmsg("-- Opening ", fullname, " for id:", id, " lun:", lun);
 
           imageReady = scsiDiskOpenHDDImage(id, fullname, lun, blk, type, use_prefix);
           if(imageReady)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -813,7 +813,7 @@ static void scsiDiskCheckDir(char * dir_name, int target_idx, image_config_t* im
             logmsg("SCSI", target_idx, " searching default ", type_name, " image directory '", dir_name, "'");
 
             setRootFolder(target_idx, false, dir_name);
-            g_scsi_settings.initDevice(target_idx, type, true);
+            g_scsi_settings.initDevice(target_idx, type);
         }
     }
 }

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -503,7 +503,7 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
 
     cfg.blockSize = log_ini_getl(section, "BlockSize", cfg.blockSize, CONFIGFILE, log_settings);
     cfg.tapeLengthMB = log_ini_getl(section, "TapeLengthMB", cfg.tapeLengthMB, CONFIGFILE, log_settings);
-    cfg.tapeDensity = log_ini_getl(section, "TapeDensity", cfg.tapeDensity, CONFIGFILE, log_settings);
+    cfg.tapeDensity = log_ini_getl(section, "TapeDensity", cfg.tapeDensity, CONFIGFILE, log_settings, &log_getl_8bit_hex);
 
 
 #if ENABLE_COW


### PR DESCRIPTION
Changes:
- Log zuluscsi.ini settings for image directories
- Log tape density set in zuluscsi.ini as a hex value

If an SD card has an image directory like TP0 or HD1 with an image file in that directory, the `zuluscsi.ini` settings for that device were not being printed in the log.

This fixes the issue by enabling logging for the g_scsi_settings.initDevice() call for image directories.

The example `zuluscsi.ini` file list the different tape densities as hex values, so it makes sense to print the density as hex in the log file if set in `zuluscsi.ini`.