### PR TITLE
Add ZuluControl-firmware support for a Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Zulu Control Board
 -------------------
 The Zulu Control Board is a small device which plugs into the I2C connector of the ZuluSCSI Blaster (Currently, that is the only supported board)
 It features an OLED screen, a rotary encoder, and two push buttons.
-This allows you to both control and visualise various aspects of the ZuluSCSI.
+This allows you to both control and visualize various aspects of the ZuluSCSI.
 Note: There are no error screens. Error must still be inspected in the log files.
 
 On power up a splash screen will display the current firmware version:
@@ -463,6 +463,26 @@ Control Board Config
 - 4 - Horizontal Scrolling Icons
 - 5 - Vertical Raining Icons
 - 6 - Light speed
+
+
+ZuluControl-firmware
+----------------------
+See [ZuluControl-firmware](https://github.com/rabbitholecomputing/ZuluControl-firmware) for the latest.
+
+This is firmware that runs on a separate wireless board and communicates with the ZuluSCSI over the I2C interface. It provides a simple HTTP webserver that allows controlling images on removable devices.
+
+The basic settings to get the HTTP webserver up and running are the following under the `[WebUI]` section in the `zuluscsi.ini` file.
+```
+[WebUI]
+WiFiSSID = "your_ssid" # SSID for the WIFI network
+WiFiPassword = "your_password" # Password for the WIFI network.
+
+#Optional Static IPv4 Settings - fill in with your network settings
+StaticIP = "192.168.1.42"
+Netmask = "255.255.255.0"
+Gateway = "192.168.1.1"
+```
+Goto the IP with your favorite web browser, and you should be able to control the ZuluSCSI over a web interface.
 
 
 Project structure

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -65,7 +65,10 @@ bool controlIsRemovableDevice(uint8_t scsi_id)
 {
     if (scsi_id >= S2S_MAX_TARGETS) return false;
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
+    // Use img.deviceType rather than S2S_CFG_TARGET_ENABLED: scsiDiskSetImageConfig
+    // always sets deviceType from persisted settings even when scsiDiskOpenHDDImage
+    // fails, leaving scsiId without the ENABLED bit. Zero-initialized (unconfigured)
+    // targets have deviceType=S2S_CFG_FIXED which isRemovableType() rejects.
     return isRemovableType((S2S_CFG_TYPE)img.deviceType);
 }
 
@@ -84,7 +87,6 @@ const char* controlGetDeviceTypeName(uint8_t scsi_id)
 {
     if (scsi_id >= S2S_MAX_TARGETS) return "Unknown";
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return "Inactive";
     switch ((S2S_CFG_TYPE)img.deviceType)
     {
         case S2S_CFG_OPTICAL:     return "CD-ROM";
@@ -104,9 +106,30 @@ bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen)
     if (scsi_id >= S2S_MAX_TARGETS) return false;
 
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
     if (img.ejected || !img.file.isOpen() || img.current_image[0] == '\0')
         return false;
+
+    strncpy(buf, img.current_image, buflen - 1);
+    buf[buflen - 1] = '\0';
+    return true;
+}
+
+bool controlGetMediaStatus(uint8_t scsi_id, char *buf, size_t buflen, bool *ejected_out)
+{
+    if (!buf || buflen == 0) return false;
+    buf[0] = '\0';
+    if (scsi_id >= S2S_MAX_TARGETS) return false;
+
+    image_config_t &img = scsiDiskGetImageConfig(scsi_id);
+    bool has_file = img.file.isOpen() && img.current_image[0] != '\0';
+
+    // Report the actual SCSI ejected state; the image path is always returned
+    // when a file is open so the UI shows the loaded image even during the
+    // transient media-change eject that follows a controlLoadImage call.
+    if (ejected_out)
+        *ejected_out = img.ejected || !has_file;
+
+    if (!has_file) return false;
 
     strncpy(buf, img.current_image, buflen - 1);
     buf[buflen - 1] = '\0';
@@ -120,7 +143,6 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
     if (scsi_id >= S2S_MAX_TARGETS) return false;
 
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
 
     // Explicit ImgDir in zuluscsi.ini takes first priority
     char section[] = "SCSI0";
@@ -179,7 +201,6 @@ bool controlGetImagePrefix(uint8_t scsi_id, char *buf, size_t buflen)
     buf[0] = '\0';
     if (scsi_id >= S2S_MAX_TARGETS) return false;
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
     if (!img.use_prefix) return false;
 
     const char *tp;
@@ -307,7 +328,6 @@ bool controlLoadImage(uint8_t scsi_id, const char *full_path)
 {
     if (scsi_id >= S2S_MAX_TARGETS) return false;
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
     if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
 
     if (full_path == nullptr || full_path[0] == '\0')
@@ -332,7 +352,6 @@ bool controlEjectMedia(uint8_t scsi_id)
 {
     if (scsi_id >= S2S_MAX_TARGETS) return false;
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
     if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
 
     if (img.ejected) return true;
@@ -353,7 +372,6 @@ bool controlInsertMedia(uint8_t scsi_id)
 {
     if (scsi_id >= S2S_MAX_TARGETS) return false;
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
-    if (!(img.scsiId & S2S_CFG_TARGET_ENABLED)) return false;
     if (!isRemovableType((S2S_CFG_TYPE)img.deviceType)) return false;
 
     if (!img.ejected) return true;

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
@@ -44,6 +44,12 @@ const char* controlGetDeviceTypeName(uint8_t scsi_id);
 // Returns false and sets buf[0]='\0' when ejected or device inactive.
 bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen);
 
+// UI-oriented media status: returns true and fills buf with the loaded image
+// path whenever a file is open, including during a SCSI media-change eject
+// (unlike controlGetCurrentImage which returns false when ejected).
+// ejected_out receives the actual SCSI ejected flag.
+bool controlGetMediaStatus(uint8_t scsi_id, char *buf, size_t buflen, bool *ejected_out);
+
 // Get the directory that is searched for available images for a device.
 // Returns true and writes the directory path into buf on success.
 // For prefix-mode devices (root-directory layout) buf receives "/".

--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -479,6 +479,7 @@ bool initScreenHardware()
         return false;
     }
     g_displayEnabled = true;
+    g_i2c_claimed = true;
         // Clear the buffer
     g_display->clearDisplay();
     g_display->display();

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
@@ -1,0 +1,646 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// ZuluSCSI WebUI I2C server - state machine and message handlers.
+// Mirrors the media management capabilities of the USB serial console.
+//
+// zuluscsi.ini [WebUI] section keys:
+//   WiFiSSID       = "my_wifi_ssid"
+//   WiFiPassword   = "my_wifi_password"
+//   StaticIP   = "192.168.1.100"
+//   Netmask    = "255.255.255.0"
+//   Gateway    = "192.168.1.1"
+#ifdef ZULUCONTROL_FIRMWARE
+
+#include "ZuluSCSI_WebUI.h"
+#include "ZuluSCSI_WebUI_I2CServer.h"
+#include <ZuluSCSI_log.h>
+#include <ZuluSCSI_control_api.h>
+#include <minIni.h>
+#include <Arduino.h>
+#include <string.h>
+#include <stdio.h>
+
+#define CONFIGFILE "zuluscsi.ini"
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+enum class WebUIState
+{
+    Disabled,       // No SSID configured - WebUI off
+    Searching,      // Polling for WebUI board presence
+    SendReset,      // Sending RESET to flush WebUI board state
+    SendAPIVer,     // Sending server API version
+    WaitAPIVer,     // Waiting for WebUI board to reply with its API version
+    SendSSID,       // Sending WiFi SSID
+    SendPassword,   // Sending WiFi password
+    SendStaticIP,   // Sending optional static IP info
+    SendConnect,    // Sending WIFI_CONNECT
+    WaitIP,         // Waiting for WebUI board to send its IP address
+    Running,        // Normal operation
+};
+
+static WebUIState  g_state       = WebUIState::Disabled;
+static bool        g_enabled     = false;
+static bool        g_subscribed  = false;  // I2C WebUI client subscribed to status updates
+static bool        g_sd_ready    = false;  // SD card currently present and ready
+
+static char        g_ssid[64]    = {0};
+static char        g_pass[64]    = {0};
+static char        g_static_ip[20] = {0};
+static char        g_netmask[20]   = {0};
+static char        g_gateway[20]   = {0};
+static bool        g_has_static_ip = false;
+
+static uint32_t    g_last_poll_ms    = 0;
+static uint32_t    g_last_status_ms  = 0;
+static uint32_t    g_wait_start_ms   = 0;
+
+#define POLL_INTERVAL_MS   150
+#define STATUS_INTERVAL_MS 3000
+#define WAIT_TIMEOUT_MS    5000
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static uint32_t ms_now()
+{
+    return (uint32_t)millis();
+}
+
+static bool elapsed(uint32_t start, uint32_t period)
+{
+    return (uint32_t)(ms_now() - start) >= period;
+}
+
+// Write a compact JSON object for one image into buf (max buflen bytes).
+// Returns number of bytes written (not including null terminator).
+static int image_json(char *buf, size_t buflen, int idx, const char *filename,
+                      const char *full_path, uint64_t size, bool is_dir)
+{
+    return snprintf(buf, buflen,
+        "{\"idx\":%d,\"filename\":\"%s\",\"path\":\"%s\",\"size\":%llu,\"isDir\":%s}",
+        idx, filename, full_path, (unsigned long long)size, is_dir ? "true" : "false");
+}
+
+// Build full system-status JSON and send it to the WebUI board.
+static void send_status_json()
+{
+    uint8_t ids[S2S_MAX_TARGETS];
+    int dev_count = controlListRemovableDevices(ids, S2S_MAX_TARGETS);
+
+    char json[480] = {0};
+    int pos = 0;
+    pos += snprintf(json + pos, sizeof(json) - pos, "{\"devices\":[");
+
+    for (int d = 0; d < dev_count && pos < (int)sizeof(json) - 80; d++)
+    {
+        uint8_t id = ids[d];
+        char imgpath[128] = {0};
+        bool is_ejected = true;
+        bool has_image = controlGetMediaStatus(id, imgpath, sizeof(imgpath), &is_ejected);
+        const char *type = controlGetDeviceTypeName(id);
+
+        // Truncate very long image paths to keep JSON within Wire buffer limits
+        char shortname[48] = {0};
+        const char *slash = strrchr(imgpath, '/');
+        strncpy(shortname, slash ? slash + 1 : imgpath, sizeof(shortname) - 1);
+
+        if (d > 0) json[pos++] = ',';
+        pos += snprintf(json + pos, sizeof(json) - pos,
+            "{\"id\":%d,\"type\":\"%s\",\"image\":\"%s\",\"ejected\":%s}",
+            id, type ? type : "Unknown",
+            has_image ? shortname : "",
+            is_ejected ? "true" : "false");
+    }
+    pos += snprintf(json + pos, sizeof(json) - pos, "]}");
+
+    webuiI2CSend(I2C_SERVER_SYSTEM_STATUS_JSON, json);
+}
+
+// Send JSON array of removable devices to WebUI board.
+static void send_device_list_json()
+{
+    uint8_t ids[S2S_MAX_TARGETS];
+    int count = controlListRemovableDevices(ids, S2S_MAX_TARGETS);
+
+    char json[256] = {0};
+    int pos = 0;
+    pos += snprintf(json + pos, sizeof(json) - pos, "[");
+
+    for (int i = 0; i < count; i++)
+    {
+        const char *type = controlGetDeviceTypeName(ids[i]);
+        if (i > 0) json[pos++] = ',';
+        pos += snprintf(json + pos, sizeof(json) - pos,
+            "{\"id\":%d,\"type\":\"%s\"}", ids[i], type ? type : "Unknown");
+    }
+    snprintf(json + pos, sizeof(json) - pos, "]");
+
+    webuiI2CSend(I2C_SERVER_DEVICE_LIST_JSON, json);
+}
+
+// ── Image listing helpers ─────────────────────────────────────────────────────
+
+struct FilenameListCtx
+{
+    uint8_t scsi_id;
+    bool    started;
+    int     count;
+};
+
+static void filename_list_cb(int idx, const char *filename, const char *full_path,
+                              uint64_t size, bool is_dir, void *userdata)
+{
+    FilenameListCtx *ctx = (FilenameListCtx *)userdata;
+
+    if (!ctx->started)
+    {
+        // Signal start of filename cache update
+        uint8_t scsi_hdr[1] = {ctx->scsi_id};
+        webuiI2CSend(I2C_SERVER_UPDATE_FILENAME_CACHE, scsi_hdr, 1);
+        ctx->started = true;
+    }
+
+    // payload: [scsi_id][full_path...] - full_path required by controlLoadImage
+    char payload[256];
+    payload[0] = (char)ctx->scsi_id;
+    strncpy(payload + 1, full_path, sizeof(payload) - 2);
+    payload[sizeof(payload) - 1] = '\0';
+    uint16_t pathlen = (uint16_t)strnlen(full_path, sizeof(payload) - 2);
+    webuiI2CSend(I2C_SERVER_IMAGE_FILENAME, (const uint8_t *)payload,
+                 1 + pathlen);
+    ctx->count++;
+}
+
+struct ImageJsonCtx
+{
+    uint8_t scsi_id;
+    bool    started;
+};
+
+static void image_json_cb(int idx, const char *filename, const char *full_path,
+                           uint64_t size, bool is_dir, void *userdata)
+{
+    ImageJsonCtx *ctx = (ImageJsonCtx *)userdata;
+
+    char jbuf[200];
+    int jlen = image_json(jbuf, sizeof(jbuf) - 1, idx, filename, full_path, size, is_dir);
+    if (jlen <= 0) return;
+
+    // payload: [scsi_id][json...]
+    char payload[210];
+    payload[0] = (char)ctx->scsi_id;
+    memcpy(payload + 1, jbuf, (size_t)jlen);
+    webuiI2CSend(I2C_SERVER_IMAGE_JSON, (const uint8_t *)payload, 1 + (uint16_t)jlen);
+}
+
+static void send_filenames_for_device(uint8_t scsi_id)
+{
+    // Send cache-reset header unconditionally so the I2C WebUI client clears its cache
+    // even when there are zero images (e.g. after SD card removal).
+    uint8_t scsi_hdr[1] = {scsi_id};
+    webuiI2CSend(I2C_SERVER_UPDATE_FILENAME_CACHE, scsi_hdr, 1);
+
+    // started=true: reset already sent above, callback must not send it again
+    FilenameListCtx ctx = {scsi_id, true, 0};
+    controlListImages(scsi_id, filename_list_cb, &ctx);
+
+    // End-of-list sentinel: [scsi_id] with no path bytes
+    uint8_t end_hdr[1] = {scsi_id};
+    webuiI2CSend(I2C_SERVER_IMAGE_FILENAME, end_hdr, 1);
+    dbgmsg("WebUI: sent ", ctx.count, " filenames for SCSI ID ", (int)scsi_id);
+}
+
+static void send_all_filenames()
+{
+    uint8_t ids[S2S_MAX_TARGETS];
+    int count = controlListRemovableDevices(ids, 8);
+    for (int i = 0; i < count; i++)
+    {
+        send_filenames_for_device(ids[i]);
+    }
+}
+
+// ── Message dispatcher (Running state) ───────────────────────────────────────
+
+static void handle_client_message(uint8_t cmd, const uint8_t *payload, uint16_t length)
+{
+    switch (cmd)
+    {
+        case I2C_CLIENT_NOOP:
+            break;
+
+        case I2C_CLIENT_API_VERSION:
+            // WebUI board has reset - restart handshake
+            dbgmsg("WebUI: board sent API version (restart), resetting");
+            g_state = WebUIState::SendReset;
+            g_subscribed = false;
+            break;
+
+        case I2C_CLIENT_SUBSCRIBE_STATUS_JSON:
+            dbgmsg("WebUI: subscribed to status updates");
+            g_subscribed = true;
+            send_status_json();
+            {
+                uint8_t sd_payload[1] = {g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT};
+                webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
+            }
+            send_all_filenames();
+            g_last_status_ms = ms_now();
+            break;
+
+        case I2C_CLIENT_FETCH_DEVICE_LIST:
+            dbgmsg("WebUI: sending device list");
+            send_device_list_json();
+            break;
+
+        case I2C_CLIENT_FETCH_FILENAMES:
+        {
+            uint8_t scsi_id = (length > 0) ? payload[0] : 0;
+            dbgmsg("WebUI: listing filenames for SCSI ID ", (int)scsi_id);
+            send_filenames_for_device(scsi_id);
+            break;
+        }
+
+        case I2C_CLIENT_FETCH_IMAGES_JSON:
+        {
+            uint8_t scsi_id = (length > 0) ? payload[0] : 0;
+            logmsg("WebUI: listing images JSON for SCSI ID ", (int)scsi_id);
+            ImageJsonCtx ctx = {scsi_id, false};
+            controlListImages(scsi_id, image_json_cb, &ctx);
+            // Empty I2C_SERVER_IMAGE_JSON signals end-of-list
+            uint8_t end_hdr[1] = {scsi_id};
+            webuiI2CSend(I2C_SERVER_IMAGE_JSON, end_hdr, 1);
+            break;
+        }
+
+        case I2C_CLIENT_FETCH_ITR_IMAGE:
+        {
+            // Iterator mode: send one image per request.
+            // Reuses image_json_cb but the I2C WebUI client handles iterator state.
+            // For simplicity, send all images and mark done with empty payload.
+            uint8_t scsi_id = (length > 0) ? payload[0] : 0;
+            ImageJsonCtx ctx = {scsi_id, false};
+            controlListImages(scsi_id, image_json_cb, &ctx);
+            uint8_t end_hdr[1] = {scsi_id};
+            webuiI2CSend(I2C_SERVER_IMAGE_JSON, end_hdr, 1);
+            break;
+        }
+
+        case I2C_CLIENT_LOAD_IMAGE:
+        {
+            if (length < 2)
+            {
+                logmsg("WebUI: LOAD_IMAGE missing SCSI ID or path");
+                break;
+            }
+            uint8_t scsi_id = payload[0];
+            const char *path = (const char *)(payload + 1);
+            dbgmsg("WebUI: loading image \"", path, "\" on SCSI ID ", (int)scsi_id);
+            if (!controlLoadImage(scsi_id, path))
+            {
+                logmsg("WebUI: controlLoadImage failed for SCSI ID ", (int)scsi_id);
+            }
+            if (g_subscribed) send_status_json();
+            break;
+        }
+
+        case I2C_CLIENT_EJECT_IMAGE:
+        {
+            uint8_t scsi_id = (length > 0) ? payload[0] : 0;
+            dbgmsg("WebUI: ejecting media on SCSI ID ", (int)scsi_id);
+            if (!controlEjectMedia(scsi_id))
+            {
+                logmsg("WebUI: controlEjectMedia failed for SCSI ID ", (int)scsi_id);
+            }
+            if (g_subscribed) send_status_json();
+            break;
+        }
+
+        case I2C_CLIENT_INSERT_MEDIA:
+        {
+            uint8_t scsi_id = (length > 0) ? payload[0] : 0;
+            logmsg("WebUI: inserting media on SCSI ID ", (int)scsi_id);
+            if (!controlInsertMedia(scsi_id))
+            {
+                logmsg("WebUI: controlInsertMedia failed for SCSI ID ", (int)scsi_id);
+            }
+            if (g_subscribed) send_status_json();
+            break;
+        }
+
+        case I2C_CLIENT_FETCH_SSID:
+            webuiI2CSend(I2C_SERVER_SSID, g_ssid);
+            break;
+
+        case I2C_CLIENT_FETCH_SSID_PASS:
+            webuiI2CSend(I2C_SERVER_SSID_PASS, g_pass);
+            break;
+
+        case I2C_CLIENT_IP_ADDRESS:
+        {
+            char ipbuf[32] = {0};
+            if (length > 0 && length < 32)
+            {
+                memcpy(ipbuf, payload, length);
+                ipbuf[length] = '\0';
+            }
+            logmsg("WebUI: IP address: ", ipbuf);
+            webuiI2CSend(I2C_SERVER_IP_ADDRESS_ACK);
+            break;
+        }
+
+        case I2C_CLIENT_LOG_MSG:
+        {
+            if (length > 1)
+            {
+                char prefix = (char)payload[0];
+                const char *msg = (const char *)(payload + 1);
+                if (prefix == 'd')
+                    dbgmsg("WebUI board: ", msg);
+                else
+                    logmsg("WebUI board: ", msg);
+            }
+            break;
+        }
+
+        default:
+            logmsg("WebUI: unhandled client command 0x", (int)cmd);
+            break;
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+void zuluWebUIInit()
+{
+    ini_gets("WebUI", "WiFiSSID",     "", g_ssid,      sizeof(g_ssid),      CONFIGFILE);
+    ini_gets("WebUI", "WiFiPassword", "", g_pass,      sizeof(g_pass),      CONFIGFILE);
+    ini_gets("WebUI", "StaticIP", "", g_static_ip, sizeof(g_static_ip), CONFIGFILE);
+    ini_gets("WebUI", "Netmask",  "", g_netmask,   sizeof(g_netmask),   CONFIGFILE);
+    ini_gets("WebUI", "Gateway",  "", g_gateway,   sizeof(g_gateway),   CONFIGFILE);
+
+    g_has_static_ip = (g_static_ip[0] != '\0');
+
+    if (g_ssid[0] == '\0')
+    {
+        logmsg("WebUI: No SSID configured in [WebUI] section of ", CONFIGFILE, " - disabled");
+        g_state   = WebUIState::Disabled;
+        g_enabled = false;
+        return;
+    }
+
+    logmsg("WebUI: configured for SSID \"", g_ssid, "\"");
+    g_state   = WebUIState::Searching;
+    g_enabled = true;
+    g_last_poll_ms = ms_now();
+}
+
+bool zuluWebUIEnabled()
+{
+    return g_enabled && g_state == WebUIState::Running;
+}
+
+void zuluWebUINotifySDCardReady()
+{
+    g_sd_ready = true;
+    // Send the SD status change whenever the board is reachable, regardless of
+    // WebUI state machine phase.  zuluWebUIInit() resets g_state to Searching
+    // on SD insertion which would otherwise silently drop the push.
+    if (webuiI2CWebUIPresent())
+    {
+        uint8_t sd_payload[1] = {I2C_SERVER_SD_PRESENT};
+        webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
+    }
+    if (g_subscribed && g_state == WebUIState::Running)
+    {
+        dbgmsg("WebUI: SD card ready, pushing filename cache");
+        send_all_filenames();
+    }
+}
+
+void zuluWebUINotifySDCardRemoved()
+{
+    g_sd_ready = false;
+    if (webuiI2CWebUIPresent())
+    {
+        uint8_t sd_payload[1] = {I2C_SERVER_SD_NOT_PRESENT};
+        webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
+    }
+    if (g_subscribed && g_state == WebUIState::Running)
+    {
+        dbgmsg("WebUI: SD card removed, clearing filename cache");
+        send_all_filenames();
+    }
+}
+
+void zuluWebUITask()
+{
+    if (!g_enabled) return;
+    if (!elapsed(g_last_poll_ms, POLL_INTERVAL_MS)) return;
+    g_last_poll_ms = ms_now();
+
+    static uint8_t rx_payload[WEBUI_MAX_MSG_SIZE + 1];
+    uint8_t  rx_cmd    = I2C_CLIENT_NOOP;
+    uint16_t rx_length = 0;
+
+    switch (g_state)
+    {
+        case WebUIState::Searching:
+        {
+            // Probe for WebUI board by attempting a read
+            bool got = webuiI2CReceive(&rx_cmd, rx_payload, &rx_length);
+            if (got || webuiI2CWebUIPresent())
+            {
+                dbgmsg("WebUI: board detected, starting handshake");
+                g_state = WebUIState::SendReset;
+            }
+            break;
+        }
+
+        case WebUIState::SendReset:
+            if (webuiI2CSend(I2C_SERVER_RESET))
+            {
+                dbgmsg("WebUI: sent RESET to board");
+                g_state = WebUIState::SendAPIVer;
+            }
+            break;
+
+        case WebUIState::SendAPIVer:
+            if (webuiI2CSend(I2C_SERVER_API_VERSION, WEBUI_I2C_API_VERSION " ZuluSCSI"))
+            {
+                dbgmsg("WebUI: sent server API version ", WEBUI_I2C_API_VERSION " ZuluSCSI");
+                g_wait_start_ms = ms_now();
+                g_state = WebUIState::WaitAPIVer;
+            }
+            break;
+
+        case WebUIState::WaitAPIVer:
+        {
+            bool got = webuiI2CReceive(&rx_cmd, rx_payload, &rx_length);
+            if (got && rx_cmd == I2C_CLIENT_API_VERSION)
+            {
+                const char *client_ver = (rx_length > 0) ? (const char *)rx_payload : "(unknown)";
+                // Using versioning scheme "x.y.z" match I2C client and ZuluSCSI major version "x"
+                bool major_version_match = false;
+                if (client_ver[0] != '\0')
+                {
+                    unsigned long local_major_version;
+                    char* period_location = strchr(client_ver, '.');
+                    if (period_location != NULL)
+                    {
+                        std::string remoteVersionString = client_ver;
+                        unsigned long remoteMajorVersion = strtoul(client_ver, &period_location, 10);
+                        period_location = strchr(WEBUI_I2C_API_VERSION, '.');
+                        if (period_location != NULL)
+                        {
+                            unsigned long local_major_version = strtoul(WEBUI_I2C_API_VERSION, &period_location, 10);
+                            if (local_major_version > 0 && local_major_version == remoteMajorVersion)
+                            {
+                                major_version_match = true;
+                            }
+                        }
+                    }
+                }
+                if (major_version_match)
+                {
+                    if (strcasecmp(client_ver, WEBUI_I2C_API_VERSION) == 0)
+                    {
+                        logmsg("WebUI: I2C Client and ZuluSCSI API version are an exact match: ", WEBUI_I2C_API_VERSION);
+                    }
+                    else
+                    {
+                        logmsg("WebUI: I2C Client API version: ", client_ver, " ZuluSCSI API version: ", WEBUI_I2C_API_VERSION, " major version match, consider updating to latest version of firmware");
+                    }
+                }
+                else 
+                {
+                    logmsg("WebUI: I2C Client API version: ", client_ver, " and ZuluSCSI API version ", WEBUI_I2C_API_VERSION, " have a major version mismatch.");
+                    logmsg("=== Please upgrade both devices to the latest firmware ===");
+                }
+
+                g_state = WebUIState::SendSSID;
+            }
+            else if (elapsed(g_wait_start_ms, WAIT_TIMEOUT_MS))
+            {
+                logmsg("WebUI: timeout waiting for board API version, retrying");
+                g_state = WebUIState::SendReset;
+            }
+            break;
+            }
+
+        case WebUIState::SendSSID:
+            if (webuiI2CSend(I2C_SERVER_SSID, g_ssid))
+            {
+                logmsg("WebUI: sent SSID: \"", g_ssid, "\"");
+                g_state = WebUIState::SendPassword;
+            }
+            break;
+
+        case WebUIState::SendPassword:
+            if (webuiI2CSend(I2C_SERVER_SSID_PASS, g_pass))
+            {
+                dbgmsg("WebUI: sent WiFi password");
+                g_state = g_has_static_ip ? WebUIState::SendStaticIP : WebUIState::SendConnect;
+            }
+            break;
+
+        case WebUIState::SendStaticIP:
+        {
+            // Send IP, netmask, and gateway with their prefixes
+            char ip_msg[24], nm_msg[24], gw_msg[24];
+            snprintf(ip_msg, sizeof(ip_msg), "ip%s", g_static_ip);
+            snprintf(nm_msg, sizeof(nm_msg), "nm%s", g_netmask);
+            snprintf(gw_msg, sizeof(gw_msg), "gw%s", g_gateway);
+            webuiI2CSend(I2C_SERVER_STATIC_IP, ip_msg);
+            webuiI2CSend(I2C_SERVER_STATIC_IP, nm_msg);
+            webuiI2CSend(I2C_SERVER_STATIC_IP, gw_msg);
+            dbgmsg("WebUI: sent static IP config");
+            g_state = WebUIState::SendConnect;
+            break;
+        }
+
+        case WebUIState::SendConnect:
+            if (webuiI2CSend(I2C_SERVER_WIFI_CONNECT))
+            {
+                dbgmsg("WebUI: sent wifi connect command - I2C client board will now connect");
+                g_wait_start_ms = ms_now();
+                g_state = WebUIState::WaitIP;
+            }
+            break;
+
+        case WebUIState::WaitIP:
+        {
+            // WebUI board is connecting; poll for its IP address message
+            bool got = webuiI2CReceive(&rx_cmd, rx_payload, &rx_length);
+            if (got && rx_cmd == I2C_CLIENT_IP_ADDRESS)
+            {
+                rx_payload[rx_length] = '\0';
+                logmsg("WebUI: board connected, IP: ", (const char *)rx_payload);
+                webuiI2CSend(I2C_SERVER_IP_ADDRESS_ACK);
+                g_state = WebUIState::Running;
+            }
+            else if (got && rx_cmd != I2C_CLIENT_NOOP)
+            {
+                // Handle any other messages during WiFi connect phase
+                handle_client_message(rx_cmd, rx_payload, rx_length);
+            }
+            else if (elapsed(g_wait_start_ms, 60000))
+            {
+                logmsg("WebUI: timeout waiting for board IP address, retrying handshake");
+                g_state = WebUIState::SendReset;
+            }
+            break;
+        }
+
+        case WebUIState::Running:
+        {
+            // Poll for messages from WebUI board
+            bool got = webuiI2CReceive(&rx_cmd, rx_payload, &rx_length);
+            if (!webuiI2CWebUIPresent())
+            {
+                logmsg("WebUI: board lost, searching again");
+                g_state = WebUIState::Searching;
+                g_subscribed = false;
+                break;
+            }
+
+            if (got && rx_cmd != I2C_CLIENT_NOOP)
+            {
+                handle_client_message(rx_cmd, rx_payload, rx_length);
+            }
+
+            // Send periodic status updates when subscribed
+            if (g_subscribed && elapsed(g_last_status_ms, STATUS_INTERVAL_MS))
+            {
+                send_status_json();
+                uint8_t sd_payload[1] = {g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT};
+                webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
+                g_last_status_ms = ms_now();
+            }
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+#endif

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.h
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.h
@@ -1,0 +1,49 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// ZuluSCSI WebUI I2C server - public API.
+// Manages communication with the ZuluSCSI-Remote-Interface I2C WebUI client board.
+// The I2C WebUI client (address 0x45); ZuluSCSI is I2C master.
+// Mirrors the media management API used by the USB serial console.
+
+#pragma once
+#ifdef ZULUCONTROL_FIRMWARE
+
+// Read WiFi credentials from zuluscsi.ini [WebUI] section and check for I2C WebUI client.
+// Call once after the SD card is mounted and SCSI devices are configured.
+void zuluWebUIInit();
+
+// Poll the WebUI I2C interface. Non-blocking when no I2C WebUI client present.
+// Call from platform_poll() or the main SCSI loop.
+void zuluWebUITask();
+
+// Returns true if the WebUI I2C server is active (I2C WebUI client detected and running).
+bool zuluWebUIEnabled();
+
+// Notify the WebUI that the SD card is ready (boot init or hot-swap reinit).
+// If the I2C WebUI client is connected and subscribed, pushes the full filename cache now.
+// If the I2C WebUI client is not yet subscribed, the cache is pushed when it subscribes.
+void zuluWebUINotifySDCardReady();
+
+// Notify the WebUI that the SD card has been removed.
+// Pushes an empty filename list for each device so the I2C WebUI client clears its cache.
+void zuluWebUINotifySDCardRemoved();
+#endif

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI_I2CServer.cpp
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI_I2CServer.cpp
@@ -1,0 +1,168 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// Low-level I2C master send/receive for ZuluSCSI WebUI.
+// Uses the same TwoWire (g_wire) instance as the ZuluSCSI_UI_RP2MCU library.
+#ifdef ZULUCONTROL_FIRMWARE
+
+#include "ZuluSCSI_WebUI_I2CServer.h"
+#include <Wire.h>
+#include <ZuluSCSI_log.h>
+#include <string.h>
+
+// Shared with ZuluSCSI_UI_RP2MCU (control.cpp defines it on i2c1 + GPIO_I2C_SDA/SCL)
+extern TwoWire g_wire;
+
+// Defined in ZuluSCSI_platform.cpp; set true when I2C bus is claimed by WebUI client
+extern bool g_i2c_claimed;
+
+static bool g_webui_present = false;
+
+bool webuiI2CWebUIPresent()
+{
+    return g_webui_present;
+}
+
+void webuiI2CDetectClient()
+{
+
+    g_wire.setClock(PLATFORM_I2C_CLK_SPEED);
+    g_wire.begin();
+
+    g_wire.beginTransmission(WEBUI_I2C_SLAVE_ADDR);
+    if (g_wire.endTransmission() == 0)
+    {
+        g_i2c_claimed = true;
+        logmsg("WebUI I2C: client detected at ", (uint8_t)WEBUI_I2C_SLAVE_ADDR, ", I2C bus claimed");
+    }
+    else
+    {
+        if (!g_i2c_claimed)
+        {
+            g_wire.end();
+        }
+        dbgmsg("WebUI I2C: client not detected");
+    }
+}
+
+bool webuiI2CSend(uint8_t command, const uint8_t *payload, uint16_t length)
+{
+    if (length > WEBUI_MAX_MSG_SIZE)
+    {
+        logmsg("WebUI I2C: send truncated from ", (int)length, " to ", WEBUI_MAX_MSG_SIZE);
+        length = WEBUI_MAX_MSG_SIZE;
+    }
+
+    g_wire.beginTransmission(WEBUI_I2C_SLAVE_ADDR);
+    g_wire.write(command);
+    g_wire.write((uint8_t)(length >> 8));
+    g_wire.write((uint8_t)(length & 0xFF));
+    if (length > 0 && payload != nullptr)
+    {
+        g_wire.write(payload, (size_t)length);
+    }
+    uint8_t result = g_wire.endTransmission();
+    if (result != 0)
+    {
+        g_webui_present = false;
+        return false;
+    }
+    g_webui_present = true;
+    return true;
+}
+
+bool webuiI2CSend(uint8_t command, const char *str)
+{
+    uint16_t len = str ? (uint16_t)strlen(str) : 0;
+    return webuiI2CSend(command, (const uint8_t *)str, len);
+}
+
+bool webuiI2CReceive(uint8_t *cmd_out, uint8_t *payload_out, uint16_t *length_out)
+{
+    *cmd_out = I2C_CLIENT_NOOP;
+    *length_out = 0;
+    if (payload_out) payload_out[0] = '\0';
+
+    // Read 3-byte header: [command][length_hi][length_lo]
+    uint8_t got = g_wire.requestFrom((uint8_t)WEBUI_I2C_SLAVE_ADDR, (uint8_t)3);
+    if (got < 3)
+    {
+        // I2C WebUI client not present or not responding
+        g_webui_present = (got > 0);
+        return false;
+    }
+    g_webui_present = true;
+
+    *cmd_out = g_wire.read();
+    uint8_t len_hi = g_wire.read();
+    uint8_t len_lo = g_wire.read();
+    *length_out = ((uint16_t)len_hi << 8) | len_lo;
+
+    if (*cmd_out == I2C_CLIENT_NOOP)
+    {
+        *length_out = 0;
+        return true;
+    }
+
+    if (*length_out == 0)
+    {
+        return true;
+    }
+
+    if (*length_out > WEBUI_MAX_MSG_SIZE)
+    {
+        logmsg("WebUI I2C: received oversized message length ", (int)*length_out, ", ignoring");
+        *length_out = 0;
+        *cmd_out = I2C_CLIENT_NOOP;
+        return false;
+    }
+
+    // Read payload in 8-byte chunks to match ZuluControl's BUFFER_LENGTH burst size.
+    // ZuluControl's I2C_SLAVE_REQUEST handler sends at most 8 bytes per call and
+    // deletes the outgoing packet once the final ≤8-byte burst is written. If the
+    // master reads a larger chunk that spans that final burst boundary, ZuluControl
+    // writes and deletes the packet while the master only reads part of it, losing
+    // the remaining bytes to a NACK. Using 8-byte reads here keeps each master read
+    // aligned to exactly one ZuluControl burst, preventing that off-by-one loss.
+    uint16_t remaining = *length_out;
+    uint8_t *ptr = payload_out ? payload_out : nullptr;
+
+    while (remaining > 0)
+    {
+        uint8_t chunk = (remaining > 8) ? 8 : (uint8_t)remaining;
+        uint8_t rx = g_wire.requestFrom((uint8_t)WEBUI_I2C_SLAVE_ADDR, chunk);
+        if (rx < chunk)
+        {
+            logmsg("WebUI I2C: short payload read (", (int)rx, " of ", (int)chunk, ")");
+            break;
+        }
+        for (uint8_t i = 0; i < rx; i++)
+        {
+            uint8_t b = g_wire.available() ? g_wire.read() : 0;
+            if (ptr) *ptr++ = b;
+        }
+        remaining -= rx;
+    }
+
+    if (payload_out) payload_out[*length_out] = '\0';
+    return true;
+}
+#endif

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI_I2CServer.h
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI_I2CServer.h
@@ -1,0 +1,99 @@
+/**
+ * ZuluSCSI™ - Copyright (c) 2026 Rabbit Hole Computing™
+ *
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+
+// I2C protocol constants and low-level transceiver for ZuluSCSI WebUI.
+// ZuluSCSI main MCU is I2C master; WebUI board running ZuluSCSI-Remote-Interface
+// is I2C slave at address 0x45.
+//
+// Packet format (both directions):
+//   [command:1] [length_hi:1] [length_lo:1] [payload:length]
+// Empty payload: length = 0x0000.
+
+#pragma once
+#ifdef ZULUCONTROL_FIRMWARE
+
+#include <stdint.h>
+#include <stddef.h>
+
+// I2C slave address of the WebUI board
+#define WEBUI_I2C_SLAVE_ADDR     0x45
+
+// Maximum payload length accepted on the receive path
+#define WEBUI_MAX_MSG_SIZE       512
+
+// Protocol version string - must match ZuluSCSI_WebUI_I2CClient.h
+#define WEBUI_I2C_API_VERSION    "4.0.0"
+
+// ── Server → client commands (ZuluSCSI sends to WebUI board) ────────────────
+#define I2C_SERVER_API_VERSION            0x01  // API version string
+#define I2C_SERVER_WIFI_CONNECT           0x02  // Tell I2C WebUI client to connect to WiFi
+#define I2C_SERVER_UPDATE_FILENAME_CACHE  0x08  // Announce start of filename list
+#define I2C_SERVER_IMAGE_FILENAME         0x09  // One filename; payload[0]=scsi_id, [1..]=name; empty=done
+#define I2C_SERVER_SYSTEM_STATUS_JSON     0x0A  // System status as JSON object
+#define I2C_SERVER_IMAGE_JSON             0x0B  // One image as JSON object; payload[0]=scsi_id, [1..]=json
+#define I2C_SERVER_SSID                   0x0D  // WiFi SSID string
+#define I2C_SERVER_SSID_PASS              0x0E  // WiFi password string
+#define I2C_SERVER_RESET                  0x0F  // Reset client state
+#define I2C_SERVER_STATIC_IP              0x10  // Static IP prefixed with "ip"/"nm"/"gw"
+#define I2C_SERVER_IP_ADDRESS_ACK         0x11  // Acknowledge I2C WebUI client IP address
+#define I2C_SERVER_DEVICE_LIST_JSON       0x12  // JSON array of removable device descriptors
+#define I2C_SERVER_SD_STATUS_CHANGE       0x13  // SD card presence changed; payload[0] = 0x00 not present, 0x01 present
+
+#define I2C_SERVER_SD_NOT_PRESENT 0x00
+#define I2C_SERVER_SD_PRESENT     0x01
+
+// ── Client → server commands (WebUI board sends to ZuluSCSI) ────────────────
+#define I2C_CLIENT_NOOP                   0x00  // No operation (slave queue empty)
+#define I2C_CLIENT_API_VERSION            0x01  // I2C WebUI client API version string
+#define I2C_CLIENT_FETCH_FILENAMES        0x09  // Request filename list; payload[0]=scsi_id
+#define I2C_CLIENT_SUBSCRIBE_STATUS_JSON  0x0A  // Subscribe to periodic status updates
+#define I2C_CLIENT_LOAD_IMAGE             0x0B  // Mount image; payload[0]=scsi_id, [1..]=full_path
+#define I2C_CLIENT_EJECT_IMAGE            0x0C  // Eject media; payload[0]=scsi_id
+#define I2C_CLIENT_FETCH_IMAGES_JSON      0x0D  // Request all image JSON; payload[0]=scsi_id
+#define I2C_CLIENT_FETCH_SSID             0x0E  // Request WiFi SSID
+#define I2C_CLIENT_FETCH_SSID_PASS        0x0F  // Request WiFi password
+#define I2C_CLIENT_FETCH_ITR_IMAGE        0x10  // Request next image (iterator); payload[0]=scsi_id
+#define I2C_CLIENT_IP_ADDRESS             0x11  // I2C WebUI client reports its IP address
+#define I2C_CLIENT_LOG_MSG                0x12  // Log message from I2C WebUI client ('n'/'d' prefix)
+#define I2C_CLIENT_FETCH_DEVICE_LIST      0x13  // Request list of removable SCSI devices
+#define I2C_CLIENT_INSERT_MEDIA           0x14  // Close tray / insert media; payload[0]=scsi_id
+
+// ── Low-level I2C transceiver ────────────────────────────────────────────────
+
+// Send a command with optional payload to the WebUI slave.
+// Returns true on successful ACK.
+bool webuiI2CSend(uint8_t command, const uint8_t *payload = nullptr, uint16_t length = 0);
+
+// Convenience overload for string payloads.
+bool webuiI2CSend(uint8_t command, const char *str);
+
+// Poll the WebUI slave for a queued message.
+// Returns true if a message was received; cmd_out/payload_out/length_out are filled.
+// payload_out must point to at least WEBUI_MAX_MSG_SIZE+1 bytes.
+// Returns false if the slave is absent (NAK) or sent NOOP.
+bool webuiI2CReceive(uint8_t *cmd_out, uint8_t *payload_out, uint16_t *length_out);
+
+// Returns true if the WebUI board answered the last receive attempt without error.
+bool webuiI2CWebUIPresent();
+
+// Probe for the WebUI I2C client; sets g_i2c_claimed if the slave ACKs.
+void webuiI2CDetectClient();
+#endif

--- a/lib/ZuluSCSI_WebUI_RP2MCU/library.json
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/library.json
@@ -1,0 +1,8 @@
+{
+    "name": "ZuluSCSI_WebUI_RP2MCU",
+    "version": "1.0.0",
+    "description": "ZuluSCSI WebUI I2C server - manages the I2C WebUI client remote interface board",
+    "keywords": ["zuluscsi", "webui", "i2c"],
+    "frameworks": "arduino",
+    "platforms": "raspberrypi"
+}

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
@@ -383,7 +383,7 @@ bool audio_is_playing(uint8_t id) {
 
 void audio_setup() {
 #ifdef CONTROL_BOARD
-    if (!g_scsi_settings.getSystem()->enableCDAudio || g_controlBoardEnabled || g_displayEnabled)
+    if (!g_scsi_settings.getSystem()->enableCDAudio || g_i2c_claimed)
 #else
     if (!g_scsi_settings.getSystem()->enableCDAudio)
 #endif

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -43,6 +43,10 @@
 #include "custom_timings.h"
 #include <ZuluSCSI_settings.h>
 #include "ZuluSCSI_usb_console_media.h"
+#ifdef ZULUCONTROL_FIRMWARE 
+#include <ZuluSCSI_WebUI.h>
+#include <ZuluSCSI_WebUI_I2CServer.h>
+#endif
 
 #ifdef ZULUSCSI_MCU_RP23XX
 # include <hardware/structs/scb.h>
@@ -97,7 +101,7 @@ static uint8_t g_console_buttons = 0;
 static uint8_t g_enabled_eject_buttons = 0;
 static uint8_t g_enabled_cow_buttons = 0;
 static uint8_t g_cow_button_state = 0;
-
+bool g_i2c_claimed = false;
 #ifdef ZULUSCSI_WIDE
 static bool g_is_sca = false;
 #endif
@@ -674,7 +678,9 @@ void platform_late_init()
     multicore_launch_core1(core1_handler);
 
     initUIDisplay();
-
+#ifdef ZULUCONTROL_FIRMWARE
+    webuiI2CDetectClient();
+#endif
     if (!g_scsi_initiator)
     {
         // Act as SCSI device / target
@@ -1433,6 +1439,11 @@ void platform_poll()
     // This does nothing if the sniffer is not enabled
     platform_sniffer_poll();
 #endif
+
+#ifdef ZULUCONTROL_FIRMWARE
+    if (scsiDev.phase == BUS_FREE)
+        zuluWebUITask();
+#endif
 }
 
 void platform_reset_mcu(uint32_t reset_in_ms)
@@ -1484,7 +1495,7 @@ uint8_t platform_get_buttons()
     // EJECT_BTN = 1
     if (!gpio_get(GPIO_EJECT_BTN)) buttons |= 1;
 #elif defined(GPIO_I2C_SDA)
-    if (!g_displayEnabled)
+    if (!g_i2c_claimed)
     {
             if (!init_buttons)
             {

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -71,7 +71,7 @@ extern "C" {
 
 /* These are used in debug output and default SCSI strings */
 extern const char *g_platform_name;
-
+extern bool g_i2c_claimed;
 // NOTE: The driver supports synchronous speeds higher than 10MB/s, but this
 // has not been tested due to lack of fast enough SCSI adapter.
 // #define PLATFORM_MAX_SCSI_SPEED S2S_CFG_SPEED_SYNC_20

--- a/lib/ZuluSCSI_platform_RP2MCU/library.json
+++ b/lib/ZuluSCSI_platform_RP2MCU/library.json
@@ -9,6 +9,7 @@
     "platforms": "*",
     "dependencies":
     {
-        "CUEParser": "https://github.com/rabbitholecomputing/CUEParser#v2026.03.13"
+        "CUEParser": "https://github.com/rabbitholecomputing/CUEParser#v2026.03.13",
+        "ZuluSCSI_WebUI_RP2MCU": ""
     }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -82,6 +82,7 @@ lib_deps =
     adafruit/Adafruit BusIO@^1.17.1
     ZuluSCSI_UI_RP2MCU
     ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
 debug_build_flags =
     ${env:ZuluSCSI_RP2MCU.debug_build_flags}
     	; The values can be adjusted down to get a debug build to fit in to SRAM
@@ -95,6 +96,7 @@ build_flags =
     -DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
     -DLOGBUFSIZE=8192
+    -DZULUCONTROL_FIRMWARE
 
 ; Variant of RP2040 platform, based on Raspberry Pico board and a carrier PCB
 ; Part of the ZuluSCSI_RP2040 platform, but with different pins.
@@ -187,6 +189,7 @@ lib_deps =
     adafruit/Adafruit BusIO@^1.17.1
     ZuluSCSI_UI_RP2MCU
     ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_BLASTER
@@ -204,6 +207,7 @@ build_flags =
 ;    -Wl,-Map="${platformio.build_dir}/${this.__env__}/firmware.map"
 	-DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
+    -DZULUCONTROL_FIRMWARE
 
 [env:ZuluSCSI_Pico_2_DaynaPORT]
 extends = env:ZuluSCSI_RP2MCU
@@ -241,6 +245,7 @@ lib_deps =
     adafruit/Adafruit BusIO@^1.17.1
     ZuluSCSI_UI_RP2MCU
     ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
 build_flags =
     ${env:ZuluSCSI_RP2MCU.build_flags}
     -DZULUSCSI_WIDE
@@ -253,6 +258,7 @@ build_flags =
     -DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
     -DDYNAMIC_SCSI_ID
+    -DZULUCONTROL_FIRMWARE
 
 ; Firmware for ZuluSCSI V1.0/v1.1/v1.2 hardware platforms (GD32-based microcontrollers) 
 ; has been transitioned to Long Term Support state, and is maintained in the LTS/v1.x branch. 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -67,6 +67,7 @@
 #include "ROMDrive.h"
 #include "custom_vendor_inquiry.h"
 #include "vhd_support.h"
+#include <ZuluSCSI_WebUI.h>
 
 #include "ui.h"
 
@@ -1514,8 +1515,6 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
 
   if (g_sdcard_present)
   {
-
-
     if (SD.clusterCount() == 0)
     {
       logmsg("SD card without filesystem!");
@@ -1584,7 +1583,9 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
   {
     init_eject_button();
   }
-
+#ifdef ZULUCONTROL_FIRMWARE
+  zuluWebUINotifySDCardReady();
+#endif
   blinkStatus(BLINK_STATUS_OK);
 }
 
@@ -1638,7 +1639,14 @@ extern "C" void zuluscsi_setup(void)
     }
   }
 #endif
-    logmsg("Firmware initialization complete!");
+#ifdef ZULUCONTROL_FIRMWARE
+  if (g_sdcard_present && g_i2c_claimed)
+  {
+    zuluWebUIInit();
+  }
+#endif
+
+  logmsg("Firmware initialization complete!");
 }
 
 void control_disk_swap()
@@ -1744,7 +1752,9 @@ extern "C" void zuluscsi_main_loop(void)
         {
           g_sdcard_present = false;
           logmsg("SD card removed, trying to reinit");
-
+#ifdef ZULUCONTROL_FIRMWARE
+          zuluWebUINotifySDCardRemoved();
+#endif
           if (g_displayEnabled)
           {
             sdCardStateChanged(g_sdcard_present, g_romdrive_active);
@@ -1778,6 +1788,9 @@ extern "C" void zuluscsi_main_loop(void)
         {
           sdCardStateChanged(g_sdcard_present, g_romdrive_active);
         }
+#ifdef ZULUCONTROL_FIRMWARE
+        zuluWebUINotifySDCardReady();
+#endif
       }
       else if (!g_romdrive_active)
       {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1229,6 +1229,8 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
             }
 #ifdef DYNAMIC_SCSI_ID
             dirname[2] = is_dynamic ? DYNAMIC_SCSI_ID_CHAR : scsiEncodeID(target_idx);
+#else
+            dirname[2] = scsiEncodeID(target_idx);
 #endif
             if (!SD.exists(dirname))
             {

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -216,3 +216,11 @@
 # If end sector is beyond end of SD card, it will be adjusted automatically.
 # [SCSI5]
 # IMG0 = RAW:0x00000000:0xFFFFFFFF # Whole SD card
+
+[WebUI]
+# WiFiSSID = "your_ssid" # SSID for the WIFI network
+# WiFiPassword = "your_password" # Password for the WIFI network.
+#Static IPv4 Settings - fill in with your network settings
+# StaticIP = "192.168.1.42"
+# Netmask = "255.255.255.0"
+# Gateway = "192.168.1.1"


### PR DESCRIPTION
The ZuluIDE web interface/control firmware now supports ZuluSCSI, and has been renamed ZuluControl-firmware which can be found here: https://github.com/rabbitholecomputing/ZuluControl-firmware

The Web UI requires a separate Pico W or 2W, or equivalent device, to be connected to a ZuluSCSI via the i2c/Qwiic header.

See the [ZuluControl-firmware's README.md ](https://github.com/rabbitholecomputing/ZuluControl-firmware/blob/main/README.md) on details on how to wire a Pico W/2W to a ZuluSCSI Blaster.

The settings to enable the Web UI are the following under the `[WebUI]` section in the `zuluscsi.ini` file.
```
[WebUI]
WiFiSSID = "your_ssid" # SSID for the WIFI network
WiFiPassword = "your_password" # Password for the WIFI network.
 # Optional Static IPv4 Settings, otherwise uses DHCP
StaticIP = "192.168.1.42"
Netmask = "255.255.255.0"
Gateway = "192.168.1.1"
```