### PR TITLE
Implement log rotation

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -132,18 +132,92 @@ void init_logfile()
 
   if (first_open_after_boot)
   {
-    if (g_scsi_settings.getSystem()->logRotate == 1)
+    // Rotate file to LOGFILEPREV
+    if (g_scsi_settings.getSystem()->logRotate == 1 || g_scsi_settings.getSystem()->logRotate == 2)
     {
       FsFile prev_log_file = SD.open(LOGFILE, O_RDONLY);
       if (prev_log_file.isOpen())
       {
-        if (SD.exists("zululog_prev.txt"))
+        if (SD.exists(LOGFILEPREV))
         {
-          SD.remove("zululog_prev.txt");
+          SD.remove(LOGFILEPREV);
         }
-        prev_log_file.rename("zululog_prev.txt");
+        prev_log_file.rename(LOGFILEPREV);
         prev_log_file.close();
       }
+    }
+
+    // Copy LOGFILEPREV to a numbered file in the LOGFILEDIR directory
+    if (g_scsi_settings.getSystem()->logRotate == 2)
+    {
+      // Attempt to open or create the log rotation directory
+      FsFile prev_log_file = SD.open(LOGFILEPREV, O_RDONLY);
+      if (prev_log_file.isOpen())
+      {
+        FsFile log_dir = SD.open(LOGFILEDIR, O_RDWR);
+        if (!log_dir.isOpen())
+        {
+          SD.mkdir(LOGFILEDIR);
+          log_dir = SD.open(LOGFILEDIR);
+        }
+
+        if (log_dir.isOpen() && log_dir.isDir())
+        {
+          char filename[32] = {0};
+          for (uint32_t i = 0; i <= 1000; i++)
+          {
+              if(i >= 1000)
+              {
+                logmsg("Rotation maximum reached, please delete files in the ", LOGFILEDIR, " directory");
+                break;
+              }
+              else
+              {
+                  // format file as LOGFILEROTATE(nnn).txt
+                  snprintf(filename, sizeof(filename), "%s(%03lu).txt", LOGFILEROTATE, i);
+                  if (log_dir.exists(filename))
+                    continue;
+
+                  // Create and copy the file
+                  FsFile destination;
+                  if (destination.open(&log_dir, filename, O_CREAT | O_WRONLY))
+                  {
+                    // Write a copy of the LOGFILEPREV in the LOGFILEDIR directory
+                    while(true)
+                    {
+                      size_t bytes_read = prev_log_file.readBytes(scsiDev.data, sizeof(scsiDev.data));
+                      if (bytes_read)
+                      {
+                        size_t bytes_written = destination.write(scsiDev.data, bytes_read);
+                        if (bytes_written != bytes_read)
+                        {
+                          logmsg("Log rotation error copying ", LOGFILEPREV, " to ", filename);
+                          break;
+                        }
+                      }
+                      else
+                      {
+                        break;
+                      }
+                    }
+                    destination.close();
+                    break;
+                  }
+                  else
+                  {
+                      logmsg("Log rotation could not create ", filename, " in ", LOGFILEDIR);
+                      break;
+                  }
+              }
+            }
+        }
+        else
+        {
+          logmsg("Log rotation could not open ", LOGFILEDIR, " as a directory");
+        }
+        log_dir.close();
+      }
+      prev_log_file.close();
     }
   }
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -130,6 +130,23 @@ void init_logfile()
 
   static bool first_open_after_boot = true;
 
+  if (first_open_after_boot)
+  {
+    if (g_scsi_settings.getSystem()->logRotate == 1)
+    {
+      FsFile prev_log_file = SD.open(LOGFILE, O_RDONLY);
+      if (prev_log_file.isOpen())
+      {
+        if (SD.exists("zululog_prev.txt"))
+        {
+          SD.remove("zululog_prev.txt");
+        }
+        prev_log_file.rename("zululog_prev.txt");
+        prev_log_file.close();
+      }
+    }
+  }
+
   bool truncate = first_open_after_boot;
   int flags = O_WRONLY | O_CREAT | (truncate ? O_TRUNC : O_APPEND);
   g_logfile = SD.open(LOGFILE, flags);

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -42,7 +42,7 @@
 #define LOGFILE     "zululog.txt"
 #define LOGFILEPREV "zululog_prev.txt"
 #define LOGFILEROTATE "zululog_rotate"
-#define LOGFILEDIR "zululog"
+#define LOGFILEDIR "zuluscsi_log"
 #define CRASHFILE   "zuluerr.txt"
 #define STARTUPSOUND "zulustartup.wav"
 #define FIRMWARE_PREFIX "ZuluSCSI-FW"

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -40,6 +40,9 @@
 // Configuration and log file paths
 #define CONFIGFILE  "zuluscsi.ini"
 #define LOGFILE     "zululog.txt"
