### PR TITLE
Fix single-digit IMGx ini keys ignored since 82e4983

### DIFF
--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -1101,10 +1101,7 @@ void patchDevice(uint8_t target_idx)
                 int j;
                 for (j=0;j<=IMAGE_INDEX_MAX;j++)
                 {
-                    char key[5] = "IMG0";
-                    key[3] = '0' + j;
-
-                    ini_gets(section, key, "", filename, MAX_PATH_LEN, CONFIGFILE);
+                    scsiDiskReadImgX(section, j, filename, MAX_PATH_LEN);
                     if (filename[0] == '\0')
                     {
                         break;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1165,6 +1165,10 @@ int findNextImageAfter(image_config_t &img,
 
 int scsiDiskReadImgX(const char *section, int index, char *buf, size_t buflen)
 {
+    buf[0] = '\0';
+    if (index < 0 || index > IMAGE_INDEX_MAX)
+        return 0;
+
     char key[6] = "IMG00";
     if (index < 10)
     {

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1163,6 +1163,31 @@ int findNextImageAfter(image_config_t &img,
     }
 }
 
+int scsiDiskReadImgX(const char *section, int index, char *buf, size_t buflen)
+{
+    char key[6] = "IMG00";
+    if (index < 10)
+    {
+        key[3] = '0' + index;
+        key[4] = '\0';
+    }
+    else
+    {
+        key[3] = '0' + index / 10;
+        key[4] = '0' + index % 10;
+    }
+
+    buf[0] = '\0';
+    int ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+    if (buf[0] == '\0' && index < 10)
+    {
+        key[3] = '0';
+        key[4] = '0' + index;
+        ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+    }
+    return ret;
+}
+
 int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 {
     int target_idx = img.scsiId & S2S_CFG_TARGET_ID_BITS;
@@ -1328,27 +1353,15 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
                 img.image_index = 0;
             }
 
-            char key[6] = "IMG00";
-
-            if (img.image_index < 10)
-            {
-                key[4] = '0' + img.image_index;
-            }
-            else
-            {
-                key[3] = '0' + img.image_index / 10;
-                key[4] = '0' + img.image_index % 10;
-            }
-
             // For the dynamic target, check [SCSIn] IMG keys first, then [SCSI<X>].
             int ret = 0;
             buf[0] = '\0';
 #ifdef DYNAMIC_SCSI_ID
             if (is_dynamic)
-                ret = ini_gets(DYNAMIC_SCSI_INI_SECTION, key, "", buf, buflen, CONFIGFILE);
+                ret = scsiDiskReadImgX(DYNAMIC_SCSI_INI_SECTION, img.image_index, buf, buflen);
 #endif
             if (!ret || buf[0] == '\0')
-                ret = ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+                ret = scsiDiskReadImgX(section, img.image_index, buf, buflen);
 
             if (buf[0] != '\0')
             {

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -168,6 +168,10 @@ void scsiDiskCloseTray(image_config_t &img);
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, int blocksize, S2S_CFG_TYPE type = S2S_CFG_FIXED, bool use_prefix = false);
 void scsiDiskLoadConfig(int target_idx);
 
+// Read IMG0-IMG99 entry from an ini section, accepting both
+// unpadded (IMG5) and zero-padded (IMG05) single digit keys.
+int scsiDiskReadImgX(const char *section, int index, char *buf, size_t buflen);
+
 // Checks if a filename extension is appropriate for further processing as a disk image.
 // The current implementation does not check the the filename prefix for validity.
 bool scsiDiskFilenameValid(const char* name);

--- a/src/uiDiskUtils.cpp
+++ b/src/uiDiskUtils.cpp
@@ -30,10 +30,7 @@ extern "C" void getImgXByIndex(uint8_t id, int index, char* buf, size_t buflen, 
     char section[6] = "SCSI0";
     section[4] = scsiEncodeID(id);
 
-    char key[5] = "IMG0";
-    key[3] = '0' + index;
-
-    ini_gets(section, key, "", buf, buflen, CONFIGFILE);
+    scsiDiskReadImgX(section, index, buf, buflen);
 
     FsVolume *vol = SD.vol();
     FsFile fHandle = vol->open(buf, O_RDONLY);


### PR DESCRIPTION
Since 82e4983 (v2026.07.01+) the parser only matches zero-padded `IMG00`-`IMG09`, so documented `IMG0`-`IMG9` keys are silently ignored and devices configured only via IMGx never appear on the bus.

Repro: `[SCSI4]` with `Type=2`, `IMG0=disc.iso` → no SCSI4 device, no `[SCSI4]` lines in log.

Fix: shared `scsiDiskReadImgX()` accepts both unpadded and padded single-digit keys; UI code paths now use it too (they previously built invalid keys for `IMG10`+).

Tested: ZuluSCSI_Blaster build passes; key lookup verified for IMG0/IMG05/IMG10/IMG99 cases.