### PR TITLE
Allow ImgXX to be up to 99 entries in zuluscsi.ini

### DIFF
--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -27,7 +27,7 @@
 #include <ZuluSCSI_platform_config.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2026.06.13"
+#define FW_VER_NUM      "2026.06.16"
 #define FW_VER_SUFFIX   "devel"
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
@@ -88,7 +88,7 @@
 #endif
 
 // Image definition options
-#define IMAGE_INDEX_MAX 9               // Maximum number of 'IMG0' style statements parsed
+#define IMAGE_INDEX_MAX 99              // Maximum number of 'IMG0' - `IMG99` style statements parsed
 
 // SCSI config
 #define NUM_SCSILUN 1          // Maximum number of LUNs supported     (Currently has to be 1)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1224,15 +1224,17 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
                     strcpy(dirname, "ZP0");
                     break;
                 default:
-                    dbgmsg("No matching device type for default directory found");
+                    logmsg("No matching device type for default directory found");
                     return 0;
             }
 #ifdef DYNAMIC_SCSI_ID
             dirname[2] = is_dynamic ? DYNAMIC_SCSI_ID_CHAR : scsiEncodeID(target_idx);
+#else
+            dirname[2] = scsiEncodeID(target_idx);
 #endif
             if (!SD.exists(dirname))
             {
-                dbgmsg("Default image directory, ", dirname, " does not exist");
+                logmsg("Default image directory, ", dirname, " does not exist");
                 return 0;
             }
         }
@@ -1319,8 +1321,17 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
                 img.image_index = 0;
             }
 
-            char key[5] = "IMG0";
-            key[3] = '0' + img.image_index;
+            char key[6] = "IMG00";
+
+            if (img.image_index < 10)
+            {
+                key[4] = '0' + img.image_index;
+            }
+            else
+            {
+                key[3] = '0' + img.image_index / 10;
+                key[4] = '0' + img.image_index % 10;
+            }
 
             // For the dynamic target, check [SCSIn] IMG keys first, then [SCSI<X>].
             int ret = 0;


### PR DESCRIPTION
For issue #868 via a patch from @TuscanRaider

Move from 0-9 IMGx to 0-99 IMGx entires under a SCSI ID section of zuluscsi.ini.

Fix an issue with default directories not being processed anymore due to an ifdef for DYNAMIC_SCSI_ID without an else clause handling normal default directories' SCSI IDs.