+#define LOGFILEPREV "zululog_prev.txt"
+#define LOGFILEROTATE "zululog_rotate"
+#define LOGFILEDIR "zululog"
 #define CRASHFILE   "zuluerr.txt"
 #define STARTUPSOUND "zulustartup.wav"
 #define FIRMWARE_PREFIX "ZuluSCSI-FW"

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -262,6 +262,17 @@ void log_getl_bus_width(const char *Key, long value)
          );
 }
 
+
+void log_getl_log_rotate(const char *Key, long value)
+{
+        logmsg("---- ", Key, " = ", (int) value, ": ",
+           value == 0 ? "Log rotation disabled"
+         : value == 1 ? "Rotate log to zululog_prev.txt"
+         : "invalid"
+         );
+}
+
+
 // Acts just like ini_gets but logs the setting if enabled is true
 static int log_ini_gets(const char *Section, const char *Key, const char *DefValue, char *Buffer, int BufferSize, const char *Filename, bool enabled, void (*custom_message)(const char *Key, char *buffer, int BufferSize) = nullptr)
 {
@@ -613,6 +624,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 #endif
 
     cfgSys.logToSDCard = true;
+
+    cfgSys.logRotate = 1;
 #if ENABLE_COW
     cfgSys.cowBufferSize = DEFAULT_COW_BUFFER_SIZE;
 #endif
@@ -805,7 +818,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 
     cfgSys.maxBusWidth = log_ini_getl("SCSI", "MaxBusWidth", cfgSys.maxBusWidth, CONFIGFILE, log_settings, log_getl_bus_width);
     cfgSys.logToSDCard = log_ini_getbool("SCSI", "LogToSDCard", cfgSys.logToSDCard, CONFIGFILE, log_settings);
-
+    cfgSys.logRotate = log_ini_getl("SCSI", "LogRotate", cfgSys.logRotate, CONFIGFILE, log_settings, log_getl_log_rotate);
 #if ENABLE_COW
     cfgSys.cowBufferSize = log_ini_getl("SCSI", "CowBufferSize", cfgSys.cowBufferSize, CONFIGFILE, log_settings);
 #endif

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -268,6 +268,7 @@ void log_getl_log_rotate(const char *Key, long value)
         logmsg("---- ", Key, " = ", (int) value, ": ",
            value == 0 ? "Log rotation disabled"
          : value == 1 ? "Rotate log to zululog_prev.txt"
+         : value == 2 ? "Save all rotations in /zululog/"
          : "invalid"
          );
 }

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -268,7 +268,7 @@ void log_getl_log_rotate(const char *Key, long value)
         logmsg("---- ", Key, " = ", (int) value, ": ",
            value == 0 ? "Log rotation disabled"
          : value == 1 ? "Rotate log to zululog_prev.txt"
-         : value == 2 ? "Save all rotations in /zululog/"
+         : value == 2 ? "Save all rotations in /zuluscsi_log/"
          : "invalid"
          );
 }

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -132,6 +132,8 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
 
     bool logToSDCard;
 
+    int logRotate;
+
 #if ENABLE_COW
     uint16_t cowBufferSize;
 #endif

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -12,6 +12,7 @@
 #DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card
+#LogRotate = 1 # 0: disable log rotation, 1: single log rotation
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -12,7 +12,7 @@
 #DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card
-#LogRotate = 1 # 0: disable log rotation, 1: single log rotation
+#LogRotate = 1 # 0: disable log rotation, 1: single log rotation, 2: save all rotated logs in /zululog/
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -12,7 +12,7 @@
 #DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card
-#LogRotate = 1 # 0: disable log rotation, 1: single log rotation, 2: save all rotated logs in /zululog/
+#LogRotate = 1 # 0: disable log rotation, 1: single log rotation, 2: save all rotated logs in /zuluscsi_log/
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9


### PR DESCRIPTION
By default log rotation will save a copy of the previous log file as `zululog_prev.txt` before creating a new `zululog.txt.

There is now a `LogRotate` setting for the `[SCSI]` section in the `zuluscsi.ini` file.
- `LogRotate = 0` - disables log rotation and `zululog_prev.txt` will not be created or overwritten
-`LogRotate = 1` - is the default behavior and renames the previous `zululog.txt` as `zululog_prev.txt`
- `LogRotate = 2` - will create a `zuluscsi_log` directory and copies a `zululog_prev.txt` file to that directory with the name `zululog_rotate(nnn).txt` where nnn is a zero padded number between 000 -  999 where the higher number is the most recent.