### PR TITLE
Fix inquiry VPD pages returning wrong page code

### DIFF
--- a/lib/SCSI2SD/src/firmware/inquiry.c
+++ b/lib/SCSI2SD/src/firmware/inquiry.c
@@ -45,9 +45,7 @@ static uint8_t StandardResponse[] =
 0, 0, // Reserved
 0x18 // Enable sync and linked commands
 };
-// Vendor set by config 'c','o','d','e','s','r','c',' ',
-// prodId set by config'S','C','S','I','2','S','D',' ',' ',' ',' ',' ',' ',' ',' ',' ',
-// Revision set by config'2','.','0','a'
+// Vendor, Product ID and Revision set by config
 
 
 static const uint8_t SupportedVitalPages[] =
@@ -142,6 +140,38 @@ void s2s_scsiInquiry()
 						config,
 						scsiDev.data,
 						sizeof(scsiDev.data));
+
+				// Set removable bit
+				switch (scsiDev.target->cfg->deviceType)
+				{
+				case S2S_CFG_OPTICAL:
+					scsiDev.data[1] |= 0x80; // Removable bit.
+					break;
+
+				case S2S_CFG_SEQUENTIAL:
+					scsiDev.data[1] |= 0x80; // Removable bit.
+					break;
+
+				case S2S_CFG_MO:
+					scsiDev.data[1] |= 0x80; // Removable bit.
+					break;
+
+				case S2S_CFG_FLOPPY_14MB:
+				case S2S_CFG_REMOVABLE:
+				case S2S_CFG_ZIP100:
+					scsiDev.data[1] |= 0x80; // Removable bit.
+					break;
+
+				case S2S_CFG_NETWORK:
+				case S2S_CFG_AMIGAWIFI:
+					scsiDev.data[2] = 0x01;  // ANSI SCSI version is SCSI 1.
+					break;
+				
+				default:
+					// Accept defaults for a fixed disk.
+					break;
+				}
+
 			}
 			scsiDev.phase = DATA_IN;
 		}
@@ -156,7 +186,7 @@ void s2s_scsiInquiry()
 			scsiDev.dataLen = customVpdLen;
 			scsiDev.phase = DATA_IN;
 		}
-		else	 if (pageCode == 0x00)
+		else if (pageCode == 0x00)
 		{
 			memcpy(scsiDev.data, SupportedVitalPages, sizeof(SupportedVitalPages));
 			scsiDev.dataLen = sizeof(SupportedVitalPages);
@@ -236,35 +266,6 @@ void s2s_scsiInquiry()
 		// Set the device type as needed.
 		scsiDev.data[0] = getDeviceTypeQualifier();
 
-		switch (scsiDev.target->cfg->deviceType)
-		{
-		case S2S_CFG_OPTICAL:
-			scsiDev.data[1] |= 0x80; // Removable bit.
-			break;
-
-		case S2S_CFG_SEQUENTIAL:
-			scsiDev.data[1] |= 0x80; // Removable bit.
-			break;
-
-		case S2S_CFG_MO:
-			scsiDev.data[1] |= 0x80; // Removable bit.
-			break;
-
-		case S2S_CFG_FLOPPY_14MB:
-		case S2S_CFG_REMOVABLE:
-		case S2S_CFG_ZIP100:
-			scsiDev.data[1] |= 0x80; // Removable bit.
-			break;
-
-		case S2S_CFG_NETWORK:
-		case S2S_CFG_AMIGAWIFI:
-			scsiDev.data[2] = 0x01;  // Page code.
-			break;
-		
-		default:
-			// Accept defaults for a fixed disk.
-			break;
-		}
 	}
 
 	// Set the first byte to indicate LUN presence.


### PR DESCRIPTION
The VPD pages returned in a SCSI inquiry command for removable devices contained the wrong page code for some supported pages.

This is because the code would bitwise OR 0x80 to the VPD page code if the device was removable. The code that does this was meant only for standard inquiry responses. The fix is to move this code under the standard inquiry response code path so it isn't applied to VPD page responses.