### PR TITLE
Add AS400_CISC and AS400_PPC as the two main AS400 hdd presets

### DIFF
--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -39,12 +39,12 @@ ZuluSCSISettings g_scsi_settings;
 
 const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000", "X68000-SCSI","X68000-SASI", "DOS", "NeXT",
 #ifdef PLATFORM_AS400
-    "AS400", "AS400_BS520", "AS400_BS522",
+    "AS400", "AS400_BS520", "AS400_BS522", "AS400_CISC", "AS400_PPC",
 #endif
 };
 const char *devicePresetName[] = {"", "ST32430N", 
 #ifdef PLATFORM_AS400
-    "AS400_BS520", "AS400_BS522",
+    "AS400_BS520", "AS400_BS522", "AS400_CISC", "AS400_PPC",
 #endif
 };
 
@@ -353,11 +353,13 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
             case SYS_PRESET_AS400:
             // For the AS400 preset, we want to set the device preset to the block size 520
                 [[fallthrough]];
-            case SYS_PRESET_AS400_BS520:
-                m_devPreset[scsiId] = DEV_PRESET_AS400_BS520;
+            case SYS_PRESET_AS400_BS520: [[fallthrough]];
+            case SYS_PRESET_AS400_CISC:
+                m_devPreset[scsiId] = DEV_PRESET_AS400_CISC;
                 break;
-            case SYS_PRESET_AS400_BS522:
-                m_devPreset[scsiId] = DEV_PRESET_AS400_BS522;
+            case SYS_PRESET_AS400_BS522: [[fallthrough]];
+            case SYS_PRESET_AS400_PPC:
+                m_devPreset[scsiId] = DEV_PRESET_AS400_PPC;
                 break;
             default:
                 break;  
@@ -377,12 +379,14 @@ void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetNam
             driveinfo = deviceInitST32430N(scsiId);
             break;
 #ifdef PLATFORM_AS400
-        case DEV_PRESET_AS400_BS520:
+        case DEV_PRESET_AS400_BS520: [[fallthrough]];
+        case DEV_PRESET_AS400_CISC:
             deviceInitAS400(scsiId);
             cfgDev.blockSize = 520;
             driveinfo = as400_driveinfo_dgvs09u_fixed;
             break;
-        case DEV_PRESET_AS400_BS522:
+        case DEV_PRESET_AS400_BS522: [[fallthrough]];
+        case DEV_PRESET_AS400_PPC:
             deviceInitAS400(scsiId);
             cfgDev.blockSize = 522;
             driveinfo = as400_driveinfo_dgvs09u_fixed;
@@ -725,16 +729,18 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
         deviceInitAS400(SCSI_SETTINGS_SYS_IDX);
         m_sysPreset = SYS_PRESET_AS400;
     }
-    else if (strequals(systemPresetName[SYS_PRESET_AS400_BS520], presetName))
+    else if (strequals(systemPresetName[SYS_PRESET_AS400_BS520], presetName)
+            || strequals(systemPresetName[SYS_PRESET_AS400_CISC], presetName))
     {
         deviceInitAS400(SCSI_SETTINGS_SYS_IDX);
-        m_sysPreset = SYS_PRESET_AS400_BS520;
+        m_sysPreset = SYS_PRESET_AS400_CISC;
     }
-    else if (strequals(systemPresetName[SYS_PRESET_AS400_BS522], presetName))
+    else if (strequals(systemPresetName[SYS_PRESET_AS400_BS522], presetName)
+            || strequals(systemPresetName[SYS_PRESET_AS400_PPC], presetName))
     {
 
         deviceInitAS400(SCSI_SETTINGS_SYS_IDX);
-        m_sysPreset = SYS_PRESET_AS400_BS522;
+        m_sysPreset = SYS_PRESET_AS400_PPC;
     }
 #endif 
     else

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -72,6 +72,8 @@ typedef enum
     SYS_PRESET_AS400,
     SYS_PRESET_AS400_BS520,
     SYS_PRESET_AS400_BS522,
+    SYS_PRESET_AS400_CISC,
+    SYS_PRESET_AS400_PPC,
 #endif
 } scsi_system_preset_t;
 
@@ -83,6 +85,8 @@ typedef enum
 #ifdef PLATFORM_AS400
     DEV_PRESET_AS400_BS520,
     DEV_PRESET_AS400_BS522,
+    DEV_PRESET_AS400_CISC,
+    DEV_PRESET_AS400_PPC,
 #endif
 } scsi_device_preset_t;
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -4,7 +4,7 @@
 # Settings that apply to all SCSI IDs
 
 # Select a system preset to apply default settings
-# Known systems: "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000" or "X68000_SCSI", "X68000_SASI", "DOS", "NeXT", "AS400" or "AS400_BS520", "AS400_BS522"
+# Known systems: "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000" or "X68000_SCSI", "X68000_SASI", "DOS", "NeXT", "AS400" or "AS400_CISC", "AS400_PPC"
 #System="Mac"
 
 #Debug = 0   # Same effect as DIPSW2, enables verbose log messages
@@ -88,8 +88,8 @@
 # Select a device preset to apply default settings
 # Known Devices:
 # "ST32430N" - Seagate ST32430N 2.09GB hard drive, used in some Macintosh models. For use with Macs set System="Mac"
-# "AS400_BS520" - IBM AS/400 Hard drive with 520 byte sectors
-# "AS400_BS522" - IBM AS/400 Hard drive with 522 byte sectors
+# "AS400_CISC" - IBM AS/400 Hard drive with 520 byte sectors
+# "AS400_PPC" - IBM AS/400 Hard drive with 522 byte sectors
 #Device = "ST32430N"
 
 # AS/400 only: pin the 8-byte serial reported in the standard inquiry and


### PR DESCRIPTION
AS400_CISC and AS400_PPC are replacing AS400_520 and AS400_522 respectively as presets for the zuluide.ini file. The old settings are being kept, but undocumented for backwards compatibility.