### PR TITLE
Accept zulucontrol*.uf2 for upgrade file

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1652,11 +1652,24 @@ extern "C" void zuluscsi_setup(void)
 #ifdef ZULUCONTROL_FIRMWARE
   if (g_sdcard_present && g_i2c_claimed)
   {
-    if (SD.exists(ZULUCONTROL_FW_FILE))
+    FsFile root = SD.open("/");
+    FsFile file;
+    while (file.openNext(&root))
     {
-      logmsg("ZuluControl-firmware file found on SD card, attempting to upgrade firmware");
-      zuluWebUIUpgradeFirmware(ZULUCONTROL_FW_FILE);
+      char filename[MAX_FILE_PATH];
+      file.getName(filename, sizeof(filename));
+      const char *extension = strrchr(filename, '.');
+      if (extension && strncasecmp(extension, ".uf2", 4) == 0 && strncasecmp(filename, ZULUCONTROL_UF2_PREFIX, sizeof(ZULUCONTROL_UF2_PREFIX) - 1) == 0)
+      {
+        file.close();
+        logmsg("ZuluControl-firmware UF2, \"", filename, "\", found on SD card, attempting to upgrade firmware");
+        zuluWebUIUpgradeFirmware(filename);
+        break;
+      }
     }
+    file.close();
+    root.close();
+
     zuluWebUIInit();
   }
 #endif

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -48,6 +48,7 @@
 #define FIRMWARE_PREFIX "ZuluSCSI-FW"
 
 #define ZULUCONTROL_FW_FILE "zulucontrol.uf2"
+#define ZULUCONTROL_UF2_PREFIX "zulucontrol"
 
 #define SNIFFERFILE "zuluscsi_sniff.dat"
 


### PR DESCRIPTION
Will use any file that matches `zulucontrol*.uf2` to attempt to upgrade the ZuluControl-firmware over I2C.