### PR TITLE
Fix sniffer DMA conflict and normalize DMA defines

### DIFF
--- a/.github/workflows/analyze_crashlogs.yml
+++ b/.github/workflows/analyze_crashlogs.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install tools
         run: |
           sudo apt-get install binutils-arm-none-eabi

--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: ZuluSCSI
           fetch-depth: "0"

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.cpp
@@ -395,25 +395,25 @@ extern "C"
 {
 void audio_dma_irq() {
     // Using dma irq raw register access, because the 2.1.0 pico-sdk function seem to cause issues
-    if (dma_hw->intr & (1 << SOUND_DMA_CHA)) {
-        dma_hw->ints2 = (1 << SOUND_DMA_CHA);
+    if (dma_hw->intr & (1 << SOUND_DMA_CH_A)) {
+        dma_hw->ints2 = (1 << SOUND_DMA_CH_A);
         sbufst_a = STALE;
         if (audio_stopping) {
-            channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CHA);
+            channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CH_A);
         }
-        dma_channel_configure(SOUND_DMA_CHA,
+        dma_channel_configure(SOUND_DMA_CH_A,
                 &snd_dma_a_cfg,
                 i2s.getPioFIFOAddr(),
                 output_buf_a,
                 out_len_a / 4,
                 false);
-    } else if (dma_hw->intr & (1 << SOUND_DMA_CHB)) {
-        dma_hw->ints2 = (1 <<  SOUND_DMA_CHB);
+    } else if (dma_hw->intr & (1 << SOUND_DMA_CH_B)) {
+        dma_hw->ints2 = (1 <<  SOUND_DMA_CH_B);
         sbufst_b = STALE;
         if (audio_stopping) {
-            channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CHB);
+            channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CH_B);
         }
-        dma_channel_configure(SOUND_DMA_CHB,
+        dma_channel_configure(SOUND_DMA_CH_B,
                 &snd_dma_b_cfg,
                 i2s.getPioFIFOAddr(),
                 output_buf_b,
@@ -443,8 +443,8 @@ void audio_setup() {
     i2s.setBitsPerSample(16);
     i2s.setDivider(g_zuluscsi_timings->audio.clk_div_pio, 0);
     i2s.begin(I2S_PIO_HW, I2S_PIO_SM);
-    dma_channel_claim(SOUND_DMA_CHA);
-	dma_channel_claim(SOUND_DMA_CHB);
+    dma_channel_claim(SOUND_DMA_CH_A);
+	dma_channel_claim(SOUND_DMA_CH_B);
 
     irq_set_exclusive_handler(I2S_DMA_IRQ_NUM, audio_dma_irq);
     irq_set_enabled(I2S_DMA_IRQ_NUM, true);
@@ -463,8 +463,8 @@ void audio_disable()
     if (audio_is_active())
         audio_stop();
     i2s.end();
-    dma_channel_unclaim(SOUND_DMA_CHA);
-    dma_channel_unclaim(SOUND_DMA_CHB);
+    dma_channel_unclaim(SOUND_DMA_CH_A);
+    dma_channel_unclaim(SOUND_DMA_CH_B);
     irq_remove_handler(DMA_IRQ_0, audio_dma_irq);
 }
 
@@ -746,28 +746,28 @@ bool  audio_play_track_index(uint8_t owner,      image_config_t* img,
 // Source-agnostic: used by both CD-DA playback and host PCM streaming.
 static void audio_dma_start_channels()
 {
-    snd_dma_a_cfg = dma_channel_get_default_config(SOUND_DMA_CHA);
+    snd_dma_a_cfg = dma_channel_get_default_config(SOUND_DMA_CH_A);
     channel_config_set_transfer_data_size(&snd_dma_a_cfg, DMA_SIZE_32);
     channel_config_set_dreq(&snd_dma_a_cfg, i2s.getPioDreq());
     channel_config_set_read_increment(&snd_dma_a_cfg, true);
-    channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CHB);
+    channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CH_B);
     channel_config_set_high_priority(&snd_dma_a_cfg, true);
-    dma_channel_configure(SOUND_DMA_CHA, &snd_dma_a_cfg, i2s.getPioFIFOAddr(),
+    dma_channel_configure(SOUND_DMA_CH_A, &snd_dma_a_cfg, i2s.getPioFIFOAddr(),
             output_buf_a, AUDIO_OUT_BUFFER_SIZE, false);
-    hw_set_bits(&dma_hw->inte2, 1 << SOUND_DMA_CHA );
-    dma_irqn_set_channel_enabled(I2S_DMA_IRQ_IDX, SOUND_DMA_CHA, true);
-    snd_dma_b_cfg = dma_channel_get_default_config(SOUND_DMA_CHB);
+    hw_set_bits(&dma_hw->inte2, 1 << SOUND_DMA_CH_A );
+    dma_irqn_set_channel_enabled(I2S_DMA_IRQ_IDX, SOUND_DMA_CH_A, true);
+    snd_dma_b_cfg = dma_channel_get_default_config(SOUND_DMA_CH_B);
     channel_config_set_transfer_data_size(&snd_dma_b_cfg, DMA_SIZE_32);
     channel_config_set_dreq(&snd_dma_b_cfg, i2s.getPioDreq());
     channel_config_set_read_increment(&snd_dma_b_cfg, true);
-    channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CHA);
+    channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CH_A);
     channel_config_set_high_priority(&snd_dma_b_cfg, true);
-    dma_channel_configure(SOUND_DMA_CHB, &snd_dma_b_cfg, i2s.getPioFIFOAddr(),
+    dma_channel_configure(SOUND_DMA_CH_B, &snd_dma_b_cfg, i2s.getPioFIFOAddr(),
             output_buf_b, AUDIO_OUT_BUFFER_SIZE, false);
-    hw_set_bits(&dma_hw->inte2, 1 << SOUND_DMA_CHB );
-    dma_irqn_set_channel_enabled(I2S_DMA_IRQ_IDX, SOUND_DMA_CHB, true);
+    hw_set_bits(&dma_hw->inte2, 1 << SOUND_DMA_CH_B );
+    dma_irqn_set_channel_enabled(I2S_DMA_IRQ_IDX, SOUND_DMA_CH_B, true);
     // ready to go
-    dma_channel_start(SOUND_DMA_CHA);
+    dma_channel_start(SOUND_DMA_CH_A);
 }
 
 static void audio_start_dma()
@@ -913,15 +913,15 @@ void audio_stop(uint8_t id, bool startup_skip) {
     // then indicate that the streams should no longer chain to one another
     // and wait for them to shut down naturally
     audio_stopping = true;
-    while (dma_channel_is_busy(SOUND_DMA_CHA)) tight_loop_contents();
-    while (dma_channel_is_busy(SOUND_DMA_CHB)) tight_loop_contents();
+    while (dma_channel_is_busy(SOUND_DMA_CH_A)) tight_loop_contents();
+    while (dma_channel_is_busy(SOUND_DMA_CH_B)) tight_loop_contents();
     // \todo check if I2S pio is done
     // The way to check is the I2S pio is done would be to check
     // if the fifo is empty and the PIO's program counter is at the first instruction
     // while (spi_is_busy(AUDIO_SPI)) tight_loop_contents();
     audio_stopping = false;
-    dma_channel_abort(SOUND_DMA_CHA);
-    dma_channel_abort(SOUND_DMA_CHB);
+    dma_channel_abort(SOUND_DMA_CH_A);
+    dma_channel_abort(SOUND_DMA_CH_B);
     // idle the subsystem
     audio_last_status[audio_owner] = ASC_COMPLETED;
     audio_paused = false;

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.h
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_i2s.h
@@ -26,8 +26,8 @@
 #define I2S_PIO_SM 0
 
 // audio subsystem DMA channels
-#define SOUND_DMA_CHA 10
-#define SOUND_DMA_CHB 11
+#define SOUND_DMA_CH_A 10
+#define SOUND_DMA_CH_B 11
 
 // size of the two audio sample buffers, in bytes
 // #define AUDIO_BUFFER_SIZE 8192 // reduce memory usage

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.cpp
@@ -346,25 +346,25 @@ static void snd_process_b() {
 /* ------------------------------------------------------------------------ */
 
 void audio_dma_irq() {
-    if (dma_hw->intr & (1 << SOUND_DMA_CHA)) {
-        dma_hw->ints0 = (1 << SOUND_DMA_CHA);
+    if (dma_hw->intr & (1 << SOUND_DMA_CH_A)) {
+        dma_hw->ints0 = (1 << SOUND_DMA_CH_A);
         multicore_fifo_push_blocking((uintptr_t) &snd_process_a);
         if (audio_stopping) {
-            channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CHA);
+            channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CH_A);
         }
-        dma_channel_configure(SOUND_DMA_CHA,
+        dma_channel_configure(SOUND_DMA_CH_A,
                 &snd_dma_a_cfg,
                 &(spi_get_hw(AUDIO_SPI)->dr),
                 wire_buf_a,
                 WIRE_BUFFER_SIZE,
                 false);
-    } else if (dma_hw->intr & (1 << SOUND_DMA_CHB)) {
-        dma_hw->ints0 = (1 << SOUND_DMA_CHB);
+    } else if (dma_hw->intr & (1 << SOUND_DMA_CH_B)) {
+        dma_hw->ints0 = (1 << SOUND_DMA_CH_B);
         multicore_fifo_push_blocking((uintptr_t) &snd_process_b);
         if (audio_stopping) {
-            channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CHB);
+            channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CH_B);
         }
-        dma_channel_configure(SOUND_DMA_CHB,
+        dma_channel_configure(SOUND_DMA_CH_B,
                 &snd_dma_b_cfg,
                 &(spi_get_hw(AUDIO_SPI)->dr),
                 wire_buf_b,
@@ -417,8 +417,8 @@ void audio_setup() {
     spi_get_hw(AUDIO_SPI)->dmacr = SPI_SSPDMACR_TXDMAE_BITS;
     hw_set_bits(&spi_get_hw(AUDIO_SPI)->cr1, SPI_SSPCR1_SSE_BITS);
 
-    dma_channel_claim(SOUND_DMA_CHA);
-	dma_channel_claim(SOUND_DMA_CHB);
+    dma_channel_claim(SOUND_DMA_CH_A);
+	dma_channel_claim(SOUND_DMA_CH_B);
 
 #ifdef AUDIO_DMA_IRQ_NUM
     irq_set_exclusive_handler(AUDIO_DMA_IRQ_NUM, audio_dma_irq);
@@ -489,28 +489,28 @@ static void audio_start_dma()
 {
     // setup the two DMA units to hand-off to each other
     // to maintain a stable bitstream these need to run without interruption
-	snd_dma_a_cfg = dma_channel_get_default_config(SOUND_DMA_CHA);
+	snd_dma_a_cfg = dma_channel_get_default_config(SOUND_DMA_CH_A);
 	channel_config_set_transfer_data_size(&snd_dma_a_cfg, DMA_SIZE_16);
 	channel_config_set_dreq(&snd_dma_a_cfg, spi_get_dreq(AUDIO_SPI, true));
 	channel_config_set_read_increment(&snd_dma_a_cfg, true);
-	channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CHB);
+	channel_config_set_chain_to(&snd_dma_a_cfg, SOUND_DMA_CH_B);
     // version of pico-sdk lacks channel_config_set_high_priority()
     snd_dma_a_cfg.ctrl |= DMA_CH0_CTRL_TRIG_HIGH_PRIORITY_BITS;
-	dma_channel_configure(SOUND_DMA_CHA, &snd_dma_a_cfg, &(spi_get_hw(AUDIO_SPI)->dr),
+	dma_channel_configure(SOUND_DMA_CH_A, &snd_dma_a_cfg, &(spi_get_hw(AUDIO_SPI)->dr),
 			wire_buf_a, WIRE_BUFFER_SIZE, false);
-    dma_channel_set_irq0_enabled(SOUND_DMA_CHA, true);
-	snd_dma_b_cfg = dma_channel_get_default_config(SOUND_DMA_CHB);
+    dma_channel_set_irq0_enabled(SOUND_DMA_CH_A, true);
+	snd_dma_b_cfg = dma_channel_get_default_config(SOUND_DMA_CH_B);
 	channel_config_set_transfer_data_size(&snd_dma_b_cfg, DMA_SIZE_16);
 	channel_config_set_dreq(&snd_dma_b_cfg, spi_get_dreq(AUDIO_SPI, true));
 	channel_config_set_read_increment(&snd_dma_b_cfg, true);
-	channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CHA);
+	channel_config_set_chain_to(&snd_dma_b_cfg, SOUND_DMA_CH_A);
     snd_dma_b_cfg.ctrl |= DMA_CH0_CTRL_TRIG_HIGH_PRIORITY_BITS;
-	dma_channel_configure(SOUND_DMA_CHB, &snd_dma_b_cfg, &(spi_get_hw(AUDIO_SPI)->dr),
+	dma_channel_configure(SOUND_DMA_CH_B, &snd_dma_b_cfg, &(spi_get_hw(AUDIO_SPI)->dr),
 			wire_buf_b, WIRE_BUFFER_SIZE, false);
-    dma_channel_set_irq0_enabled(SOUND_DMA_CHB, true);
+    dma_channel_set_irq0_enabled(SOUND_DMA_CH_B, true);
 
     // ready to go
-    dma_channel_start(SOUND_DMA_CHA);
+    dma_channel_start(SOUND_DMA_CH_A);
 }
 
 bool audio_play(uint8_t owner, image_config_t* img, uint64_t start, uint64_t end, bool swap) {
@@ -627,8 +627,8 @@ void audio_stop(uint8_t id, bool startup_skip) {
     // then indicate that the streams should no longer chain to one another
     // and wait for them to shut down naturally
     audio_stopping = true;
-    while (dma_channel_is_busy(SOUND_DMA_CHA)) tight_loop_contents();
-    while (dma_channel_is_busy(SOUND_DMA_CHB)) tight_loop_contents();
+    while (dma_channel_is_busy(SOUND_DMA_CH_A)) tight_loop_contents();
+    while (dma_channel_is_busy(SOUND_DMA_CH_B)) tight_loop_contents();
     while (spi_is_busy(AUDIO_SPI)) tight_loop_contents();
     audio_stopping = false;
 

--- a/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.h
+++ b/lib/ZuluSCSI_audio_RP2MCU/audio_spdif.h
@@ -21,8 +21,8 @@
 #include <stdint.h>
 
 // audio subsystem DMA channels
-#define SOUND_DMA_CHA 6
-#define SOUND_DMA_CHB 7
+#define SOUND_DMA_CH_A 6
+#define SOUND_DMA_CH_B 7
 
 // size of the two audio sample buffers, in bytes
 // these must be divisible by 1024

--- a/lib/ZuluSCSI_platform_RP2MCU/rp2350_sniffer_config.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp2350_sniffer_config.h
@@ -30,13 +30,13 @@ void sniffer_log(const char *msg);
 #endif
 
 // DMA channel for transfer of data from PIO to RAM
-#ifndef SNIFFER_DMACH
-#define SNIFFER_DMACH 6
+#ifndef SNIFFER_DMA_CH_A
+#define SNIFFER_DMA_CH_A 12
 #endif
 
 // DMA channel for reconfiguring first DMA channel
-#ifndef SNIFFER_DMACH_B
-#define SNIFFER_DMACH_B 7
+#ifndef SNIFFER_DMA_CH_B
+#define SNIFFER_DMA_CH_B 13
 #endif
 
 // PIO block used for capture

--- a/platformio.ini
+++ b/platformio.ini
@@ -183,7 +183,7 @@ ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
-    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.0.1
+    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.1.0
     adafruit/Adafruit SSD1306@^2.5.15
     adafruit/Adafruit GFX Library@^1.12.1
     adafruit/Adafruit BusIO@^1.17.1
@@ -238,7 +238,7 @@ ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
     ${env:ZuluSCSI_RP2MCU.lib_deps}
     SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
-    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.0.1
+    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.1.0
     compact25519=https://github.com/rabbitholecomputing/compact25519
     adafruit/Adafruit SSD1306@^2.5.15
     adafruit/Adafruit GFX Library@^1.12.1


### PR DESCRIPTION
The sniffer claimed DMA channels numbers were conflicting with other subsystems. Switching to 12 and 13 for A and B respectively fixed the issue.

Renamed the sniffer DMA and audio DMA define names to match the SCSI DMA names for easier searching for future conflicts. The standardized naming convention is `[subsystem]_DMA_CH_[letter]`. For example `SNIFFER_DMA_CH_B` or `SCSI_DMA_CH_D`.