### PR TITLE
Fix GD32-specific build errors and memory issue

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -306,8 +306,10 @@ void platform_init()
         // Buttons
         gpio_init(EJECT_BTN_PORT, GPIO_MODE_IPU, 0, EJECT_BTN_PIN);
         gpio_init(USER_BTN_PORT, GPIO_MODE_IPU, 0, USER_BTN_PIN);
+    #ifdef ENABLE_AUDIO_OUTPUT
         init_audio_gpio();
         g_audio_enabled = true;
+    #endif
     }
     else if (g_zuluscsi_version == ZSVersion_v1_2)
     {
@@ -424,7 +426,9 @@ void platform_late_init()
         set_termination(ODE_DIP_PORT, ODE_DIPSW3_PIN, "DIPSW3");
         g_log_debug = get_debug(ODE_DIP_PORT, ODE_DIPSW2_PIN, "DIPSW2");
         g_enable_apple_quirks = get_quirks(ODE_DIP_PORT, ODE_DIPSW1_PIN, "DIPSW1");
+#ifdef ENABLE_AUDIO_OUTPUT
         audio_setup();
+#endif
     }
     else if (ZSVersion_v1_2 == g_zuluscsi_version)
     {
@@ -451,6 +455,7 @@ void platform_late_init()
 
 void platform_post_sd_card_init()
 {
+#ifdef ENABLE_AUDIO_OUTPUT
     #ifdef PLATFORM_VERSION_1_1_PLUS
     if (ZSVersion_v1_2 == g_zuluscsi_version && g_scsi_settings.getSystem()->enableCDAudio)
     {
@@ -460,6 +465,7 @@ void platform_post_sd_card_init()
         audio_setup();
     }
     #endif
+#endif
 }
 
 void platform_write_led(bool state)
@@ -845,7 +851,7 @@ uint8_t platform_get_buttons()
     if (g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2)
     {
         if (!gpio_input_bit_get(EJECT_BTN_PORT, EJECT_BTN_PIN))   buttons |= 1;
-        if (!gpio_input_bit_get(USER_BTN_PORT, USER_BTN_PIN))   buttons |= 4;
+        if (!gpio_input_bit_get(USER_BTN_PORT, USER_BTN_PIN))   buttons |= 2;
     }
     else
     {
@@ -870,26 +876,21 @@ uint8_t platform_get_buttons()
         buttons_debounced = 0;
     }
 
-#ifdef PLATFORM_VERSION_1_1_PLUS
-    if(g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2)
-    {
-        static uint8_t previous = 0x00;
-        uint8_t bitmask = buttons_debounced & USER_BTN_MASK;
-        uint8_t ejectors = (previous ^ bitmask) & previous;
-        previous = bitmask;
-        if (ejectors & USER_BTN_MASK)
-        {
-            logmsg("User button pressed - feature not yet implemented");
-        }
-    }
-#endif
-
     return buttons_debounced;
 }
 
 uint8_t platform_phy_eject_button()
 {
     return (g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2) ? 1 : 0;
+}
+
+uint8_t platform_get_eject_button_mask()
+{
+    return (g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2) ? 1 : 3;
+}
+uint8_t platform_get_user_button_mask()
+{
+    return (g_zuluscsi_version == ZSVersion_v1_1_ODE || g_zuluscsi_version == ZSVersion_v1_2) ? 2 : 0;
 }
 
 /***********************/

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -47,8 +47,9 @@ enum ZuluSCSIVersion_t
 
 };
 
-#define EJECT_BTN_MASK (1|2)
-#define USER_BTN_MASK  (4)
+#define EJECT_BTN_MASK (platform_get_eject_button_mask())
+#define EJECT_BTN_MAX  2
+#define USER_BTN_MASK  (platform_get_user_button_mask())
 
 extern enum ZuluSCSIVersion_t g_zuluscsi_version;
 extern bool g_moved_select_in;
@@ -164,9 +165,11 @@ void platform_boot_to_main_firmware();
 
 // True if the board has a physical eject button
 uint8_t platform_phy_eject_button();
-void platform_set_eject_button(uint8_t eject_button);
-void platform_set_cow_button(uint8_t cow_button);
-
+inline void platform_set_eject_button(uint8_t eject_button){;}
+inline void platform_set_cow_button(uint8_t cow_button){;}
+inline uint8_t platform_get_cow_buttons_override(){return 0;}
+uint8_t platform_get_eject_button_mask();
+uint8_t platform_get_user_button_mask();
 // Configuration customizations based on DIP switch settings
 // When DIPSW1 is on, Apple quirks are enabled by default.
 void platform_config_hook(S2S_TargetCfg *config);

--- a/lib/ZuluSCSI_platform_GD32F205/audio_i2s.h
+++ b/lib/ZuluSCSI_platform_GD32F205/audio_i2s.h
@@ -29,7 +29,8 @@ extern bool g_ode_audio_stopped;
 
 // size of the a circular audio sample buffer, in bytes
 // these must be divisible by 1024
-#define AUDIO_BUFFER_SIZE 16384
+#define AUDIO_BUFFER_SIZE 10240
+// #define AUDIO_BUFFER_SIZE 16384
 // #define AUDIO_BUFFER_SIZE 8192 // ~46.44ms 
 // # define AUDIO_BUFFER_SIZE 4096 // reduce memory usage
 #define AUDIO_BUFFER_HALF_SIZE AUDIO_BUFFER_SIZE / 2

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
     ZuluSCSI_platform_GD32F205
     SCSI2SD
     ZuluContainerFS=https://github.com/rabbitholecomputing/ZuluContainerFS.git
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2025.02.25
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13
     GD32F20x_usbfs_library
 upload_protocol = stlink
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.100301.220327
@@ -115,8 +115,7 @@ build_flags =
     -DINI_CACHE_SIZE=0
     -DUSE_ARDUINO=1
 lib_deps =
-    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
     minIni
     ZuluSCSI_platform_template
     SCSI2SD
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13
+


### PR DESCRIPTION
This fixes build errors related COW enable via the serial menu on Raspberry Pi MCUs. It also decreases the Audio buffer so COW works again and fixes the Audio enable flag for V1.2s so Audio can be disabled completely at build time.