### PR TITLE
Dynamically assign SCSI ID 'n' for SCA

### DIFF
--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -111,7 +111,7 @@ long g_button3StartTime[TOTAL_CONTROL_BOARD_BUTTONS];
 bool g_button3Press[TOTAL_CONTROL_BOARD_BUTTONS];
 bool g_waitingForButton3Release[TOTAL_CONTROL_BOARD_BUTTONS];
 
-static TwoWire g_wire(i2c1, GPIO_I2C_SDA, GPIO_I2C_SCL);
+TwoWire g_wire(i2c1, GPIO_I2C_SDA, GPIO_I2C_SCL);
 Adafruit_SSD1306 *g_display;
 DeviceMap *g_devices = nullptr;
 
@@ -444,7 +444,7 @@ void enableScreen(bool state)
 
 bool initScreenHardware()
 {
-    g_wire.setClock(100000);
+    g_wire.setClock(PLATFORM_I2C_CLK_SPEED);
 
     // Setting the drive strength seems to help the I2C bus with the Pico W controller and the controller OLED display
     // to communicate and handshake properly
@@ -490,7 +490,7 @@ bool initControlBoardHardware()
 {
     // System clock may have changed
     g_wire.end();
-    g_wire.setClock(100000);
+    g_wire.setClock(PLATFORM_I2C_CLK_SPEED);
     g_wire.begin();
 
     initScreens();

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -98,6 +98,10 @@ static uint8_t g_enabled_eject_buttons = 0;
 static uint8_t g_enabled_cow_buttons = 0;
 static uint8_t g_cow_button_state = 0;
 
+#ifdef ZULUSCSI_WIDE
+static bool g_is_sca = false;
+#endif
+
 static struct {
     uint32_t slice;
     uint32_t chan;
@@ -422,6 +426,12 @@ void platform_init()
     bool data_dir_state = false;
 #else
     bool data_dir_state = true;
+#endif
+
+#if defined(ZULUSCSI_WIDE) && defined(GPIO_SCA_TEST)
+    gpio_conf(GPIO_SCA_TEST, GPIO_FUNC_SIO, false, false, false, false, false);
+    g_is_sca = !gpio_get(GPIO_SCA_TEST);
+
 #endif
 
     //        pin             function       pup   pdown  out   state           fast
@@ -1546,6 +1556,14 @@ uint8_t platform_get_cow_buttons_override()
 {
     return g_cow_button_state;
 }
+
+
+#ifdef ZULUSCSI_WIDE
+bool platform_is_sca()
+{
+    return g_is_sca;
+}
+#endif
 
 /************************************/
 /* ROM drive in extra flash space   */

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1558,7 +1558,7 @@ uint8_t platform_get_cow_buttons_override()
 }
 
 
-#ifdef ZULUSCSI_WIDE
+#if defined(ZULUSCSI_WIDE) && defined(DYNAMIC_SCSI_ID)
 bool platform_is_sca()
 {
     return g_is_sca;

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -246,6 +246,11 @@ void platform_set_cow_button(uint8_t cow_button);
 // This can be tested to see if a cow button is overridden on, if not the current platform_get_buttons() state should be used
 uint8_t platform_get_cow_buttons_override();
 
+#ifdef ZULUSCSI_WIDE
+// Returns true if the SCSI connector is SCA
+bool platform_is_sca();
+#endif
+
 #ifdef __cplusplus
 }
 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_config.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_config.h
@@ -114,3 +114,7 @@
 #ifndef PLATFORM_AS400
 #define  PLATFORM_AS400
 #endif
+
+#ifndef PLATFORM_I2C_CLK_SPEED
+#define PLATFORM_I2C_CLK_SPEED 100000
+#endif

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Wide.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_gpio_Wide.h
@@ -112,6 +112,8 @@
     #define AUDIO_DMA_IRQ_NUM DMA_IRQ_2
 #endif
 
+#define GPIO_SCA_TEST GPIO_I2C_INTR
+
 #ifdef ENABLE_AUDIO_OUTPUT_I2S
     #define GPIO_I2S_BCLK 45
     #define GPIO_I2S_WS   46

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_sca.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_sca.cpp
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 **/
 
-#ifdef ZULUSCSI_WIDE
+#ifdef DYNAMIC_SCSI_ID
 
 #include "ZuluSCSI_sca_hw_config.h"
 #include "ZuluSCSI_log.h"
@@ -151,4 +151,4 @@ bool zululscsi_sca_hw_remote_start()
     return g_sca_hardware_config.remote_start;
 }
 
-#endif // ZULUSCSI_WIDE
+#endif // DYNAMIC_SCSI_ID

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_sca.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_sca.cpp
@@ -1,0 +1,154 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
+ *
+ * This file is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#ifdef ZULUSCSI_WIDE
+
+#include "ZuluSCSI_sca_hw_config.h"
+#include "ZuluSCSI_log.h"
+#include <ZuluSCSI_platform.h>
+#include <Wire.h>
+
+#ifndef ZULUSCSI_SCA_I2C_EXPANDER_ADDR 
+#define ZULUSCSI_SCA_I2C_EXPANDER_ADDR 0x19
+#endif
+
+extern TwoWire g_wire;
+
+struct
+{
+    int8_t scsi_id;
+    bool delayed_start;
+    bool remote_start;
+    bool mated_1;
+    bool valid;
+    bool failed;
+} g_sca_hardware_config;
+
+bool zuluscsi_is_sca()
+{
+    return platform_is_sca();
+}
+
+bool zuluscsi_sca_hw_update()
+{
+    g_sca_hardware_config.failed = false;
+    g_sca_hardware_config.valid = false;
+    g_sca_hardware_config.scsi_id = -1;
+    int expander_io_input = -1;
+    g_wire.end();
+    g_wire.setClock(PLATFORM_I2C_CLK_SPEED);
+    g_wire.begin();
+
+    // invert all inputs
+    g_wire.beginTransmission(ZULUSCSI_SCA_I2C_EXPANDER_ADDR);
+    g_wire.write((uint8_t) 0x02); // Control - Switch to write to Polarity Register
+    g_wire.write((uint8_t) 0x7F); // Set Polarity Register - invert all bits but spindle
+    uint8_t status = g_wire.endTransmission();
+    if (status == 0)
+    {
+        g_wire.beginTransmission(ZULUSCSI_SCA_I2C_EXPANDER_ADDR);
+        g_wire.write((uint8_t) 0x00); // Control - Switch to read from Input Register
+        status = g_wire.endTransmission();
+    } 
+    if (0 != status)
+    {
+        g_sca_hardware_config.failed = true;
+        logmsg("Error, ", (int)status,", communicating with the SCA I2C IO expander with address ", (uint8_t)ZULUSCSI_SCA_I2C_EXPANDER_ADDR, ". Check for conflicting I2C devices and a clean I2C bus");
+    }
+
+    if (!g_sca_hardware_config.failed)
+    {
+
+        g_wire.requestFrom(ZULUSCSI_SCA_I2C_EXPANDER_ADDR, 1);
+
+        if (g_wire.available())
+        {
+            expander_io_input = g_wire.read();
+        }
+
+        if (expander_io_input == -1)
+        {
+            g_sca_hardware_config.failed = true;
+            logmsg("Error reading the SCA config pin from the I2C IO expander");
+            
+        }
+        else
+        {
+            g_sca_hardware_config.mated_1 = expander_io_input & 0x10;
+            // should wait 250 ms after mated 1 is valid to read other values
+            // ignoring for now, we'll see if that becomes an issue 
+
+            g_sca_hardware_config.scsi_id = expander_io_input & 0xF;
+            g_sca_hardware_config.delayed_start = expander_io_input & 0x20;
+            g_sca_hardware_config.remote_start = expander_io_input & 0x40;
+            g_sca_hardware_config.valid = g_sca_hardware_config.mated_1;
+            if (g_sca_hardware_config.valid)
+            {
+                dbgmsg("Valid SCA settings: SCSI ID: ", (int) g_sca_hardware_config.scsi_id,
+                        ", Delayed Start: ", g_sca_hardware_config.delayed_start ? "yes": "no",
+                        ", Remote Start: ",  g_sca_hardware_config.remote_start  ? "yes": "no"
+                );
+                LED_OFF();
+            }
+            else
+            {
+                static uint32_t invalid_print_start = 0;
+
+                if ((uint32_t)(millis() - invalid_print_start) > 3000 || invalid_print_start == 0)
+                {
+                    static bool led_state_on = false;
+                    if (led_state_on)
+                        LED_ON();
+                    else
+                        LED_OFF();
+                    led_state_on = !led_state_on;
+
+                    dbgmsg("Invalid SCA settings - mated 1 not ready");
+                    invalid_print_start = millis();
+                }
+            }
+
+            
+        }
+    }
+    return !g_sca_hardware_config.failed;
+}
+
+int8_t zuluscsi_sca_hw_scsi_id()
+{
+    return g_sca_hardware_config.valid ? g_sca_hardware_config.scsi_id : -1;
+}
+bool zuluscsi_sca_hw_valid()
+{
+    return g_sca_hardware_config.valid;
+}
+
+bool zuluscsi_sca_hw_delayed_start()
+{
+    return g_sca_hardware_config.delayed_start;
+}
+
+bool zululscsi_sca_hw_remote_start()
+{
+    return g_sca_hardware_config.remote_start;
+}
+
+#endif // ZULUSCSI_WIDE

--- a/platformio.ini
+++ b/platformio.ini
@@ -252,6 +252,7 @@ build_flags =
     -DPICO_RP2350A=0
     -DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
+    -DDYNAMIC_SCSI_ID
 
 ; Firmware for ZuluSCSI V1.0/v1.1/v1.2 hardware platforms (GD32-based microcontrollers) 
 ; has been transitioned to Long Term Support state, and is maintained in the LTS/v1.x branch. 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -57,6 +57,7 @@
 #include "ZuluSCSI_log_trace.h"
 #include "ZuluSCSI_settings.h"
 #include "ZuluSCSI_disk.h"
+#include "ZuluSCSI_sca_hw_config.h"
 #include "ZuluSCSI_initiator.h"
 #include "ZuluSCSI_msc_initiator.h"
 #include "ZuluSCSI_msc.h"
@@ -486,6 +487,78 @@ static bool typeIsRemovable(S2S_CFG_TYPE type)
     return false;
   }
 }
