### PR TITLE
Allow Wi-Fi scans while already connected

### DIFF
--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -142,12 +142,12 @@ typedef struct __attribute__((packed))
 	uint8_t scsiSpeed;
 
 	char wifiMACAddress[6];
-	char wifiSSID[32];
-	char wifiPassword[63];
+	char wifiSSID[32 + 1];
+	char wifiPassword[63 + 1];
 
 	uint8_t busWidth; // Wide bus support, 0: 8-bit, 1: 16-bit, 2: 32-bit
 
-	uint8_t reserved[17]; // Pad out to 128 bytes
+	uint8_t reserved[15]; // Pad out to 128 bytes
 } S2S_BoardCfg;
 
 typedef enum

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -41,11 +41,38 @@ extern "C" {
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
 
 static bool network_in_use = false;
+static bool g_wifi_reconnect = true;
+static char g_wifi_reconnect_ssid[32 + 1] = {0};
+static char g_wifi_reconnect_password[63 + 1] = {0};
 
 // WiFi reconnection state (file-static so wifi_join can reset on credential change)
 static uint32_t wifi_reconnect_time = 0;
-static uint32_t wifi_reconnect_interval = WIFI_RECONNECT_INTERVAL;
+static uint32_t wifi_reconnect_interval = WIFI_RECONNECT_START_INTERVAL;
 static int wifi_reconnect_attempts = 0;
+static bool g_wifi_scan_restore_connection = false;
+static bool g_wifi_scan_suspend_reconnect = false;
+
+static void platform_network_wifi_store_reconnect_credentials(const char *ssid, const char *password)
+{
+	if (ssid != NULL)
+		strlcpy(g_wifi_reconnect_ssid, ssid, sizeof(g_wifi_reconnect_ssid));
+	else
+		g_wifi_reconnect_ssid[0] = '\0';
+
+	if (password != NULL)
+		strlcpy(g_wifi_reconnect_password, password, sizeof(g_wifi_reconnect_password));
+	else
+		g_wifi_reconnect_password[0] = '\0';
+}
+
+static void platform_network_wifi_schedule_reconnect()
+{
+	if (g_wifi_reconnect_ssid[0] == '\0')
+		return;
+
+	g_wifi_scan_suspend_reconnect = false;
+	g_wifi_reconnect = true;
+}
 
 bool platform_network_supported()
 {
@@ -138,11 +165,12 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 	if (!platform_network_supported())
 		return false;
 
+	platform_network_wifi_store_reconnect_credentials(ssid, password);
 	// Explicit join (e.g. SCSI command with new credentials) resets reconnect state
 	if (!reconnect)
 	{
 		wifi_reconnect_attempts = 0;
-		wifi_reconnect_interval = WIFI_RECONNECT_INTERVAL;
+		wifi_reconnect_interval = WIFI_RECONNECT_START_INTERVAL;
 		wifi_reconnect_time = millis();
 	}
 
@@ -161,15 +189,12 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 
 	if (ret == 0)
 	{
-		if (!reconnect)
-		{
-			// Short single blink at start of connection sequence
-			PICO_W_LED_OFF();
-			delay(PICO_W_SHORT_BLINK_DELAY);
-			PICO_W_LED_ON();
-			delay(PICO_W_SHORT_BLINK_DELAY);
-			PICO_W_LED_OFF();
-		}
+		// Short single blink at start of connection sequence
+		PICO_W_LED_OFF();
+		delay(PICO_W_SHORT_BLINK_DELAY);
+		PICO_W_LED_ON();
+		delay(PICO_W_SHORT_BLINK_DELAY);
+		PICO_W_LED_OFF();
 	}
 	else
 	{
@@ -180,53 +205,54 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 
 void platform_network_poll()
 {
+	if (g_wifi_scan_restore_connection && !cyw43_wifi_scan_active(&cyw43_state))
+	{
+		logmsg("Wi-Fi scan complete, reconnecting to \"", g_wifi_reconnect_ssid, "\"");
+		g_wifi_scan_restore_connection = false;
+		platform_network_wifi_schedule_reconnect();
+	}
+
 	static int last_network_status = CYW43_LINK_DOWN;
 	if (!network_in_use)
 		return;
 	int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
-	char * ssid = scsiDev.boardCfg.wifiSSID;
-	if ((last_network_status != status) && (status == CYW43_LINK_BADAUTH || status == CYW43_LINK_NONET || status == CYW43_LINK_FAIL || status == CYW43_LINK_NOIP))
+	char * ssid = (g_wifi_reconnect_ssid[0]) ? g_wifi_reconnect_ssid : scsiDev.boardCfg.wifiSSID;
+	if (status == CYW43_LINK_BADAUTH || status == CYW43_LINK_NONET || status == CYW43_LINK_FAIL || status == CYW43_LINK_NOIP)
 	{
-		switch (status)
+		if (last_network_status != status)
 		{
-			case CYW43_LINK_NOIP:
-				logmsg("Wi-Fi connected to ", ssid, " but was not assigned an IP");
-				break;
-			case CYW43_LINK_BADAUTH:
-				logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the setting \"WiFiPassword\" in ", CONFIGFILE);
-				break;
-			case CYW43_LINK_NONET:
-				logmsg("Wi-Fi SSID ", ssid, " not found, possible out of range or down");
-				break;
-			case CYW43_LINK_FAIL:
-				logmsg("Wi-Fi connection to ", ssid, " failed");
-				break;
+			switch (status)
+			{
+				case CYW43_LINK_NOIP:
+					logmsg("Wi-Fi connected to ", ssid, " but was not assigned an IP");
+					break;
+				case CYW43_LINK_BADAUTH:
+					logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the setting \"WiFiPassword\" in ", CONFIGFILE);
+					break;
+				case CYW43_LINK_NONET:
+					logmsg("Wi-Fi SSID ", ssid, " not found, possible out of range or down");
+					break;
+				case CYW43_LINK_FAIL:
+					logmsg("Wi-Fi connection to ", ssid, " failed");
+					break;
+			}
 		}
-		wifi_reconnect_time = millis();
 	}
 
-	// Reset reconnect state when link comes back up
-	if (status == CYW43_LINK_JOIN || status == CYW43_LINK_NOIP)
-	{
-		wifi_reconnect_attempts = 0;
-		wifi_reconnect_interval = WIFI_RECONNECT_INTERVAL;
-	}
-
-	if (status <= CYW43_LINK_DOWN
-		&& status != CYW43_LINK_BADAUTH
+	if (g_wifi_reconnect
 		&& ssid[0] != '\0'
 		&& scsiDev.phase == BUS_FREE
-		&& wifi_reconnect_attempts < WIFI_RECONNECT_MAX_ATTEMPTS
 		&& (uint32_t)(millis() - wifi_reconnect_time) > wifi_reconnect_interval)
 	{
+		
 		wifi_reconnect_time = millis();
 		wifi_reconnect_attempts++;
-		logmsg("Attempting Wi-Fi reconnection to \"", ssid, "\" (attempt ", wifi_reconnect_attempts, "/", WIFI_RECONNECT_MAX_ATTEMPTS, ")");
-		platform_network_wifi_join(ssid, scsiDev.boardCfg.wifiPassword, true);
-		wifi_reconnect_interval *= 2;
+		wifi_reconnect_interval += WIFI_RECONNECT_INCREMENT_INTERVAL;
+		if (wifi_reconnect_interval > WIFI_RECONECT_MAX_INTERVAL)
+			wifi_reconnect_interval = WIFI_RECONECT_MAX_INTERVAL;
+		logmsg("Attempting Wi-Fi reconnection to \"", ssid, "\" attempts: ", wifi_reconnect_attempts, " next attempt in ", (int)wifi_reconnect_interval / 1000, " seconds");
+		platform_network_wifi_join(ssid, (g_wifi_reconnect_password[0]) ? g_wifi_reconnect_password : scsiDev.boardCfg.wifiPassword, true);
 
-		if (wifi_reconnect_attempts >= WIFI_RECONNECT_MAX_ATTEMPTS)
-			logmsg("Wi-Fi reconnection limit reached, no further attempts will be made");
 	}
 
 	last_network_status = status;
@@ -319,9 +345,40 @@ int platform_network_wifi_start_scan()
 	if (cyw43_wifi_scan_active(&cyw43_state))
 		return -1;
 
+	int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+	if (status != CYW43_LINK_DOWN)
+	{
+		if (g_wifi_reconnect_ssid[0] == '\0' && scsiDev.boardCfg.wifiSSID[0] != '\0')
+			platform_network_wifi_store_reconnect_credentials(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+
+		if (g_wifi_reconnect_ssid[0] != '\0')
+		{
+			logmsg("Temporarily disconnecting from Wi-Fi SSID \"", g_wifi_reconnect_ssid, "\" to scan for hotspots");
+			g_wifi_scan_restore_connection = true;
+			g_wifi_scan_suspend_reconnect = true;
+			cyw43_arch_disable_sta_mode();
+			cyw43_arch_enable_sta_mode();
+		}
+		else
+		{
+			logmsg("Wi-Fi scan requested while connected, but reconnect credentials are not available");
+		}
+	}
+
 	cyw43_wifi_scan_options_t scan_options = { 0 };
 	memset(wifi_network_list, 0, sizeof(wifi_network_list));
-	return cyw43_wifi_scan(&cyw43_state, &scan_options, NULL, platform_network_wifi_scan_result);
+	int ret = cyw43_wifi_scan(&cyw43_state, &scan_options, NULL, platform_network_wifi_scan_result);
+	if (ret != 0)
+	{
+		logmsg("Failed to start Wi-Fi scan: ", ret);
+		if (g_wifi_scan_restore_connection)
+		{
+			g_wifi_scan_restore_connection = false;
+			platform_network_wifi_schedule_reconnect();
+		}
+	}
+
+	return ret;
 }
 
 int platform_network_wifi_scan_finished()
@@ -407,7 +464,14 @@ void cyw43_cb_process_ethernet(void *cb_data, int itf, size_t len, const uint8_t
 
 void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf)
 {
-	logmsg("Disassociated from Wi-Fi SSID \"",  (char *)self->ap_ssid,"\"");
+	if (g_wifi_scan_suspend_reconnect)
+	{
+		logmsg("Disassociated from Wi-Fi to scan for hotspots");
+		return;
+	}
+
+	logmsg("Disassociated from Wi-Fi SSID \"",  g_wifi_reconnect_ssid,"\" reconnecting");
+	g_wifi_reconnect = true;
 }
 
 void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
@@ -417,15 +481,9 @@ void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 	if (ssid)
 	{
 		logmsg("Successfully connected to Wi-Fi SSID \"",ssid,"\"");
-		// blink LED 3 times when connected
-		PICO_W_LED_OFF();
-		for (uint8_t i = 0; i < 3; i++)
-		{
-			delay(PICO_W_SHORT_BLINK_DELAY);
-			PICO_W_LED_ON();
-			delay(PICO_W_SHORT_BLINK_DELAY);
-			PICO_W_LED_OFF();
-		}
+		wifi_reconnect_attempts = 0;
+		wifi_reconnect_interval = WIFI_RECONNECT_START_INTERVAL;
+		g_wifi_reconnect = false;
 	}
 }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -36,6 +36,15 @@ extern "C" {
 #define PICO_W_LED_OFF() cyw43_arch_gpio_put(PICO_W_GPIO_LED_PIN, 0)
 #define PICO_W_LONG_BLINK_DELAY 200
 #define PICO_W_SHORT_BLINK_DELAY 75
+#define PICO_W_BLINK_CONNECTED_TIMES 3
+enum blink_connected_t
+{
+	BLINK_CONNECTED_OFF = 0,
+	BLINK_CONNECTED_ON,
+	BLINK_CONNECTED_ACTIVE,
+};
+static blink_connected_t g_blink_connected = BLINK_CONNECTED_OFF;
+
 
 // A default DaynaPort-compatible MAC
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
@@ -205,6 +214,39 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 
 void platform_network_poll()
 {
+	if (scsiDev.phase == BUS_FREE)
+	{
+		static uint32_t blink_start = 0;
+		static uint8_t blinks = 0;
+		if (g_blink_connected == BLINK_CONNECTED_ON)
+		{
+			blink_start =  millis();
+			blinks = 2 * PICO_W_BLINK_CONNECTED_TIMES;
+			g_blink_connected = BLINK_CONNECTED_ACTIVE;
+		}
+
+		if (g_blink_connected == BLINK_CONNECTED_ACTIVE && (uint32_t)(millis() - blink_start) > PICO_W_SHORT_BLINK_DELAY )
+		{
+			if (blinks & 1)
+			{
+				PICO_W_LED_ON();
+			}
+			else
+			{
+				PICO_W_LED_OFF();
+			}
+
+			if (blinks == 0)
+			{
+				g_blink_connected = BLINK_CONNECTED_OFF;
+			}
+			else
+			{
+				blink_start = millis();
+				--blinks;
+			}
+		}
+	}
 	if (g_wifi_scan_restore_connection && !cyw43_wifi_scan_active(&cyw43_state))
 	{
 		logmsg("Wi-Fi scan complete, reconnecting to \"", g_wifi_reconnect_ssid, "\"");
@@ -244,7 +286,6 @@ void platform_network_poll()
 		&& scsiDev.phase == BUS_FREE
 		&& (uint32_t)(millis() - wifi_reconnect_time) > wifi_reconnect_interval)
 	{
-		
 		wifi_reconnect_time = millis();
 		wifi_reconnect_attempts++;
 		wifi_reconnect_interval += WIFI_RECONNECT_INCREMENT_INTERVAL;
@@ -483,6 +524,7 @@ void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 		logmsg("Successfully connected to Wi-Fi SSID \"",ssid,"\"");
 		wifi_reconnect_attempts = 0;
 		wifi_reconnect_interval = WIFI_RECONNECT_START_INTERVAL;
+		g_blink_connected = BLINK_CONNECTED_ON;
 		g_wifi_reconnect = false;
 	}
 }

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -58,10 +58,9 @@
 #define SDCARD_POLL_INTERVAL 5000
 
 // How often to attempt WiFi reconnection after link loss (ms)
-#define WIFI_RECONNECT_INTERVAL 10000
-
-// Maximum number of WiFi reconnection attempts before giving up
-#define WIFI_RECONNECT_MAX_ATTEMPTS 5
+#define WIFI_RECONNECT_START_INTERVAL 5000
+#define WIFI_RECONECT_MAX_INTERVAL 15000
+#define WIFI_RECONNECT_INCREMENT_INTERVAL 5000
 
 // Watchdog timeout
 // Watchdog will first issue a bus reset and if that does not help, crashdump.


### PR DESCRIPTION
The current RP2 Wi-Fi scan path assumes the interface is idle. When the Pico W is already associated, a scan request from the toolbox API can fail immediately, which makes the Amiga UI report that it cannot run a Wi-Fi scan.

Fix this by treating scans as a temporary mode switch. If the interface is already connected, save the reconnect credentials, drop STA mode, start the scan, and reconnect automatically once the scan completes. This preserves the existing connection model while allowing hotspot discovery from a live session.

Also fix reconnect credential handling so the saved password is copied from the password argument instead of the SSID.

This allows the UI to enumerate hotspots even when the network device is already in use, at the cost of a brief link interruption during the scan.

Blinking the RM2 LED on WiFi connect has been moved to a non-blocking method executed during Bus Free SCSI phase as it was happening during a SCSI transaction, which caused a timeout on the DaynaPORT SCSI Read and possibly other SCSI commands.

This is not a clean cherry-pick as code around reconnection handling has been changed since the original commit.