### PR TITLE
Disable parity check on initiator reads when InitiatorParity=0

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
@@ -320,7 +320,12 @@ uint32_t scsiHostWrite(const uint8_t *data, uint32_t count)
 
 uint32_t scsiHostRead(uint8_t *data, uint32_t count)
 {
-    int parityError = 0;
+    int parityErrorValue = 0;
+    int* parityError = nullptr;
+    if (g_scsi_settings.getSystem()->enableParity)
+    {
+        parityError = &parityErrorValue;
+    }
     uint32_t fullcount = count;
 
     int cd_start = SCSI_IN(CD);
@@ -329,7 +334,7 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count)
     if ((count & 1) == 0 && ((uint32_t)data & 1) == 0)
     {
         // Even number of bytes, use accelerated routine
-        count = scsi_accel_host_read(data, count, &parityError, g_scsiHostBusWidth, &g_scsiHostPhyReset);
+        count = scsi_accel_host_read(data, count, parityError, g_scsiHostBusWidth, &g_scsiHostPhyReset);
     }
     else
     {
@@ -360,12 +365,12 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count)
 
             if (g_scsiHostBusWidth == 0)
             {
-                data[i] = scsiHostReadOneByte(&parityError);
+                data[i] = scsiHostReadOneByte(parityError);
             }
 #ifdef ZULUSCSI_WIDE
             else if (g_scsiHostBusWidth == 1)
             {
-                uint16_t word = scsiHostReadOneWord(&parityError);
+                uint16_t word = scsiHostReadOneWord(parityError);
                 data[i++] = word & 0xFF;
                 if (i < count) data[i] = word >> 8;
             }
@@ -380,7 +385,7 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count)
 
     scsiLogDataIn(data, count);
 
-    if (g_scsiHostPhyReset || parityError)
+    if (g_scsiHostPhyReset || (parityError && *parityError))
     {
         return 0;
     }

--- a/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
@@ -322,7 +322,7 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count)
 {
     int parityErrorValue = 0;
     int* parityError = nullptr;
-    if (g_scsi_settings.getSystem()->enableParity)
+    if (g_scsi_settings.getSystem()->initiatorParity)
     {
         parityError = &parityErrorValue;
     }

--- a/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_host.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsi_accel_host.cpp
@@ -229,24 +229,26 @@ uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, in
         }
     }
 
+    if (parityError)
+    {
 #ifdef ZULUSCSI_WIDE
-    bool parity_ok;
-    if (busWidth == 0)
-        parity_ok = scsi_check_parity(paritycheck);
-    else
-        parity_ok = scsi_check_parity_16bit(paritycheck);
+        bool parity_ok;
+        if (busWidth == 0)
+            parity_ok = scsi_check_parity(paritycheck);
+        else
+            parity_ok = scsi_check_parity_16bit(paritycheck);
 #else
-    bool parity_ok = scsi_check_parity(paritycheck & 0xFFFF) && scsi_check_parity(paritycheck >> 16);
+        bool parity_ok = scsi_check_parity(paritycheck & 0xFFFF) && scsi_check_parity(paritycheck >> 16);
 #endif
 
-    // Check parity errors in whole block
-    // This doesn't detect if there is even number of parity errors in block.
-    if (!parity_ok)
-    {
-        logmsg("Parity error in scsi_accel_host_read(): ", paritycheck);
-        *parityError = 1;
+        // Check parity errors in whole block
+        // This doesn't detect if there is even number of parity errors in block.
+        if (!parity_ok)
+        {
+            logmsg("Parity error in scsi_accel_host_read(): ", paritycheck);
+            *parityError = 1;
+        }
     }
-
     g_scsi_host_state = SCSIHOST_IDLE;
     SCSI_RELEASE_DATA_REQ();
     scsi_accel_host_config_gpio(busWidth);

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -609,7 +609,10 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 #endif
 
     cfgSys.logToSDCard = true;
-#if ENABLE_COW
+
+    cfgSys.initiatorParity = true;
+
+#ifdef ENABLE_COW
     cfgSys.cowBufferSize = DEFAULT_COW_BUFFER_SIZE;
 #endif
 
@@ -799,6 +802,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 
     cfgSys.maxBusWidth = log_ini_getl("SCSI", "MaxBusWidth", cfgSys.maxBusWidth, CONFIGFILE, log_settings, log_getl_bus_width);
     cfgSys.logToSDCard = log_ini_getbool("SCSI", "LogToSDCard", cfgSys.logToSDCard, CONFIGFILE, log_settings);
+    cfgSys.initiatorParity = log_ini_getbool("SCSI", "InitiatorParity", cfgSys.initiatorParity, CONFIGFILE, log_settings);
 
 #if ENABLE_COW
     cfgSys.cowBufferSize = log_ini_getl("SCSI", "CowBufferSize", cfgSys.cowBufferSize, CONFIGFILE, log_settings);

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -126,6 +126,8 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
 
     uint8_t maxBusWidth;
 
+    bool initiatorParity;
+
     bool logToSDCard;
 
 #if ENABLE_COW

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -56,13 +56,15 @@
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
 #InitiatorUseRead10 = 0 # 0: Always use READ6 command, 1: Always use READ10 command, not set: Autodetect READ10 support
 #InitiatorBusWidth = 0 # 0: Always 8-bit, 1: Always 16-bit, not set: Select best supported
+#InitiatorParity = 1 # 0: Disable, 1: Enable (default) - Use parity when cloning devices
+#InitiatorVHD = 0 # Set to 1 for hard drives to be imaged as fixed VHD images
 
 #InitiatorMSC = 0 # Force USB MSC mode for initiator. By default enabled only if SD card is not inserted.
 #InitiatorMSCReadOnly = 0 # Prevent writing to the drive through USB MSC
 #InitiatorMSCDisablePrefetch = 0 # Disable read prefetching in USB MSC mode
 #InitiatorMSCStatusInterval = 5000 # Periodically report access status to log
 #InitiatorMSCInitDelay = 500 # In milliseconds, gives time for USB serial to configure itself
-#InitiatorVHD = 0 # Set to 1 for hard drives to be imaged as fixed VHD images
+
 # On RP2040 based boards and v1.2 the audio disabled by default
 # On Blasters audio is enabled by default
 #EnableCDAudio = 0 # 1: Enable CD audio


### PR DESCRIPTION
Don't test for parity when reading from the device if `InitiatorParity=0`  under the `[SCSI]` section in `zuluscsi.ini`.