+static bool mountSDCard();
+static void spin_for_reboot(bool rebooting);
+
+// set the Dynamic SCSI ID
+static void configDynamicScsiId()
+{
+  
+  int8_t id_override = ini_getl("SCSI", "DynamicScsiId", -1, CONFIGFILE);
+  if (id_override >= 0)
+  {
+    logmsg("Dynamic SCSI ID overridden by 'DynamicScsiId = ", (int) id_override,"' in ", CONFIGFILE);
+    scsiDiskSetDynamicId(id_override);
+  }
+  else
+  {
+    // This is nearly like the main loop as it could loop indefinitely
+    // It allows for menu reset and saving the log file to the SD so the user can figure
+    // out if they are hanging due to a bad SCA connection
+    bool first_loop = true;
+    uint32_t check_sd_start = millis();
+    FsFile file_check;
+    file_check = SD.open("/", O_RDONLY);
+    if (SD.card() && SD.sdErrorCode() == 0 && file_check.isOpen())
+        file_check.close();
+    else
+      g_sdcard_present = mountSDCard();
+    
+    init_logfile();
+
+    bool sca_hw_works = false;
+    do {
+      sca_hw_works = zuluscsi_sca_hw_update();
+
+      if (first_loop && sca_hw_works && !zuluscsi_sca_hw_valid())
+      {
+        logmsg("SCA connector reported not mated (check the SCA connection) - will poll indefinitely until SCA is properly seated.");
+        logmsg("To override set 'DynamicScsiId = <0 - ",S2S_MAX_TARGETS - 1,">' in ", CONFIGFILE, " or do not use 'n' for image SCSI ID");
+      }
+      first_loop = false;
+
+      // psuedo main loop - for logging, to trap resets and SD card removal/inserts
+      // rebooting into SD card reader doesn't work, but standard reboot does
+      if ((uint32_t)(millis() - check_sd_start) > 3000)
+      {
+        file_check = SD.open("/", O_RDONLY);
+        if (SD.card() && SD.sdErrorCode() == 0 && file_check.isOpen())
+        {
+          file_check.close();
+        }
+        else
+        {
+          g_sdcard_present = mountSDCard();
+          init_logfile();
+        }
+        check_sd_start = millis();
+      }
+      platform_poll();
+      save_logfile();
+      // if the SD card has been removed and this setting changed to a valid ID
+      id_override = ini_getl("SCSI", "DynamicScsiId", -1, CONFIGFILE);
+      if (id_override >= 0 && id_override < S2S_MAX_TARGETS)
+      {
+        scsiDiskSetDynamicId(id_override);
+        break;
+      }
+      spin_for_reboot(g_rebooting);
+    } while (sca_hw_works && !zuluscsi_sca_hw_valid());
+
+    if (id_override < 0 && sca_hw_works)
+      scsiDiskSetDynamicId(zuluscsi_sca_hw_scsi_id());
+  }
+}
 
 // Iterate over the root path in the SD card looking for candidate image files.
 bool findHDDImages()
