### PR TITLE
Add a media selection menu system over USB console

### DIFF
--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -147,6 +147,13 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
         }
     }
 
+    // Prefix-mode: images sit in the root directory filtered by a 3-char prefix
+    if (img.use_prefix)
+    {
+        if (buflen >= 2) { buf[0] = '/'; buf[1] = '\0'; }
+        return true;
+    }
+
     // Fall back to the conventional directory name for this device type
     if (!img.image_directory) return false;
 
@@ -163,6 +170,33 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
     }
     prefix[2] = scsiEncodeID(scsi_id);
     memcpy(buf, prefix, sizeof(prefix));
+    return true;
+}
+
+bool controlGetImagePrefix(uint8_t scsi_id, char *buf, size_t buflen)
+{
+    if (!buf || buflen < 4) return false;
+    buf[0] = '\0';
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    if (!img.use_prefix) return false;
+
+    const char *tp;
+    switch ((S2S_CFG_TYPE)img.deviceType)
+    {
+        case S2S_CFG_OPTICAL:     tp = "cd"; break;
+        case S2S_CFG_REMOVABLE:   tp = "re"; break;
+        case S2S_CFG_SEQUENTIAL:  tp = "tp"; break;
+        case S2S_CFG_FLOPPY_14MB: tp = "fd"; break;
+        case S2S_CFG_MO:          tp = "mo"; break;
+        case S2S_CFG_ZIP100:      tp = "zp"; break;
+        default: return false;
+    }
+    buf[0] = tp[0];
+    buf[1] = tp[1];
+    buf[2] = scsiEncodeID(scsi_id);
+    buf[3] = '\0';
     return true;
 }
 
@@ -202,8 +236,10 @@ static bool isDirACueBinSet(const char *dirpath, uint64_t &total_size)
     return true;
 }
 
