### PR TITLE
Apply reject truncated MODE SELECT parameter lists

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -728,6 +728,13 @@ static void doModeSelect(void)
 
 		int idx;
 		int blockDescLen;
+
+		// SCSI2 8.2.8: the command shall be terminated with CHECK CONDITION
+		// if the parameter list length truncates the mode parameter header,
+		// the block descriptor(s), or a mode page.
+		int headerLen = (scsiDev.cdb[0] == 0x55) ? 8 : 4;
+		if (scsiDev.dataLen < headerLen) goto badLength;
+
 		if (scsiDev.cdb[0] == 0x55)
 		{
 			blockDescLen =
@@ -739,6 +746,9 @@ static void doModeSelect(void)
 			blockDescLen = scsiDev.data[3];
 			idx = 4;
 		}
+
+		// The header check above guarantees dataLen >= idx.
+		if (blockDescLen > scsiDev.dataLen - idx) goto badLength;
 
 		// Store device-specific parameter byte (byte 2 for 6-byte, byte 3 for 10-byte)
 		// For sequential devices this contains buffered mode in bits 6-4
@@ -791,8 +801,10 @@ static void doModeSelect(void)
 			int pageCode = scsiDev.data[idx] & 0x3F;
 			if (pageCode == 0) goto out;
 
+			if (idx + 2 > scsiDev.dataLen) goto badLength;
+
 			int pageLen = scsiDev.data[idx + 1];
-			if (idx + 2 + pageLen > scsiDev.dataLen) goto bad;
+			if (idx + 2 + pageLen > scsiDev.dataLen) goto badLength;
 
 			switch (pageCode)
 			{
@@ -838,6 +850,15 @@ static void doModeSelect(void)
 	}
 
 	goto out;
+
+// SCSI2 8.2.8 separates a parameter list that is too short for what it
+// describes (1Ah) from one whose contents are unsupported (26h).
+badLength:
+	scsiDev.status = CHECK_CONDITION;
+	scsiDev.target->sense.code = ILLEGAL_REQUEST;
+	scsiDev.target->sense.asc = PARAMETER_LIST_LENGTH_ERROR;
+	goto out;
+
 bad:
 	scsiDev.status = CHECK_CONDITION;
 	scsiDev.target->sense.code = ILLEGAL_REQUEST;


### PR DESCRIPTION
Applying
https://github.com/BlueSCSI/BlueSCSI-v2/commit/500ceda6eb76c2e9657a68e822cdbb13558c5d25

Summary:
```
scsi: reject truncated MODE SELECT parameter lists

A parameter list too short for the header, block descriptor or page it
describes now returns PARAMETER LIST LENGTH ERROR per SCSI-2 8.2.8,
instead of applying buffer contents the host never transferred.
```