@@ -611,21 +684,47 @@ bool findHDDImages()
         // Parse SCSI device ID
         int file_name_length = strlen(name);
         if(file_name_length > 2) { // HD[N]
-          int tmp_id = scsiParseId(name[HDIMG_ID_POS]);
-          if (tmp_id >= S2S_MAX_TARGETS)
+          // The dynamic ID character 'n' maps to the run time acquired SCSI ID.
+          if (tolower(name[HDIMG_ID_POS]) == DYNAMIC_SCSI_ID_CHAR)
           {
-            logmsg("The file, ", name, " with SCSI ID: ", tmp_id, " is larger than allowed on the SCSI bus, skipping file");
-            continue;
-          }
-
-          if(tmp_id > -1 && tmp_id < S2S_MAX_TARGETS)
-          {
-            id = tmp_id; // If valid id, set it, else use default
-            use_prefix = true;
+#ifdef ZULUSCSI_WIDE
+            // Lazily resolve the SCA SCSI ID the first time an 'n'-prefixed
+            // image is found, so the expander is only queried when needed.
+            if (scsiDiskGetDynamicId() < 0 && zuluscsi_is_sca())
+            {
+              configDynamicScsiId();
+            }
+#endif
+            int8_t dyn_id = scsiDiskGetDynamicId();
+            if (dyn_id >= 0)
+            {
+              id = dyn_id;
+              use_prefix = true;
+            }
+            else
+            {
+              logmsg("-- Ignoring ", name, ": uses dynamic ID char 'n' but query for ID failed");
+              continue;
+            }
           }
           else
           {
-            id = usedDefaultId++;
+            int tmp_id = scsiParseId(name[HDIMG_ID_POS]);
+            if (tmp_id >= S2S_MAX_TARGETS)
+            {
+              logmsg("The file, ", name, " with SCSI ID: ", tmp_id, " is larger than allowed on the SCSI bus, skipping file");
+              continue;
+            }
+
+            if(tmp_id > -1 && tmp_id < S2S_MAX_TARGETS)
+            {
+              id = tmp_id; // If valid id, set it, else use default
+              use_prefix = true;
+            }
+            else
+            {
+              id = usedDefaultId++;
+            }
           }
         }
 
@@ -673,6 +772,9 @@ bool findHDDImages()
         if (is_zp) type = S2S_CFG_ZIP100;
 
         g_scsi_settings.initDevice(id, type);
+        // For the dynamic target, [SCSIn] settings override [SCSI<X>] settings.
+        if (id == (int)scsiDiskGetDynamicId())
+            g_scsi_settings.applyDynamicSectionOverrides(id);
         // set the default block size now that we know the device type
         if (g_scsi_settings.getDevice(id)->blockSize == 0)
         {
@@ -963,6 +1065,14 @@ static void reinitSCSI()
   else
 #endif // ZULUSCSI_HARDWARE_CONFIG
   {
+#ifdef ZULUSCSI_WIDE
+    // Lazily resolve the SCA SCSI ID the first time 'n'-prefixed directories
+    // are found, so the expander is only queried when needed.
+    if (scsiDiskGetDynamicId() < 0 && zuluscsi_is_sca() && scsiDiskHasDynamicDirs())
+    {
+      configDynamicScsiId();
+    }
+#endif
     readSCSIDeviceConfig();
     findHDDImages();
 
@@ -1425,10 +1535,9 @@ void control_disk_swap()
 #endif
 }
 
-extern "C" void zuluscsi_main_loop(void)
+static void spin_for_reboot(bool rebooting)
 {
-    // While timer for reboot is going, attempt to close SD images
-  if (g_rebooting)
+  if (rebooting)
   {
     while (!scsiIsWriteFinished(NULL) || !scsiIsReadFinished(NULL))
     {
@@ -1446,6 +1555,12 @@ extern "C" void zuluscsi_main_loop(void)
       platform_reset_watchdog();
     }
   }
+}
+
+extern "C" void zuluscsi_main_loop(void)
+{
+    // While timer for reboot is going, attempt to close SD images
+  spin_for_reboot(g_rebooting);
 
   static uint32_t sd_card_check_time = 0;
   static uint32_t last_request_time = 0;
@@ -1499,8 +1614,6 @@ extern "C" void zuluscsi_main_loop(void)
       last_request_time = millis();
     }
   }
