### PR TITLE
Media selection menu: Fix USB serial console output stopping if serial device is busy

### DIFF
--- a/src/ZuluSCSI_usb_console_media.cpp
+++ b/src/ZuluSCSI_usb_console_media.cpp
@@ -31,6 +31,12 @@ extern "C" {
 #include <scsi2sd.h>
 }
 
+// How long to wait while serial interface is busy
+// before giving up printing more characters
+#ifndef USB_CONSOLE_MEDIA_SERIAL_PRINT_TIMEOUT_MS
+#define  USB_CONSOLE_MEDIA_SERIAL_PRINT_TIMEOUT_MS 30
+#endif
+
 // -----------------------------------------------------------------------
 // Direct serial output helpers — bypass the log buffer entirely so that
 // interactive menu text does not pollute zululog.txt.
@@ -41,12 +47,18 @@ static void serial_out(const char *str)
     if (!str || !*str) return;
     uint32_t remaining = (uint32_t)strlen(str);
     const uint8_t *p = (const uint8_t *)str;
-    while (remaining > 0)
+    uint32_t timeout_start = millis();
+    const uint32_t timeout_ms = USB_CONSOLE_MEDIA_SERIAL_PRINT_TIMEOUT_MS;
+
+    while ((uint32_t)(millis() - timeout_start) < timeout_ms && remaining > 0)
     {
         uint32_t sent = platform_write_to_serial((uint8_t *)p, remaining);
-        if (sent == 0) break;
+        // sent == 0 when serial is busy, reset timeout whenever serial isn't busy
+        if (sent > 0)
+            timeout_start = millis();
         p += sent;
         remaining -= sent;
+        platform_reset_watchdog();
     }
 }
 


### PR DESCRIPTION
Printing menu strings the serial out was stopping if the serial device (USB console) was busy. This fix begins a timeout when the serial device is busy and only stops printing if a timeout is reached, arbitrarily set to 30ms.

The timeout can be set at compile time by setting the C define `USB_CONSOLE_MEDIA_SERIAL_PRINT_TIMEOUT_MS` to the number of milliseconds it should wait before ending string printing when the serial out device is busy.