### PR TITLE
Conditionally suppress geometry log message and log number of sectors

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -746,9 +746,10 @@ bool findHDDImages()
       else
       {
         logmsg("SCSI ID: ", (int)(cfg->scsiId & S2S_CFG_TARGET_ID_BITS),
-              ", BlockSize: ", (int)cfg->bytesPerSector,
               ", Type: ", (int)cfg->deviceType,
               ", Quirks: ", (int)cfg->quirks,
+              ", BlockSize: ", (int)cfg->bytesPerSector,
+              ", Sectors: ", (int) cfg->scsiSectors,
               ", Size: ", capacity_kB, "kB",
               typeIsRemovable((S2S_CFG_TYPE)cfg->deviceType) ? ", Removable" : ""
               );

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -407,14 +407,16 @@ static void autoConfigGeometry(image_config_t &img)
         img.sectorsPerTrack = sect;
         img.headsPerCylinder = head;
     }
-
-    bool divisible = (img.scsiSectors % ((uint32_t)img.sectorsPerTrack * img.headsPerCylinder)) == 0;
-    logmsg("---- Drive geometry from ", method,
-        ": SectorsPerTrack=", (int)img.sectorsPerTrack,
-        " HeadsPerCylinder=", (int)img.headsPerCylinder,
-        " total sectors ", (int)img.scsiSectors,
-        divisible ? " (divisible)" : " (not divisible)"
-        );
+    if (img.bytesPerSector == DEFAULT_BLOCKSIZE)
+    {
+        bool divisible = (img.scsiSectors % ((uint32_t)img.sectorsPerTrack * img.headsPerCylinder)) == 0;
+        logmsg("---- Drive geometry from ", method,
+            ": SectorsPerTrack=", (int)img.sectorsPerTrack,
+            " HeadsPerCylinder=", (int)img.headsPerCylinder,
+            " total sectors ", (int)img.scsiSectors,
+            divisible ? " (divisible)" : " (not divisible)"
+            );
+        }
 }
 
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, int blocksize, S2S_CFG_TYPE type, bool use_prefix)


### PR DESCRIPTION
Don't display auto calculated geometry message with non standard blocks sizes different from 512. Drives like those for the AS400 with 520 and 522 block sizes do have geometry but seem to be arbitrary and non-divisible to the sector count. The auto calculation will occur, but not be logged.

Add the number of sectors to the SCSI information at the end of initialization. So it now reports something like this: 
`SCSI ID: 0, Type: 0, Quirks: 0, BlockSize: 522, Sectors: 522279, Size: 266239kB`