-
-
 
   if (g_sdcard_present)
   {

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -691,27 +691,40 @@ bool findHDDImages()
           // The dynamic ID character 'n' maps to the run time acquired SCSI ID.
           if (tolower(name[HDIMG_ID_POS]) == DYNAMIC_SCSI_ID_CHAR)
           {
+             if (zuluscsi_is_sca())
+             {
+              // Lazily resolve the SCA SCSI ID the first time an 'n'-prefixed
+              // image is found, so the expander is only queried when needed.
+              if (scsiDiskGetDynamicId() < 0)
+              {
+                configDynamicScsiId();
+              }
 
-            // Lazily resolve the SCA SCSI ID the first time an 'n'-prefixed
-            // image is found, so the expander is only queried when needed.
-            if (scsiDiskGetDynamicId() < 0 && zuluscsi_is_sca())
-            {
-              configDynamicScsiId();
-            }
-
-            int8_t dyn_id = scsiDiskGetDynamicId();
-            if (dyn_id >= 0)
-            {
-              id = dyn_id;
-              use_prefix = true;
+              int8_t dyn_id = scsiDiskGetDynamicId();
+              if (dyn_id >= 0)
+              {
+                id = dyn_id;
+                use_prefix = true;
+              }
+              else
+              {
+                logmsg("-- Ignoring \"", name, "\": uses dynamic ID char 'n' but query for ID failed");
+                continue;
+              }
             }
             else
             {
-              logmsg("-- Ignoring ", name, ": uses dynamic ID char 'n' but query for ID failed");
+              logmsg("-- Ignoring \"", name, "\": this board does not support dynamic SCSI IDs, set 'n' to a valid SCSI ID");
               continue;
             }
           }
           else
+#else // !DYNAMIC_SCSI_ID
+          if (tolower(name[HDIMG_ID_POS]) == DYNAMIC_SCSI_ID_CHAR)
+          {
+            logmsg("-- Ignoring \"", name, "\": this board does not support dynamic SCSI IDs, set 'n' to a valid SCSI ID");
+            continue;
+          }
 #endif // DYNAMIC_SCSI_ID
           {
             int tmp_id = scsiParseId(name[HDIMG_ID_POS]);

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -490,6 +490,7 @@ static bool typeIsRemovable(S2S_CFG_TYPE type)
 static bool mountSDCard();
 static void spin_for_reboot(bool rebooting);
 
+#ifdef DYNAMIC_SCSI_ID
 // set the Dynamic SCSI ID
 static void configDynamicScsiId()
 {
@@ -559,6 +560,7 @@ static void configDynamicScsiId()
       scsiDiskSetDynamicId(zuluscsi_sca_hw_scsi_id());
   }
 }
+#endif
 
 // Iterate over the root path in the SD card looking for candidate image files.
 bool findHDDImages()
@@ -683,18 +685,20 @@ bool findHDDImages()
 
         // Parse SCSI device ID
         int file_name_length = strlen(name);
+
         if(file_name_length > 2) { // HD[N]
+#ifdef DYNAMIC_SCSI_ID
           // The dynamic ID character 'n' maps to the run time acquired SCSI ID.
           if (tolower(name[HDIMG_ID_POS]) == DYNAMIC_SCSI_ID_CHAR)
           {
-#ifdef ZULUSCSI_WIDE
+
             // Lazily resolve the SCA SCSI ID the first time an 'n'-prefixed
             // image is found, so the expander is only queried when needed.
             if (scsiDiskGetDynamicId() < 0 && zuluscsi_is_sca())
             {
               configDynamicScsiId();
             }
-#endif
+
             int8_t dyn_id = scsiDiskGetDynamicId();
             if (dyn_id >= 0)
             {
@@ -708,6 +712,7 @@ bool findHDDImages()
             }
           }
           else
+#endif // DYNAMIC_SCSI_ID
           {
             int tmp_id = scsiParseId(name[HDIMG_ID_POS]);
             if (tmp_id >= S2S_MAX_TARGETS)
@@ -772,9 +777,11 @@ bool findHDDImages()
         if (is_zp) type = S2S_CFG_ZIP100;
 
         g_scsi_settings.initDevice(id, type);
+#ifdef DYNAMIC_SCSI_ID
         // For the dynamic target, [SCSIn] settings override [SCSI<X>] settings.
         if (id == (int)scsiDiskGetDynamicId())
             g_scsi_settings.applyDynamicSectionOverrides(id);
+#endif
         // set the default block size now that we know the device type
         if (g_scsi_settings.getDevice(id)->blockSize == 0)
         {
@@ -1065,7 +1072,7 @@ static void reinitSCSI()
   else
 #endif // ZULUSCSI_HARDWARE_CONFIG
   {
-#ifdef ZULUSCSI_WIDE
+#ifdef DYNAMIC_SCSI_ID
     // Lazily resolve the SCA SCSI ID the first time 'n'-prefixed directories
     // are found, so the expander is only queried when needed.
     if (scsiDiskGetDynamicId() < 0 && zuluscsi_is_sca() && scsiDiskHasDynamicDirs())

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -72,6 +72,12 @@
 #define HDIMG_LUN_POS 3                 // Position to embed LUN numbers
 #define HDIMG_BLK_POS 5                 // Position to embed block size numbers
 
+// Dynamic SCSI ID — set at boot from GPIO I2C expander (see ZuluSCSI_sca_hw_config.h).
+// The INI section [SCSIn] and image prefixes HDn/CDn/TPn/etc. apply to this device.
+// [SCSIn] settings take priority over the hardcoded [SCSI<X>] section for this ID.
+#define DYNAMIC_SCSI_INI_SECTION "SCSIn"
+#define DYNAMIC_SCSI_ID_CHAR     'n'
+
 #if defined(CONTROL_BOARD)
 #define MAX_FILE_PATH 260                // Maximum file name length
 #else

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -72,7 +72,7 @@
 #define HDIMG_LUN_POS 3                 // Position to embed LUN numbers
 #define HDIMG_BLK_POS 5                 // Position to embed block size numbers
 
-// Dynamic SCSI ID — set at boot from GPIO I2C expander (see ZuluSCSI_sca_hw_config.h).
+
 // The INI section [SCSIn] and image prefixes HDn/CDn/TPn/etc. apply to this device.
 // [SCSIn] settings take priority over the hardcoded [SCSI<X>] section for this ID.
 #define DYNAMIC_SCSI_INI_SECTION "SCSIn"

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -93,6 +93,7 @@ int8_t scsiParseId(const char scsi_id_text)
     return -1;
 }
 
+#ifdef  DYNAMIC_SCSI_ID
 // SCSI ID read from the GPIO I2C expander at boot. -1 = not available.
 static int8_t g_dynamic_scsi_id = -1;
 
@@ -120,6 +121,7 @@ bool scsiDiskHasDynamicDirs()
     }
     return false;
 }
+#endif
 
 char scsiEncodeID(const uint8_t scsi_id)
 {
@@ -882,13 +884,17 @@ static void scsiDiskSetConfig(int target_idx)
     char section[6] = "SCSI0";
     section[4] = scsiEncodeID(target_idx);
     char tmp[32];
-
+#ifdef DYNAMIC_SCSI_ID
     bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
+#endif
 
-    // [SCSIn] ImgDir takes priority over [SCSI<X>] ImgDir for the dynamic target.
+
     tmp[0] = '\0';
+#ifdef DYNAMIC_SCSI_ID
+    // [SCSIn] ImgDir takes priority over [SCSI<X>] ImgDir for the dynamic target.
     if (is_dynamic)
         ini_gets(DYNAMIC_SCSI_INI_SECTION, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
+#endif
     if (!tmp[0])
         ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
 
@@ -901,6 +907,7 @@ static void scsiDiskSetConfig(int target_idx)
     }
     else
     {
+#ifdef DYNAMIC_SCSI_ID
         // For the dynamic target, check HDn/CDn/etc. directories first.
         // These take priority over the hardcoded HD<X>/CD<X>/etc. directories.
         if (is_dynamic)
@@ -913,7 +920,7 @@ static void scsiDiskSetConfig(int target_idx)
             scsiDiskCheckDir("FDn", target_idx, &img, S2S_CFG_FLOPPY_14MB, "floppy");
             scsiDiskCheckDir("ZPn", target_idx, &img, S2S_CFG_ZIP100, "Iomega Zip 100");
         }
-
+#endif
         strcpy(tmp, "HD0");
         tmp[2] = scsiEncodeID(target_idx);
         scsiDiskCheckDir(tmp, target_idx, &img, S2S_CFG_FIXED, "disk");
@@ -1155,9 +1162,9 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 
     char section[6] = "SCSI0";
     section[4] = scsiEncodeID(target_idx);
-
+#ifdef DYNAMIC_SCSI_ID
     bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
-
+#endif
     // sanity check: is provided buffer is long enough to store a filename?
     assert(buflen >= MAX_FILE_PATH);
 
@@ -1181,10 +1188,12 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
         // image directory was found during startup
         char dirname[MAX_FILE_PATH];
         char key[] = "ImgDir";
-        // For the dynamic target, check [SCSIn] ImgDir first, then [SCSI<X>].
         int dirlen = 0;
+#ifdef DYNAMIC_SCSI_ID
+        // For the dynamic target, check [SCSIn] ImgDir first, then [SCSI<X>].
         if (is_dynamic)
             dirlen = ini_gets(DYNAMIC_SCSI_INI_SECTION, key, "", dirname, sizeof(dirname), CONFIGFILE);
+#endif
         if (!dirlen)
             dirlen = ini_gets(section, key, "", dirname, sizeof(dirname), CONFIGFILE);
         if (!dirlen)
@@ -1218,7 +1227,9 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
                     dbgmsg("No matching device type for default directory found");
                     return 0;
             }
+#ifdef DYNAMIC_SCSI_ID
             dirname[2] = is_dynamic ? DYNAMIC_SCSI_ID_CHAR : scsiEncodeID(target_idx);
+#endif
             if (!SD.exists(dirname))
             {
                 dbgmsg("Default image directory, ", dirname, " does not exist");
@@ -1314,8 +1325,10 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
             // For the dynamic target, check [SCSIn] IMG keys first, then [SCSI<X>].
             int ret = 0;
             buf[0] = '\0';
+#ifdef DYNAMIC_SCSI_ID
             if (is_dynamic)
                 ret = ini_gets(DYNAMIC_SCSI_INI_SECTION, key, "", buf, buflen, CONFIGFILE);
+#endif
             if (!ret || buf[0] == '\0')
                 ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
 
@@ -1345,6 +1358,7 @@ void scsiDiskLoadConfig(int target_idx)
     // Then settings specific to target ID
     scsiDiskSetConfig(target_idx);
 
+#ifdef DYNAMIC_SCSI_ID
     // Apply [SCSIn] on top of the [SCSI<X>] settings that scsiDiskSetConfig loaded,
     // then immediately sync g_scsi_settings → g_DiskImages so that scsiDiskGetNextImageName
     // reads the final device type and settings (not the pre-override values).
@@ -1354,7 +1368,7 @@ void scsiDiskLoadConfig(int target_idx)
         g_scsi_settings.applyDynamicSectionOverrides(target_idx);
         scsiDiskSetImageConfig(target_idx);
     }
-
+#endif
     // Check if we have image specified by name
     char filename[MAX_FILE_PATH];
     image_config_t &img = g_DiskImages[target_idx];

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -93,6 +93,34 @@ int8_t scsiParseId(const char scsi_id_text)
     return -1;
 }
 
+// SCSI ID read from the GPIO I2C expander at boot. -1 = not available.
+static int8_t g_dynamic_scsi_id = -1;
+
+void scsiDiskSetDynamicId(int8_t id)
+{
+    g_dynamic_scsi_id = (id >= 0 && id < S2S_MAX_TARGETS) ? id : -1;
+    if (g_dynamic_scsi_id >= 0)
+        logmsg("Dynamic SCSI ID: ", (int)g_dynamic_scsi_id);
+}
+
+int8_t scsiDiskGetDynamicId()
+{
+    return g_dynamic_scsi_id;
+}
+
+bool scsiDiskHasDynamicDirs()
+{
+    static const char * const dirs[] = {
+        "HDn", "CDn", "REn", "MOn", "TPn", "FDn", "ZPn"
+    };
+    for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++)
+    {
+        if (SD.exists(dirs[i]))
+            return true;
+    }
+    return false;
+}
+
 char scsiEncodeID(const uint8_t scsi_id)
 {
     if (scsi_id >= 0xA && scsi_id <= 0xF)
@@ -810,16 +838,17 @@ bool scsiDiskFolderIsTapeFolder(FsFile *dir)
 {
     char filename[MAX_FILE_PATH + 1];
     dir->getName(filename, sizeof(filename));
-    // string starts with 'tp', the 3rd character is a SCSI ID, and it has more 3 charters
-    // e.g. "tp0 - tape 01"
-    if (strlen(filename) > 3 && strncasecmp("tp", filename, 2) == 0 && scsiParseId(filename[2]) > 0)
+    // string starts with 'tp', the 3rd character is a SCSI ID or the dynamic ID char,
+    // and the name has more than 3 characters — e.g. "tp0 - tape 01" or "tpn - tape"
+    if (strlen(filename) > 3 && strncasecmp("tp", filename, 2) == 0
+        && (scsiParseId(filename[2]) > 0 || tolower(filename[2]) == DYNAMIC_SCSI_ID_CHAR))
     {
         return true;
     }
     return false;
 }
 
-static void scsiDiskCheckDir(char * dir_name, int target_idx, image_config_t* img, S2S_CFG_TYPE type, const char* type_name)
+static void scsiDiskCheckDir(const char * dir_name, int target_idx, image_config_t* img, S2S_CFG_TYPE type, const char* type_name)
 {
     if (SD.exists(dir_name))
     {
@@ -844,7 +873,7 @@ static void scsiDiskCheckDir(char * dir_name, int target_idx, image_config_t* im
 // Otherwise keep current settings.
 static void scsiDiskSetConfig(int target_idx)
 {
-    
+
     image_config_t &img = g_DiskImages[target_idx];
     img.scsiId = target_idx;
 
@@ -854,7 +883,15 @@ static void scsiDiskSetConfig(int target_idx)
     section[4] = scsiEncodeID(target_idx);
     char tmp[32];
 
-    ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
+    bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
+
+    // [SCSIn] ImgDir takes priority over [SCSI<X>] ImgDir for the dynamic target.
+    tmp[0] = '\0';
+    if (is_dynamic)
+        ini_gets(DYNAMIC_SCSI_INI_SECTION, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
+    if (!tmp[0])
+        ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
+
     if (tmp[0])
     {
         logmsg("SCSI", target_idx, " using image directory '", tmp, "'");
@@ -864,6 +901,19 @@ static void scsiDiskSetConfig(int target_idx)
     }
     else
     {
+        // For the dynamic target, check HDn/CDn/etc. directories first.
+        // These take priority over the hardcoded HD<X>/CD<X>/etc. directories.
+        if (is_dynamic)
+        {
+            scsiDiskCheckDir("HDn", target_idx, &img, S2S_CFG_FIXED, "disk");
+            scsiDiskCheckDir("CDn", target_idx, &img, S2S_CFG_OPTICAL, "optical");
+            scsiDiskCheckDir("REn", target_idx, &img, S2S_CFG_REMOVABLE, "removable");
+            scsiDiskCheckDir("MOn", target_idx, &img, S2S_CFG_MO, "magneto-optical");
+            scsiDiskCheckDir("TPn", target_idx, &img, S2S_CFG_SEQUENTIAL, "tape");
+            scsiDiskCheckDir("FDn", target_idx, &img, S2S_CFG_FLOPPY_14MB, "floppy");
+            scsiDiskCheckDir("ZPn", target_idx, &img, S2S_CFG_ZIP100, "Iomega Zip 100");
+        }
+
         strcpy(tmp, "HD0");
         tmp[2] = scsiEncodeID(target_idx);
         scsiDiskCheckDir(tmp, target_idx, &img, S2S_CFG_FIXED, "disk");
@@ -913,6 +963,7 @@ static void scsiDiskSetConfig(int target_idx)
     }
 #endif
     g_scsi_settings.initDevice(target_idx, (S2S_CFG_TYPE)img.deviceType, true);
+
 }
 
 // Compares the prefix of both files and the scsi ID
@@ -1105,6 +1156,8 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
     char section[6] = "SCSI0";
     section[4] = scsiEncodeID(target_idx);
 
+    bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
+
     // sanity check: is provided buffer is long enough to store a filename?
     assert(buflen >= MAX_FILE_PATH);
 
@@ -1128,37 +1181,44 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
         // image directory was found during startup
         char dirname[MAX_FILE_PATH];
         char key[] = "ImgDir";
-        int dirlen = ini_gets(section, key, "", dirname, sizeof(dirname), CONFIGFILE);
+        // For the dynamic target, check [SCSIn] ImgDir first, then [SCSI<X>].
+        int dirlen = 0;
+        if (is_dynamic)
+            dirlen = ini_gets(DYNAMIC_SCSI_INI_SECTION, key, "", dirname, sizeof(dirname), CONFIGFILE);
+        if (!dirlen)
+            dirlen = ini_gets(section, key, "", dirname, sizeof(dirname), CONFIGFILE);
         if (!dirlen)
         {
+            // Reconstruct the default directory name from the device type.
+            // Dynamic targets use the 'n' suffix (HDn, CDn, …); others use the hex ID.
             switch (img.deviceType)
             {
                 case S2S_CFG_FIXED:
-                    strcpy(dirname ,"HD0");
+                    strcpy(dirname, "HD0");
                     break;
                 case S2S_CFG_OPTICAL:
                     strcpy(dirname, "CD0");
-                break;
+                    break;
                 case S2S_CFG_REMOVABLE:
                     strcpy(dirname, "RE0");
-                break;
+                    break;
                 case S2S_CFG_MO:
                     strcpy(dirname, "MO0");
-                break;
+                    break;
                 case S2S_CFG_SEQUENTIAL:
-                    strcpy(dirname ,"TP0");
-                break;
+                    strcpy(dirname, "TP0");
+                    break;
                 case S2S_CFG_FLOPPY_14MB:
                     strcpy(dirname, "FD0");
-                break;
+                    break;
                 case S2S_CFG_ZIP100:
                     strcpy(dirname, "ZP0");
-                break;
+                    break;
                 default:
                     dbgmsg("No matching device type for default directory found");
                     return 0;
             }
-            dirname[2] = scsiEncodeID(target_idx);
+            dirname[2] = is_dynamic ? DYNAMIC_SCSI_ID_CHAR : scsiEncodeID(target_idx);
             if (!SD.exists(dirname))
             {
                 dbgmsg("Default image directory, ", dirname, " does not exist");
@@ -1251,7 +1311,14 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
             char key[5] = "IMG0";
             key[3] = '0' + img.image_index;
 
-            int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+            // For the dynamic target, check [SCSIn] IMG keys first, then [SCSI<X>].
+            int ret = 0;
+            buf[0] = '\0';
+            if (is_dynamic)
+                ret = ini_gets(DYNAMIC_SCSI_INI_SECTION, key, "", buf, buflen, CONFIGFILE);
+            if (!ret || buf[0] == '\0')
+                ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+
             if (buf[0] != '\0')
             {
                 img.deviceType = g_scsi_settings.getDevice(target_idx)->deviceType;
@@ -1277,6 +1344,16 @@ void scsiDiskLoadConfig(int target_idx)
 {
     // Then settings specific to target ID
     scsiDiskSetConfig(target_idx);
+
+    // Apply [SCSIn] on top of the [SCSI<X>] settings that scsiDiskSetConfig loaded,
+    // then immediately sync g_scsi_settings → g_DiskImages so that scsiDiskGetNextImageName
+    // reads the final device type and settings (not the pre-override values).
+    bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id && scsiDiskHasDynamicDirs());
+    if (is_dynamic)
+    {
+        g_scsi_settings.applyDynamicSectionOverrides(target_idx);
+        scsiDiskSetImageConfig(target_idx);
+    }
 
     // Check if we have image specified by name
     char filename[MAX_FILE_PATH];

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -225,6 +225,18 @@ int8_t scsiParseId(const char scsi_id_text);
 // Encode ID as char
 char scsiEncodeID(const uint8_t scsi_id);
 
+// Store the SCSI ID read at boot (-1 = not available).
+// Must be called before readSCSIDeviceConfig().
+void scsiDiskSetDynamicId(int8_t id);
+
+// Return the stored dynamic SCSI ID (-1 if not set).
+int8_t scsiDiskGetDynamicId();
+
+// Return true if any 'n'-prefixed device directory (HDn, CDn, TPn, …) exists on the SD card.
+// Used to decide whether to query the SCA hardware for a dynamic SCSI ID before
+// readSCSIDeviceConfig() runs.
+bool scsiDiskHasDynamicDirs();
+
 // Begin writing to prefetch buffer.
 // If the buffer is not available, returns NULL.
 // Otherwise returns pointer to which caller can write up to maxSectors sectors.

--- a/src/ZuluSCSI_sca_hw_config.h
+++ b/src/ZuluSCSI_sca_hw_config.h
@@ -29,7 +29,7 @@
 #pragma once
 #include <stdint.h>
 
-#ifdef ZULUSCSI_WIDE
+#ifdef DYNAMIC_SCSI_ID
 
 // Return whether the ZuluSCSI is using an SCA connector
 bool zuluscsi_is_sca();
@@ -54,4 +54,4 @@ bool zululscsi_sca_hw_remote_start();
 
 
 
-#endif // ZULUSCSI_WIDE
+#endif // DYNAMIC_SCSI_ID

--- a/src/ZuluSCSI_sca_hw_config.h
+++ b/src/ZuluSCSI_sca_hw_config.h
@@ -1,0 +1,57 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
+ *
+ * This file is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+// Interface for SCA option connector peripherals (ZuluSCSI Wide only).
+//
+
+// Call this once after platform_late_init() and before readSCSIDeviceConfig().
+// The returned ID maps to the [SCSIn] section in zuluscsi.ini and to image
+// directories/files named with the prefix character 'n' (e.g., HDn/, CDn.img).
+
+#pragma once
+#include <stdint.h>
+
+#ifdef ZULUSCSI_WIDE
+
+// Return whether the ZuluSCSI is using an SCA connector
+bool zuluscsi_is_sca();
+
+// Read the latest SCA configuration signals on the bus
+bool zuluscsi_sca_hw_update();
+
+// Get the SCSI ID from the last zuluscsi_sca_hw_update()
+// Returns 0–15 on success, or -1 if the expander is absent or the read fails.
+int8_t zuluscsi_sca_hw_scsi_id();
+
+// Get wether the last zuluscsi_sca_hw_update() data is valid
+bool zuluscsi_sca_hw_valid();
+
+// Get the delayed start status from the last zuluscsi_sca_hw_update()
+// Should check zuluscsi_sca_hw_valid before reading the value
+bool zuluscsi_sca_hw_delayed_start();
+
+// Get the remote start status from the last zuluscsi_sca_hw_update()
+// Should check zuluscsi_sca_hw_valid() before reading the value
+bool zululscsi_sca_hw_remote_start();
+
+
+
+#endif // ZULUSCSI_WIDE

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -901,6 +901,24 @@ scsi_device_settings_t* ZuluSCSISettings::initDevice(uint8_t scsiId, S2S_CFG_TYP
     return &cfg;
 }
 
+scsi_device_settings_t* ZuluSCSISettings::applyDynamicSectionOverrides(uint8_t scsiId, bool disable_logging)
+{
+    scsi_device_settings_t& cfg = m_dev[scsiId];
+    bool log_settings = false;
+    if (!disable_logging)
+    {
+        log_settings = ini_getbool("SCSI", "LogIniSettings", true, CONFIGFILE);
+        if (log_settings)
+            logmsg("-- [" DYNAMIC_SCSI_INI_SECTION "] settings in ", CONFIGFILE, ":");
+    }
+    readIniSCSIDeviceSetting(cfg, DYNAMIC_SCSI_INI_SECTION, log_settings);
+    formatDriveInfoField(cfg.vendor, sizeof(cfg.vendor), cfg.rightAlignStrings);
+    formatDriveInfoField(cfg.prodId, sizeof(cfg.prodId), cfg.rightAlignStrings);
+    formatDriveInfoField(cfg.revision, sizeof(cfg.revision), cfg.rightAlignStrings);
+    formatDriveInfoField(cfg.serial, sizeof(cfg.serial), true);
+    return &cfg;
+}
+
 scsi_system_settings_t *ZuluSCSISettings::getSystem()
 {
     return &m_sys;

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -225,6 +225,12 @@ public:
     // see if any SCSI devices have an eject button set
     const bool isEjectButtonSet();
 
+    // Apply [SCSIn] settings as overrides on top of already-loaded [SCSI<X>] settings
+    // for the device whose ID was read from the GPIO expander.
+    // Only modifies fields that are explicitly present in the [SCSIn] section.
+    // Pass disable_logging=true to suppress the section-header and per-key log lines.
+    scsi_device_settings_t* applyDynamicSectionOverrides(uint8_t scsiId, bool disable_logging = false);
+
 protected:
     // Set default drive vendor / product info after the image file
     // is loaded and the device type is known.

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -180,6 +180,14 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
         size_t len = AS400VendorInquiryLen;
         if (len > MAX_SPD_SIZE) len = MAX_SPD_SIZE;
         memcpy(g_custom_spd[scsiId].data, AS400VendorInquiry, len);
+        // Patch vendor (bytes 8-15) and product ID (bytes 16-31) from device
+        // settings so that [SCSI<X>] and [SCSIn] Vendor/Product overrides take
+        // effect even when the AS/400 default SPD is active.
+        const scsi_device_settings_t *devCfg = g_scsi_settings.getDevice(scsiId);
+        if (len >= 16)
+            memcpy(g_custom_spd[scsiId].data + 8, devCfg->vendor, sizeof(devCfg->vendor));
+        if (len >= 32)
+            memcpy(g_custom_spd[scsiId].data + 16, devCfg->prodId, sizeof(devCfg->prodId));
         if (len >= 46)
             injectSerial(g_custom_spd[scsiId].data, 38, scsiId);
         if (len >= 121)

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -46,6 +46,9 @@
 # Wide bus support
 # MaxBusWidth = 0 # 0: 8-bit, 1: 16-bit. Defaults to maximum supported.
 
+# SCA settings
+# DynamicScsiId = -1 # 0-15: Override the dynamically assigned SCSI ID, -1 to disable override
+
 # ROM settings
 #DisableROMDrive = 1 # Disable the ROM drive if it has been loaded to flash
 #ROMDriveSCSIID = 7 # Override ROM drive's SCSI ID
@@ -171,6 +174,10 @@
 # If IMG0..IMG9 are specified, they are cycled after each eject command.
 #IMG0 = FirstCD.iso
 #IMG1 = SecondCD.bin
+
+#[SCSIn]
+# settings under this section apply to dynamically assigned SCSI id images
+# like "hdn - my sca image.bin" for Wide SCA boards
 
 #[SCSI4]
 #Type = 5


### PR DESCRIPTION
If an image is prefixed with SCSI ID 'n' like `HDn - my sca image.bin` then the SCSI ID will be dynamically assigned via pins on the SCA connector.

The device setting in zuluscsi.ini will be first be set by the `[SCSIx]` section where x is the hard coded SCSI ID in hex. Then all device setting under the section `[SCSIn]` where n is the letter 'n' will be used and will override those set in `[SCSIx]`. `[SCSIx]` does not need to be defined for `[SCSIn]` to work.

When an device is using a SCSI ID `n` and is an Wide SCA board the ZuluSCSI will indefinitely loop until the MATE 1 pin on the SCA connector is grounded by the host machine. It will then read the SCA SCSI ID pins and the rest of the initialization will continue.

The dynamic SCSI ID can be overridden by setting `DynamicScsiId = X` where X is the SCSI ID in base 10 you want the the HDn device to be. This will skip the indefinite polling in loop.

Another way to avoid the polling loop with an Wide SCA board is to simply not set a SCSI ID 'n' image.