-// controlListImages — flat FsFile loop, deliberately avoids SDNavigator
-// and its WalkDirectory recursion.
+// controlListImages — single-pass flat FsFile scan, deliberately avoids
+// SDNavigator/WalkDirectory (stack-overflow risk on RP2350).
+// For root-directory prefix-mode devices the list is filtered to entries
+// whose names begin with the 3-char type+ID prefix (e.g. "cd4").
 int controlListImages(uint8_t scsi_id,
     void (*callback)(int idx, const char *filename,
                      const char *full_path, uint64_t size, bool is_dir, void *userdata),
@@ -212,6 +248,12 @@ int controlListImages(uint8_t scsi_id,
     char imgdir[MAX_FILE_PATH];
     if (!controlGetImageDirectory(scsi_id, imgdir, sizeof(imgdir)))
         return 0;
+
+    // For root "/" avoid producing "//name"
+    bool root_dir = (imgdir[0] == '/' && imgdir[1] == '\0');
+
+    char imgprefix[4];
+    bool filter_prefix = controlGetImagePrefix(scsi_id, imgprefix, sizeof(imgprefix));
 
     FsFile dir;
     if (!dir.open(imgdir))
@@ -234,7 +276,13 @@ int controlListImages(uint8_t scsi_id,
         uint64_t size = is_dir ? 0 : (uint64_t)entry.size();
         entry.close();
 
-        snprintf(full_path, sizeof(full_path), "%s/%s", imgdir, name);
+        if (filter_prefix && strncasecmp(name, imgprefix, 3) != 0)
+            continue;
+
+        if (root_dir)
+            snprintf(full_path, sizeof(full_path), "/%s", name);
+        else
+            snprintf(full_path, sizeof(full_path), "%s/%s", imgdir, name);
 
         if (is_dir)
         {

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -1,0 +1,324 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+#include "ZuluSCSI_control_api.h"
+#include "ZuluSCSI_disk.h"
+#include "ZuluSCSI_cdrom.h"
+#include "ZuluSCSI_log.h"
+#include "ZuluSCSI_config.h"
+#include <minIni.h>
+#include <SdFat.h>
+#include <string.h>
+#include <strings.h>
+#include <stdio.h>
+
+extern "C" {
+#include <scsi2sd.h>
+}
+
+// SD card global declared in ZuluSCSI.h
+extern SdFs SD;
+
+// -----------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------
+
+static bool isRemovableType(S2S_CFG_TYPE type)
+{
+    switch (type)
+    {
+        case S2S_CFG_OPTICAL:
+        case S2S_CFG_REMOVABLE:
+        case S2S_CFG_FLOPPY_14MB:
+        case S2S_CFG_MO:
+        case S2S_CFG_SEQUENTIAL:
+        case S2S_CFG_ZIP100:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// -----------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------
+
+bool controlIsRemovableDevice(uint8_t scsi_id)
+{
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    return isRemovableType((S2S_CFG_TYPE)img.deviceType);
+}
+
+int controlListRemovableDevices(uint8_t *ids_out, int max_count)
+{
+    int count = 0;
+    for (uint8_t i = 0; i < S2S_MAX_TARGETS && count < max_count; i++)
+    {
+        if (controlIsRemovableDevice(i))
+            ids_out[count++] = i;
+    }
+    return count;
+}
+
+const char* controlGetDeviceTypeName(uint8_t scsi_id)
+{
+    if (scsi_id >= S2S_MAX_TARGETS) return "Unknown";
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return "Inactive";
+    switch ((S2S_CFG_TYPE)img.deviceType)
+    {
+        case S2S_CFG_OPTICAL:     return "CD-ROM";
+        case S2S_CFG_REMOVABLE:   return "Removable";
+        case S2S_CFG_FLOPPY_14MB: return "Floppy";
+        case S2S_CFG_MO:          return "MO";
+        case S2S_CFG_SEQUENTIAL:  return "Tape";
+        case S2S_CFG_ZIP100:      return "Zip";
+        default:                  return "Unknown";
+    }
+}
+
+bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen)
+{
+    if (!buf || buflen == 0) return false;
+    buf[0] = '\0';
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    if (img.ejected || !img.file.isOpen() || img.current_image[0] == '\0')
+        return false;
+
+    strncpy(buf, img.current_image, buflen - 1);
+    buf[buflen - 1] = '\0';
+    return true;
+}
+
+bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
+{
+    if (!buf || buflen == 0) return false;
+    buf[0] = '\0';
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+
+    // Explicit ImgDir in zuluscsi.ini takes first priority
+    char section[8];
+    snprintf(section, sizeof(section), "SCSI%c", '0' + scsi_id);
+    char dirname[MAX_FILE_PATH];
+    int dirlen = ini_gets(section, "ImgDir", "", dirname, sizeof(dirname), CONFIGFILE);
+    if (dirlen > 0)
+    {
+        strncpy(buf, dirname, buflen - 1);
+        buf[buflen - 1] = '\0';
+        return true;
+    }
+
+    // Derive from the currently loaded image path
+    if (img.image_directory && img.current_image[0] != '\0')
+    {
+        strncpy(buf, img.current_image, buflen - 1);
+        buf[buflen - 1] = '\0';
+        char *last_slash = strrchr(buf, '/');
+        if (last_slash && last_slash != buf)
+        {
+            *last_slash = '\0';
+            return true;
+        }
+    }
+
+    // Fall back to the conventional directory name for this device type
+    if (!img.image_directory) return false;
+
+    char prefix[3];
+    switch ((S2S_CFG_TYPE)img.deviceType)
+    {
+        case S2S_CFG_OPTICAL:     strncpy(prefix, "CD", 3); break;
+        case S2S_CFG_REMOVABLE:   strncpy(prefix, "RE", 3); break;
+        case S2S_CFG_SEQUENTIAL:  strncpy(prefix, "TP", 3); break;
+        case S2S_CFG_FLOPPY_14MB: strncpy(prefix, "FD", 3); break;
+        case S2S_CFG_MO:          strncpy(prefix, "MO", 3); break;
+        case S2S_CFG_ZIP100:      strncpy(prefix, "ZP", 3); break;
+        default: return false;
+    }
+    snprintf(buf, buflen, "%s%c", prefix, '0' + scsi_id);
+    return true;
+}
+
+// Flat FsFile scan for exactly one .cue file — identifies a directory as a
+// CUE/BIN disc set without calling WalkDirectory (avoids stack overflow).
+// total_size receives the sum of all file sizes in the directory (0 on false).
+static bool isDirACueBinSet(const char *dirpath, uint64_t &total_size)
+{
+    total_size = 0;
+
+    FsFile dir;
+    if (!dir.open(dirpath))
+        return false;
+
+    char name[MAX_FILE_PATH];
+    int cue_count = 0;
+
+    FsFile entry;
+    while (entry.openNext(&dir, O_RDONLY))
+    {
+        if (!entry.isDir() && !entry.isHidden() && entry.getName(name, sizeof(name)))
+        {
+            total_size += (uint64_t)entry.size();
+            const char *ext = strrchr(name, '.');
+            if (ext && strcasecmp(ext, ".cue") == 0)
+                cue_count++;
+        }
+        entry.close();
+    }
+
+    dir.close();
+    if (cue_count != 1)
+    {
+        total_size = 0;
+        return false;
+    }
+    return true;
+}
+
+// controlListImages — flat FsFile loop, deliberately avoids SDNavigator
+// and its WalkDirectory recursion.  The crash analysis showed that
+// WalkDirectory's per-frame stack (~1 KB: two FsFile objects + three
+// MAX_FILE_PATH char arrays) combined with the USB hardware timer IRQ
+// firing mid-SDIO caused a StackOverflow on RP2350.  A direct FsFile
+// scan keeps the extra stack under ~750 bytes total for the function.
+int controlListImages(uint8_t scsi_id,
+    void (*callback)(int idx, const char *filename,
+                     const char *full_path, uint64_t size, bool is_dir, void *userdata),
+    void *userdata)
+{
+    char imgdir[MAX_FILE_PATH];
+    if (!controlGetImageDirectory(scsi_id, imgdir, sizeof(imgdir)))
+        return 0;
+
+    FsFile dir;
+    if (!dir.open(imgdir))
+        return 0;
+
+    char name[MAX_FILE_PATH];
+    char full_path[MAX_FILE_PATH];
+    int count = 0;
+
+    FsFile entry;
+    while (entry.openNext(&dir, O_RDONLY))
+    {
+        if (!entry.getName(name, sizeof(name)) || entry.isHidden())
+        {
+            entry.close();
+            continue;
+        }
+
+        bool is_dir = entry.isDir();
+        uint64_t size = is_dir ? 0 : (uint64_t)entry.size();
+        entry.close();
+
+        snprintf(full_path, sizeof(full_path), "%s/%s", imgdir, name);
+
+        if (is_dir)
+        {
+            if (!isDirACueBinSet(full_path, size))
+                continue;
+        }
+        else if (!scsiDiskFilenameValid(name))
+        {
+            continue;
+        }
+
+        if (callback)
+            callback(count, name, full_path, size, is_dir, userdata);
+        count++;
+    }
+
+    dir.close();
+    return count;
+}
+
+bool controlLoadImage(uint8_t scsi_id, const char *full_path)
+{
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
+
+    if (full_path == nullptr || full_path[0] == '\0')
+    {
+        // Advance to the next image in sequence with a media-change event
+        char next_name[MAX_FILE_PATH];
+        if (scsiDiskGetNextImageName(img, next_name, sizeof(next_name)) <= 0)
+        {
+            logmsg("Control: no next image found for SCSI ID ", (int)scsi_id);
+            return false;
+        }
+        logmsg("Control: advancing to next image '", next_name,
+               "' on SCSI ID ", (int)scsi_id);
+        return switchNextImage(img, next_name);
+    }
+
+    logmsg("Control: loading '", full_path, "' on SCSI ID ", (int)scsi_id);
+    return switchNextImage(img, full_path);
+}
+
+bool controlEjectMedia(uint8_t scsi_id)
+{
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
+
+    if (img.ejected) return true;
+
+    logmsg("Control: ejecting SCSI ID ", (int)scsi_id);
+    if ((S2S_CFG_TYPE)img.deviceType == S2S_CFG_OPTICAL)
+    {
+        img.ejected = true;
+        img.cdrom_events = 3; // Media removal
+    }
+    else
+    {
+        img.ejected = true;
+    }
+    return true;
+}
+
+bool controlInsertMedia(uint8_t scsi_id)
+{
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
+
+    if (!img.ejected) return true;
+
+    logmsg("Control: inserting media on SCSI ID ", (int)scsi_id);
+    if ((S2S_CFG_TYPE)img.deviceType == S2S_CFG_OPTICAL)
+        cdromCloseTray(img);
+    else
+        img.ejected = false;
+
+    return true;
+}

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -1,5 +1,5 @@
-/**
- * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+/*
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
  *
@@ -123,8 +123,8 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
     if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
 
     // Explicit ImgDir in zuluscsi.ini takes first priority
-    char section[8];
-    snprintf(section, sizeof(section), "SCSI%c", '0' + scsi_id);
+    char section[] = "SCSI0";
+    section[4] =  scsiEncodeID(scsi_id);
     char dirname[MAX_FILE_PATH];
     int dirlen = ini_gets(section, "ImgDir", "", dirname, sizeof(dirname), CONFIGFILE);
     if (dirlen > 0)
@@ -150,18 +150,19 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
     // Fall back to the conventional directory name for this device type
     if (!img.image_directory) return false;
 
-    char prefix[3];
+    char prefix[4];
     switch ((S2S_CFG_TYPE)img.deviceType)
     {
-        case S2S_CFG_OPTICAL:     strncpy(prefix, "CD", 3); break;
-        case S2S_CFG_REMOVABLE:   strncpy(prefix, "RE", 3); break;
-        case S2S_CFG_SEQUENTIAL:  strncpy(prefix, "TP", 3); break;
-        case S2S_CFG_FLOPPY_14MB: strncpy(prefix, "FD", 3); break;
-        case S2S_CFG_MO:          strncpy(prefix, "MO", 3); break;
-        case S2S_CFG_ZIP100:      strncpy(prefix, "ZP", 3); break;
+        case S2S_CFG_OPTICAL:     strncpy(prefix, "CD0", 4); break;
+        case S2S_CFG_REMOVABLE:   strncpy(prefix, "RE0", 4); break;
+        case S2S_CFG_SEQUENTIAL:  strncpy(prefix, "TP0", 4); break;
+        case S2S_CFG_FLOPPY_14MB: strncpy(prefix, "FD0", 4); break;
+        case S2S_CFG_MO:          strncpy(prefix, "MO0", 4); break;
+        case S2S_CFG_ZIP100:      strncpy(prefix, "ZP0", 4); break;
         default: return false;
     }
-    snprintf(buf, buflen, "%s%c", prefix, '0' + scsi_id);
+    prefix[2] = scsiEncodeID(scsi_id);
+    memcpy(buf, prefix, sizeof(prefix));
     return true;
 }
 
@@ -202,11 +203,7 @@ static bool isDirACueBinSet(const char *dirpath, uint64_t &total_size)
 }
 
 // controlListImages — flat FsFile loop, deliberately avoids SDNavigator
-// and its WalkDirectory recursion.  The crash analysis showed that
-// WalkDirectory's per-frame stack (~1 KB: two FsFile objects + three
-// MAX_FILE_PATH char arrays) combined with the USB hardware timer IRQ
-// firing mid-SDIO caused a StackOverflow on RP2350.  A direct FsFile
-// scan keeps the extra stack under ~750 bytes total for the function.
+// and its WalkDirectory recursion.
 int controlListImages(uint8_t scsi_id,
     void (*callback)(int idx, const char *filename,
                      const char *full_path, uint64_t size, bool is_dir, void *userdata),
@@ -295,12 +292,11 @@ bool controlEjectMedia(uint8_t scsi_id)
     logmsg("Control: ejecting SCSI ID ", (int)scsi_id);
     if ((S2S_CFG_TYPE)img.deviceType == S2S_CFG_OPTICAL)
     {
-        img.ejected = true;
-        img.cdrom_events = 3; // Media removal
+        cdromPerformEject(img);
     }
     else
     {
-        img.ejected = true;
+        doPerformEject(img);
     }
     return true;
 }

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
@@ -1,0 +1,76 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// Interface-neutral media management API.
+// Provides image selection, listing, ejection, and insertion for removable
+// SCSI devices (CD-ROM, Tape, Removable, Floppy, MO, Zip).
+// Usable by the USB serial console, future network interfaces, or other UIs.
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Check if a SCSI target has removable/changeable media
+bool controlIsRemovableDevice(uint8_t scsi_id);
+
+// List all active removable device SCSI IDs into ids_out[0..max_count-1]
+// Returns number of devices found
+int controlListRemovableDevices(uint8_t *ids_out, int max_count);
+
+// Human-readable device type name for display (e.g. "CD-ROM", "Tape")
+const char* controlGetDeviceTypeName(uint8_t scsi_id);
+
+// Get the full path of the currently mounted image for a device.
+// Returns true if an image is loaded (not ejected); buf receives the path.
+// Returns false and sets buf[0]='\0' when ejected or device inactive.
+bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen);
+
+// Get the directory that is searched for available images for a device.
+// Returns true and writes the directory path into buf on success.
+// Returns false when no image directory is configured.
+bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen);
+
+// Enumerate available images in the device's image directory.
+// For each image found, calls:
+//   callback(idx, filename, full_path, size_bytes, is_dir, userdata)
+// CUE/BIN folder sets are surfaced as single entries (full_path is the folder,
+// is_dir=true, size=0).  Plain image files have is_dir=false.
+// Returns the total count of images found.
+int controlListImages(uint8_t scsi_id,
+    void (*callback)(int idx, const char *filename,
+                     const char *full_path, uint64_t size, bool is_dir, void *userdata),
+    void *userdata);
+
+// Load (mount) a specific image on a device.
+// full_path is the absolute SD card path returned by controlListImages.
+// Pass nullptr to advance to the next image in the device's sequence.
+// Ejects current media and signals a media change to the host.
+// Returns true on success.
+bool controlLoadImage(uint8_t scsi_id, const char *full_path);
+
+// Eject current media from a device (host sees the drive as empty).
+// Returns true on success; true is also returned if already ejected.
+bool controlEjectMedia(uint8_t scsi_id);
+
+// Insert / close tray — makes the currently staged media accessible again.
+// Returns true on success; true is also returned if already inserted.
+bool controlInsertMedia(uint8_t scsi_id);

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
@@ -46,8 +46,15 @@ bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen);
 
 // Get the directory that is searched for available images for a device.
 // Returns true and writes the directory path into buf on success.
+// For prefix-mode devices (root-directory layout) buf receives "/".
 // Returns false when no image directory is configured.
 bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen);
+
+// Get the 3-character filename prefix for root-directory prefix-mode devices
+// (e.g. "cd4" for CD-ROM on SCSI ID 4, "re1" for Removable on SCSI ID 1).
+// Returns true and fills buf when in prefix mode; false for directory-mode or
+// inactive devices.  buf must be at least 4 bytes.
+bool controlGetImagePrefix(uint8_t scsi_id, char *buf, size_t buflen);
 
 // Enumerate available images in the device's image directory.
 // For each image found, calls:

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -111,7 +111,8 @@ typedef enum
     USB_INPUT_TOGGLE_DEBUG,
     USB_INPUT_LOG_TO_SD,
     USB_INPUT_BUTTON_1,
-    USB_INPUT_BUTTON_2
+    USB_INPUT_BUTTON_2,
+    USB_INPUT_MEDIA_SUBMENU
 }
 usb_input_type_t;
 
@@ -879,6 +880,13 @@ bool platform_emergency_log_save()
 static void usb_log_poll();
 static void usb_input_poll();
 static usb_input_type_t serial_menu(menu_context_t context);
+
+// Media management submenu (defined in ZuluSCSI_usb_console_media.cpp)
+#ifdef PLATFORM_MASS_STORAGE
+extern bool serialMediaMenuActive();
+extern void serialMediaMenuProcess(char c);
+extern void serialMediaMenuEnter();
+#endif
 
 #ifdef ZULUSCSI_MCU_RP23XX
 static const char *cfsr_desc(uint32_t cfsr)
@@ -1761,6 +1769,14 @@ static usb_input_type_t serial_menu(menu_context_t context)
     if(available > 0)
     {
         int32_t read = Serial.read();
+
+        // Route to the media submenu while it is active
+        if (serialMediaMenuActive())
+        {
+            serialMediaMenuProcess((char)read);
+            return USB_INPUT_NONE;
+        }
+
         switch((char) read)
         {
             case 'X':
@@ -1796,6 +1812,10 @@ static usb_input_type_t serial_menu(menu_context_t context)
             case '2':
                 input_type = USB_INPUT_BUTTON_2;
                 break;
+            case 'M':
+            case 'm':
+                input_type = USB_INPUT_MEDIA_SUBMENU;
+                break;
             case 'Y':
             case 'y':
                 yes_keyed = true;
@@ -1828,6 +1848,7 @@ static usb_input_type_t serial_menu(menu_context_t context)
                 "    'l' - toggle logging to the SD Card, currently ", g_log_to_sd ? "on" : "off", "\r\n",
                 "    '1' - push function button 1 (eject, switch image)\r\n"
                 "    '2' - push function button 2 (eject, switch image)\r\n"
+                "    'm' - media management (image select, eject, insert)\r\n"
                 "  press 'y' after a command to confirm and execute"
             );
         }
@@ -1872,6 +1893,10 @@ static usb_input_type_t serial_menu(menu_context_t context)
                     logmsg("Pushed function button 2");
                     g_console_buttons |= 2;
                     break;
+                case USB_INPUT_MEDIA_SUBMENU:
+                    *scratch0 = 0;
+                    serialMediaMenuEnter();
+                    break;
                 default:
                     *scratch0 = 0;
                     input_type = USB_INPUT_NONE;
@@ -1907,6 +1932,9 @@ static usb_input_type_t serial_menu(menu_context_t context)
                     break;
                 case USB_INPUT_BUTTON_2:
                     logmsg("Push function button 2, press 'y' to engage or any key to clear");
+                    break;
+                case USB_INPUT_MEDIA_SUBMENU:
+                    logmsg("Enter media management submenu, press 'y' to engage or any key to clear");
                     break;
                 default:
                     input_type = USB_INPUT_NONE;

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -42,6 +42,7 @@
 #include "scsi_accel_target.h"
 #include "custom_timings.h"
 #include <ZuluSCSI_settings.h>
+#include "ZuluSCSI_usb_console_media.h"
 
 #ifdef ZULUSCSI_MCU_RP23XX
 # include <hardware/structs/scb.h>
@@ -880,13 +881,6 @@ bool platform_emergency_log_save()
 static void usb_log_poll();
 static void usb_input_poll();
 static usb_input_type_t serial_menu(menu_context_t context);
-
-// Media management submenu (defined in ZuluSCSI_usb_console_media.cpp)
-#ifdef PLATFORM_MASS_STORAGE
-extern bool serialMediaMenuActive();
-extern void serialMediaMenuProcess(char c);
-extern void serialMediaMenuEnter();
-#endif
 
 #ifdef ZULUSCSI_MCU_RP23XX
 static const char *cfsr_desc(uint32_t cfsr)

--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
@@ -49,7 +49,7 @@ SECTIONS
     * reduce the flash usage.
     */
     /DISCARD/ : {
-        *fprintf*(*)
+       /* *fprintf*(*) */
         *scanf*(*)
         *strtod*(*)
         *libipv4.a:*(*)
@@ -61,7 +61,7 @@ SECTIONS
         *libZuluSCSI_UI_RP2MCU.a:*(*)
         *libZuluSCSI_platform_RP2MCU.a:ZuluSCSI_platform_network.cpp.o*(*)
         *libFrameworkArduino.a:cyw43_wrappers.cpp.o*(*)
-
+        *libZuluControl.a:*(*)
         /* gt */
         *ZuluSCSI_tape.cpp.o*(*)
         *ZuluSCSI_mode.cpp.o*(*)

--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
@@ -49,7 +49,7 @@ SECTIONS
     * reduce the flash usage.
     */
     /DISCARD/ : {
-       /* *fprintf*(*) */
+        *fprintf*(*)
         *scanf*(*)
         *strtod*(*)
         *libipv4.a:*(*)

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,8 +27,8 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2026.05.19"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "2026.05.20"
+#define FW_VER_SUFFIX   "MediaChangerTechPreview"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2,7 +2,7 @@
  * SCSI2SD V6 - Copyright (C) 2013 Michael McMaster <michael@codesrc.com>
  * Portions Copyright (C) 2014 Doug Brown <doug@downtowndougbrown.com>
  * Portions Copyright (C) 2023 Eric Helgeson
- * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
  *
  * This file is licensed under the GPL version 3 or any later version. 
  * It is derived from disk.c in SCSI2SD V6
@@ -932,7 +932,7 @@ static void doCloseTray(image_config_t &img)
 
  
 // Eject and switch image
-static void doPerformEject(image_config_t &img)
+void doPerformEject(image_config_t &img)
 {
     uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
     if (img.deviceType == S2S_CFG_FIXED)

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -1,7 +1,7 @@
 /** 
  * SCSI2SD V6 - Copyright (C) 2013 Michael McMaster <michael@codesrc.com>
  * Copyright (C) 2014 Doug Brown <doug@downtowndougbrown.com
- * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
  * Copyright (c) 2023 joshua stein <jcs@jcs.org>
  * 
  * It is derived from disk.h in SCSI2SD V6.
@@ -159,6 +159,9 @@ int16_t skip_next(int max);
 // Get and set the eject button bit flags
 uint8_t getEjectButton(uint8_t idx);
 void    setEjectButton(uint8_t idx, int8_t eject_button);
+
+// Perform eject for devices
+void doPerformEject(image_config_t &img);
 
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED, bool use_prefix = false);
 void scsiDiskLoadConfig(int target_idx);

--- a/src/ZuluSCSI_usb_console_media.cpp
+++ b/src/ZuluSCSI_usb_console_media.cpp
@@ -1,0 +1,484 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+#ifdef PLATFORM_MASS_STORAGE
+#ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
+
+#include "ZuluSCSI_usb_console_media.h"
+#include "ZuluSCSI_platform.h"
+#include "ZuluSCSI_config.h"
+#include <ZuluSCSI_control_api.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+extern "C" {
+#include <scsi2sd.h>
+}
+
+// -----------------------------------------------------------------------
+// Direct serial output helpers — bypass the log buffer entirely so that
+// interactive menu text does not pollute zululog.txt.
+// -----------------------------------------------------------------------
+
+static void serial_out(const char *str)
+{
+    if (!str || !*str) return;
+    uint32_t remaining = (uint32_t)strlen(str);
+    const uint8_t *p = (const uint8_t *)str;
+    while (remaining > 0)
+    {
+        uint32_t sent = platform_write_to_serial((uint8_t *)p, remaining);
+        if (sent == 0) break;
+        p += sent;
+        remaining -= sent;
+    }
+}
+
+static void serial_out_int(int value)
+{
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d", value);
+    serial_out(buf);
+}
+
+// Convenience: print a string followed by \r\n
+static void serial_println(const char *str)
+{
+    serial_out(str);
+    serial_out("\r\n");
+}
+
+// -----------------------------------------------------------------------
+// State machine
+// -----------------------------------------------------------------------
+
+typedef enum
+{
+    MEDIA_MENU_INACTIVE,
+    MEDIA_MENU_DEVICE_LIST,    // Waiting for device index digit or 'b'
+    MEDIA_MENU_DEVICE_ACTIONS, // Waiting for action key for selected device
+    MEDIA_MENU_IMAGE_LIST,     // Waiting for image index digits + Enter or 'b'
+} media_menu_state_t;
+
+static media_menu_state_t s_state = MEDIA_MENU_INACTIVE;
+
+static uint8_t s_removable_ids[S2S_MAX_TARGETS];
+static int     s_removable_count = 0;
+static int     s_selected_idx = -1;
+static int     s_image_count = 0;
+
+// Up to 3 digits for image index entry
+static char s_num_buf[4];
+static int  s_num_len = 0;
+
+// -----------------------------------------------------------------------
+// Display helpers
+// -----------------------------------------------------------------------
+
+static void show_device_list()
+{
+    serial_println("");
+    serial_println("  Media Management");
+    serial_println("  ================================================");
+    serial_println("  Removable devices:");
+
+    if (s_removable_count == 0)
+    {
+        serial_println("    (none configured)");
+    }
+    else
+    {
+        for (int i = 0; i < s_removable_count; i++)
+        {
+            uint8_t id = s_removable_ids[i];
+            char cur[MAX_FILE_PATH];
+            bool has_img = controlGetCurrentImage(id, cur, sizeof(cur));
+
+            const char *basename = "(ejected)";
+            if (has_img)
+            {
+                const char *slash = strrchr(cur, '/');
+                basename = slash ? slash + 1 : cur;
+            }
+
+            serial_out("    ");
+            serial_out_int(i);
+            serial_out(": ID ");
+            serial_out_int((int)id);
+            serial_out("  ");
+            serial_out(controlGetDeviceTypeName(id));
+            serial_out("  [");
+            serial_out(basename);
+            serial_println("]");
+        }
+    }
+
+    serial_println("  ------------------------------------------------");
+    serial_out("  Select device (0-");
+    serial_out_int(s_removable_count - 1);
+    serial_println(") or 'b' to exit:");
+}
+
+static void show_device_actions()
+{
+    uint8_t id = s_removable_ids[s_selected_idx];
+    char cur[MAX_FILE_PATH];
+    bool has_img = controlGetCurrentImage(id, cur, sizeof(cur));
+    const char *basename = "(ejected)";
+    if (has_img)
+    {
+        const char *slash = strrchr(cur, '/');
+        basename = slash ? slash + 1 : cur;
+    }
+
+    serial_println("");
+    serial_out("  Device SCSI ID ");
+    serial_out_int((int)id);
+    serial_out(": ");
+    serial_println(controlGetDeviceTypeName(id));
+    serial_out("  Current: ");
+    serial_println(basename);
+    serial_println("  ================================================");
+    serial_println("    'l' - list and select image");
+    serial_println("    'n' - load next image");
+    serial_println("    'e' - eject");
+    serial_println("    'i' - insert");
+    serial_println("    'b' - back to device list");
+    serial_println("  Or enter image number + Enter to load directly:");
+}
+
+// Callback used by controlListImages() to print each entry
+static void print_image_cb(int idx, const char *filename,
+                           const char *full_path, uint64_t size, bool is_dir, void *ud)
+{
+    (void)full_path;
+    (void)ud;
+    uint32_t size_mb = (uint32_t)((size + 524288ULL) / 1048576ULL);
+    serial_out("    ");
+    serial_out_int(idx + 1);
+    serial_out(": ");
+    serial_out(filename);
+    serial_out(is_dir ? " (bin/cue " : " (");
+    serial_out_int((int)size_mb);
+    serial_println(" MB)");
+}
+
+static void show_image_list()
+{
+    uint8_t id = s_removable_ids[s_selected_idx];
+
+    serial_println("");
+    serial_out("  Available images for SCSI ID ");
+    serial_out_int((int)id);
+    serial_out(" (");
+    serial_out(controlGetDeviceTypeName(id));
+    serial_println("):");
+    serial_println("  ------------------------------------------------");
+
+    s_image_count = controlListImages(id, print_image_cb, nullptr);
+
+    if (s_image_count == 0)
+        serial_println("    (no images found)");
+
+    serial_println("  ------------------------------------------------");
+    serial_println("  Enter image number then Enter, or 'b' to cancel:");
+}
+
+// Callback to resolve the Nth image to a full path
+struct FindNthState
+{
+    int  target;
+    char path[MAX_FILE_PATH];
+    bool found;
+};
+static FindNthState s_findNth;
+
+static void find_nth_cb(int idx, const char *filename,
+                        const char *full_path, uint64_t size, bool is_dir, void *ud)
+{
+    (void)filename;
+    (void)size;
+    (void)is_dir;
+    (void)ud;
+    if (idx == s_findNth.target && !s_findNth.found)
+    {
+        strncpy(s_findNth.path, full_path, MAX_FILE_PATH - 1);
+        s_findNth.path[MAX_FILE_PATH - 1] = '\0';
+        s_findNth.found = true;
+    }
+}
+
+// -----------------------------------------------------------------------
+// Public interface
+// -----------------------------------------------------------------------
+
+extern "C" bool serialMediaMenuActive()
+{
+    return s_state != MEDIA_MENU_INACTIVE;
+}
+
+extern "C" void serialMediaMenuEnter()
+{
+    s_removable_count = controlListRemovableDevices(s_removable_ids,
+                                                    S2S_MAX_TARGETS);
+    s_selected_idx = -1;
+    s_num_len = 0;
+    s_num_buf[0] = '\0';
+    s_state = MEDIA_MENU_DEVICE_LIST;
+    show_device_list();
+}
+
+extern "C" void serialMediaMenuProcess(char c)
+{
+    // Ignore bare CR/LF when no digits are pending
+    if ((c == '\r' || c == '\n') && s_num_len == 0)
+        return;
+
+    switch (s_state)
+    {
+        // ------------------------------------------------------------
+        case MEDIA_MENU_DEVICE_LIST:
+        {
+            if (c == 'b' || c == 'B')
+            {
+                serial_println("  Exiting media menu.");
+                s_state = MEDIA_MENU_INACTIVE;
+                return;
+            }
+            int dev_idx = c - '0';
+            if (c >= '0' && dev_idx < s_removable_count)
+            {
+                s_selected_idx = dev_idx;
+                s_state = MEDIA_MENU_DEVICE_ACTIONS;
+                show_device_actions();
+                return;
+            }
+            show_device_list();
+            break;
+        }
+
+        // ------------------------------------------------------------
+        case MEDIA_MENU_DEVICE_ACTIONS:
+        {
+            uint8_t id = s_removable_ids[s_selected_idx];
+
+            if (c >= '0' && c <= '9' && s_num_len < 3)
+            {
+                s_num_buf[s_num_len++] = c;
+                s_num_buf[s_num_len] = '\0';
+                serial_out("  >> ");
+                serial_out(s_num_buf);
+                serial_println(" (press Enter to load, 'b' to cancel)");
+                break;
+            }
+
+            if ((c == '\r' || c == '\n') && s_num_len > 0)
+            {
+                int image_idx = atoi(s_num_buf) - 1;
+                s_num_len = 0;
+                s_num_buf[0] = '\0';
+
+                s_findNth.target = image_idx;
+                s_findNth.found  = false;
+                s_findNth.path[0] = '\0';
+                controlListImages(id, find_nth_cb, nullptr);
+
+                if (!s_findNth.found)
+                {
+                    serial_out("  Image ");
+                    serial_out_int(image_idx + 1);
+                    serial_println(" not found.");
+                }
+                else
+                {
+                    serial_out("  Loading '");
+                    serial_out(s_findNth.path);
+                    serial_out("' on SCSI ID ");
+                    serial_out_int((int)id);
+                    serial_println(" ...");
+
+                    if (controlLoadImage(id, s_findNth.path))
+                        serial_println("  Image loaded. Host will see a media change.");
+                    else
+                        serial_println("  Failed to load image.");
+                }
+                show_device_actions();
+                break;
+            }
+
+            switch (c)
+            {
+                case 'b':
+                case 'B':
+                    s_num_len = 0;
+                    s_num_buf[0] = '\0';
+                    s_state = MEDIA_MENU_DEVICE_LIST;
+                    s_removable_count = controlListRemovableDevices(
+                                            s_removable_ids, S2S_MAX_TARGETS);
+                    show_device_list();
+                    break;
+
+                case 'l':
+                case 'L':
+                    s_num_len = 0;
+                    s_num_buf[0] = '\0';
+                    s_state = MEDIA_MENU_IMAGE_LIST;
+                    show_image_list();
+                    break;
+
+                case 'n':
+                case 'N':
+                    if (controlLoadImage(id, nullptr))
+                        serial_println("  Next image staged — host will see media change.");
+                    else
+                        serial_println("  No next image available.");
+                    show_device_actions();
+                    break;
+
+                case 'e':
+                case 'E':
+                {
+                    char id_str[4];
+                    snprintf(id_str, sizeof(id_str), "%d", (int)id);
+                    if (controlEjectMedia(id))
+                    {
+                        serial_out("  SCSI ID ");
+                        serial_out(id_str);
+                        serial_println(" ejected.");
+                    }
+                    else
+                    {
+                        serial_println("  Eject failed.");
+                    }
+                    show_device_actions();
+                    break;
+                }
+
+                case 'i':
+                case 'I':
+                {
+                    char id_str[4];
+                    snprintf(id_str, sizeof(id_str), "%d", (int)id);
+                    if (controlInsertMedia(id))
+                    {
+                        serial_out("  SCSI ID ");
+                        serial_out(id_str);
+                        serial_println(" media inserted.");
+                    }
+                    else
+                    {
+                        serial_println("  Insert failed.");
+                    }
+                    show_device_actions();
+                    break;
+                }
+
+                default:
+                    s_num_len = 0;
+                    s_num_buf[0] = '\0';
+                    show_device_actions();
+                    break;
+            }
+            break;
+        }
+
+        // ------------------------------------------------------------
+        case MEDIA_MENU_IMAGE_LIST:
+        {
+            if (c == 'b' || c == 'B')
+            {
+                s_num_len = 0;
+                s_state = MEDIA_MENU_DEVICE_ACTIONS;
+                show_device_actions();
+                return;
+            }
+
+            if (c >= '0' && c <= '9' && s_num_len < 3)
+            {
+                s_num_buf[s_num_len++] = c;
+                s_num_buf[s_num_len] = '\0';
+                serial_out("  >> ");
+                serial_out(s_num_buf);
+                serial_println(" (press Enter to load, 'b' to cancel)");
+                return;
+            }
+
+            if ((c == '\r' || c == '\n') && s_num_len > 0)
+            {
+                int image_idx = atoi(s_num_buf);
+                s_num_len = 0;
+                s_num_buf[0] = '\0';
+
+                if (image_idx < 1 || image_idx > s_image_count)
+                {
+                    serial_out("  Invalid index ");
+                    serial_out_int(image_idx);
+                    serial_out(" (valid range 1-");
+                    serial_out_int(s_image_count);
+                    serial_println(").");
+                    serial_println("  Enter image number then Enter, or 'b' to cancel:");
+                    return;
+                }
+
+                s_findNth.target = image_idx - 1;
+                s_findNth.found  = false;
+                s_findNth.path[0] = '\0';
+                uint8_t id = s_removable_ids[s_selected_idx];
+                controlListImages(id, find_nth_cb, nullptr);
+
+                if (!s_findNth.found)
+                {
+                    serial_out("  Could not locate image at index ");
+                    serial_out_int(image_idx);
+                    serial_println(".");
+                    serial_println("  Enter image number then Enter, or 'b' to cancel:");
+                    return;
+                }
+
+                serial_out("  Loading '");
+                serial_out(s_findNth.path);
+                serial_out("' on SCSI ID ");
+                serial_out_int((int)id);
+                serial_println(" ...");
+
+                if (controlLoadImage(id, s_findNth.path))
+                    serial_println("  Image loaded. Host will see a media change.");
+                else
+                    serial_println("  Failed to load image.");
+
+                s_state = MEDIA_MENU_DEVICE_ACTIONS;
+                show_device_actions();
+                return;
+            }
+
+            serial_println("  Enter image number then Enter, or 'b' to cancel:");
+            break;
+        }
+
+        default:
+            s_state = MEDIA_MENU_INACTIVE;
+            break;
+    }
+}
+
+#endif // PIO_FRAMEWORK_ARDUINO_NO_USB
+#endif // PLATFORM_MASS_STORAGE

--- a/src/ZuluSCSI_usb_console_media.cpp
+++ b/src/ZuluSCSI_usb_console_media.cpp
@@ -1,5 +1,5 @@
 /**
- * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
  *
@@ -18,9 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **/
-
-#ifdef PLATFORM_MASS_STORAGE
-#ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
 
 #include "ZuluSCSI_usb_console_media.h"
 #include "ZuluSCSI_platform.h"
@@ -231,12 +228,12 @@ static void find_nth_cb(int idx, const char *filename,
 // Public interface
 // -----------------------------------------------------------------------
 
-extern "C" bool serialMediaMenuActive()
+bool serialMediaMenuActive()
 {
     return s_state != MEDIA_MENU_INACTIVE;
 }
 
-extern "C" void serialMediaMenuEnter()
+void serialMediaMenuEnter()
 {
     s_removable_count = controlListRemovableDevices(s_removable_ids,
                                                     S2S_MAX_TARGETS);
@@ -247,7 +244,7 @@ extern "C" void serialMediaMenuEnter()
     show_device_list();
 }
 
-extern "C" void serialMediaMenuProcess(char c)
+void serialMediaMenuProcess(char c)
 {
     // Ignore bare CR/LF when no digits are pending
     if ((c == '\r' || c == '\n') && s_num_len == 0)
@@ -480,5 +477,3 @@ extern "C" void serialMediaMenuProcess(char c)
     }
 }
 
-#endif // PIO_FRAMEWORK_ARDUINO_NO_USB
-#endif // PLATFORM_MASS_STORAGE

--- a/src/ZuluSCSI_usb_console_media.h
+++ b/src/ZuluSCSI_usb_console_media.h
@@ -1,5 +1,5 @@
 /**
- * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
  *
@@ -26,20 +26,16 @@
 
 #pragma once
 
-#ifdef PLATFORM_MASS_STORAGE
-
 // Returns true while the media submenu is active.
 // The platform serial_menu() checks this to route incoming characters here
 // instead of processing them as top-level console commands.
-extern "C" bool serialMediaMenuActive();
+bool serialMediaMenuActive();
 
 // Feed one character received from the USB serial port into the submenu.
 // Only called when serialMediaMenuActive() returns true.
-extern "C" void serialMediaMenuProcess(char c);
+void serialMediaMenuProcess(char c);
 
 // Enter the media submenu.  Called by serial_menu() after the user confirms
 // the 'm' command with 'y'.  Displays the removable-device list and
 // transitions the state machine into DEVICE_LIST state.
-extern "C" void serialMediaMenuEnter();
-
-#endif // PLATFORM_MASS_STORAGE
+void serialMediaMenuEnter();

--- a/src/ZuluSCSI_usb_console_media.h
+++ b/src/ZuluSCSI_usb_console_media.h
@@ -1,0 +1,45 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2025 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// USB serial console media management submenu.
+// Provides an interactive text menu for listing, selecting, ejecting and
+// inserting images on removable SCSI devices (CD-ROM, Tape, etc.).
+// Driven by the platform's usb_input_poll() / serial_menu() machinery.
+
+#pragma once
+
+#ifdef PLATFORM_MASS_STORAGE
+
+// Returns true while the media submenu is active.
+// The platform serial_menu() checks this to route incoming characters here
+// instead of processing them as top-level console commands.
+extern "C" bool serialMediaMenuActive();
+
+// Feed one character received from the USB serial port into the submenu.
+// Only called when serialMediaMenuActive() returns true.
+extern "C" void serialMediaMenuProcess(char c);
+
+// Enter the media submenu.  Called by serial_menu() after the user confirms
+// the 'm' command with 'y'.  Displays the removable-device list and
+// transitions the state machine into DEVICE_LIST state.
+extern "C" void serialMediaMenuEnter();
+
+#endif // PLATFORM_MASS_STORAGE


### PR DESCRIPTION
With the USB console, users can now select what image they want to change to on a removable SCSI device. This is done through hitting the `m` key in the USB console. Then hitting `y` to select the
media management submenu.

From here users can select the device they want to change media on and then select the image they want to change to, list selectable images, and more.

<img width="1073" height="1165" alt="image" src="https://github.com/user-attachments/assets/04bbd611-11e7-4020-8b2f-0ba130e81e5b" />
