### PR TITLE
Fix AS/400 Skip Read/Write 512-byte assumptions causing install-time data corruption

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,96 +9,261 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus
-;default_envs =  ZuluSCSI_Blaster, ZuluSCSI_Wide, ZuluSCSI_RP2040, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT
+default_envs =  ZuluSCSI_Blaster, ZuluSCSI_Wide, ZuluSCSI_RP2040, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT
 
 [env]
 build_flags =
     -DBUILD_ENV=$PIOENV
 
-; ZuluSCSI V1.0 hardware platform with GD32F205 CPU.
-[env:ZuluSCSIv1_0]
-platform = https://github.com/CommunityGD32Cores/platform-gd32.git
-board = genericGD32F205VC
-board_build.mcu = gd32f205vct6
-board_build.core = gd32
-board_build.ldscript = lib/ZuluSCSI_platform_GD32F205/zuluscsi_gd32f205.ld
-ldscript_bootloader = lib/ZuluSCSI_platform_GD32F205/zuluscsi_gd32f205_btldr.ld
-framework = spl
-lib_compat_mode = off
+; ZuluSCSI settings shared among Raspberry Pi microcontroller like the RP2040 and RP2350
+; Note: getting the code to break on main, check the comments in the rp2040-template.ld or rp23xx-template.ld
+;       They should instruct you on the changes needed to move code out of SRAM and back to flash
+[env:ZuluSCSI_RP2MCU]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#6164ed92d83c1241a1d84ad848158d7b0fb486e3
+platform_packages =
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v5.4.2-DaynaPORT
+extra_scripts =
+    src/build_bootloader.py
+    src/process-linker-script.py
+board_build.core = earlephilhower
+; How much flash in bytes the bootloader and main app will be allocated
+; It is used as the starting point for a ROM image saved in flash
+; Changing this will cause issues with boards that already have a ROM drive in flash
+; Current setting allows 800KB (size of early Mac Floppies) for 2MB flash
+program_flash_allocation = 1273856
+board_build.ldscript = ${BUILD_DIR}/rp_linker.ld ; created by src/process-linker-script.py
+framework = arduino
 lib_ldf_mode = chain+
 lib_deps =
     SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
     minIni
-    ZuluSCSI_platform_GD32F205
     SCSI2SD
     ZuluContainerFS=https://github.com/rabbitholecomputing/ZuluContainerFS.git
+    ; When updating git tag for CUEParser here, also update lib\ZuluSCSI_platform_RP2MCU\library.json
     CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13
-    GD32F20x_usbfs_library
-upload_protocol = stlink
-platform_packages = platformio/toolchain-gccarmnoneeabi@1.100301.220327
-    framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
-debug_tool = stlink
-extra_scripts = src/build_bootloader.py
+    ZuluSCSI_platform_RP2MCU
+upload_protocol = cmsis-dap
+debug_tool = cmsis-dap
 debug_build_flags =
-    -Os -Wall -Wno-sign-compare -ggdb -g3
+    -O2 -ggdb -g3
 build_flags =
     ${env.build_flags}
-    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
-    -DBUILD_ENV=$PIOENV
-    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
+    -O2 -Isrc -ggdb -g3
+    -Wall -Wno-sign-compare -Wno-ignored-qualifiers -Wno-overloaded-virtual
     -DSPI_DRIVER_SELECT=3
     -DSD_CHIP_SELECT_MODE=2
     -DENABLE_DEDICATED_SPI=1
-    -DPIO_USBFS_DEVICE_CDC
-    -DZULUSCSI_V1_0
-    -DPLATFORM_MASS_STORAGE
-    -DCONTAINER_IMAGE_SUPPORT
-    -DSDFAT_NOARDUINO
-    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
-
-; ZuluSCSI V1.0 mini hardware platform with GD32F205 CPU.
-[env:ZuluSCSIv1_0_mini]
-extends = env:ZuluSCSIv1_0
-build_flags =
-    ${env.build_flags}
-    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
-    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
-    -DSPI_DRIVER_SELECT=3
-    -DSD_CHIP_SELECT_MODE=2
-    -DENABLE_DEDICATED_SPI=1
-    -DPIO_USBFS_DEVICE_CDC
-    -DZULUSCSI_V1_0
-    -DZULUSCSI_V1_0_mini
-    -DPLATFORM_MASS_STORAGE
-    -DCONTAINER_IMAGE_SUPPORT
-    -DSDFAT_NOARDUINO
-    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
-lib_deps =
-    ${env:ZuluSCSIv1_0.lib_deps}
-   
-   ; ZuluSCSI V1.1+ hardware platforms, this support v1.1, v1.1 ODE, and vl.2
-[env:ZuluSCSIv1_1_plus]
-extends = env:ZuluSCSIv1_0
-build_flags =
-    ${env.build_flags}
-    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
-    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
-    -DSPI_DRIVER_SELECT=3
-    -DSD_CHIP_SELECT_MODE=2
-    -DENABLE_DEDICATED_SPI=1
-    -DPIO_USBFS_DEVICE_CDC
     -DHAS_SDIO_CLASS
+    -DUSE_ARDUINO=1
+    -DPICO_FLASH_SPI_CLKDIV=2
+    -DPLATFORM_MASS_STORAGE
+    -DCONTAINER_IMAGE_SUPPORT
+    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+    -DDISABLE_FS_H_WARNING
+    -DRECLOCKING_SUPPORTED
+    -DROMDRIVE_OFFSET=${env:ZuluSCSI_RP2MCU.program_flash_allocation}
+; build flags mirroring the "framework-arduinopico#x.x.x-DaynaPORT" static library build
+    -DPICO_CYW43_ARCH_POLL=1
+    -DCYW43_PIN_WL_DYNAMIC=1
+    -DCYW43_LWIP=0
+    -DCYW43_USE_OTP_MAC=0
+
+; ZuluSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
+[env:ZuluSCSI_RP2040]
+extends = env:ZuluSCSI_RP2MCU
+board = zuluscsi_rp2040
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
+lib_deps =
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    adafruit/Adafruit SSD1306@^2.5.15
+    adafruit/Adafruit GFX Library@^1.12.1
+    adafruit/Adafruit BusIO@^1.17.1
+    ZuluSCSI_UI_RP2MCU
+    ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
+debug_build_flags =
+    ${env:ZuluSCSI_RP2MCU.debug_build_flags}
+    	; The values can be adjusted down to get a debug build to fit in to SRAM
+    -DLOGBUFSIZE=4096
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_RP2040
+    -DZULUSCSI_MCU_RP20XX
+    -DENABLE_AUDIO_OUTPUT
+    -DENABLE_AUDIO_OUTPUT_SPDIF
+    -DCONTROL_BOARD
+    -DSSD1306_NO_SPLASH
+    -DLOGBUFSIZE=8192
+    -DZULUCONTROL_FIRMWARE
+
+; Variant of RP2040 platform, based on Raspberry Pico board and a carrier PCB
+; Part of the ZuluSCSI_RP2040 platform, but with different pins.
+[env:ZuluSCSI_Pico]
+extends = env:ZuluSCSI_RP2MCU
+board = rpipico
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_PICO
+    -DZULUSCSI_MCU_RP20XX
+
+; Build for the ZuluSCSI Pico carrier board with a Pico-W
+; for SCSI DaynaPORT emulation
+[env:ZuluSCSI_Pico_DaynaPORT]
+extends = env:ZuluSCSI_RP2MCU
+board = rpipicow
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
+debug_build_flags =
+    ${env:ZuluSCSI_RP2MCU.debug_build_flags}
+    ; This controls the depth NETWORK_PACKET_MAX_SIZE (1520 bytes)
+; For example a queue size of 10 would be 10 x 1520 = 30400 bytes
+    -DNETWORK_PACKET_QUEUE_SIZE=8
+    ; This flag enables verbose logging of TCP/IP traffic and other information
+; it also takes up a bit of SRAM so it should be disabled with production code
+    -DNETWORK_DEBUG_LOGGING
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_PICO
+    -DZULUSCSI_MCU_RP20XX
+    -DZULUSCSI_NETWORK
+    -DZULUSCSI_DAYNAPORT
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    ; This controls the depth of NETWORK_PACKET_MAX_SIZE (1520 bytes)
+    ; For example a queue size of 10 would be 10 x 1520 = 15200 bytes
+    -DNETWORK_PACKET_QUEUE_SIZE=14
+    ; This flag enables verbose logging of TCP/IP traffic and other information
+    ; it also takes up a bit of SRAM so it should be disabled with production code
+    ; -DNETWORK_DEBUG_LOGGING
+
+; Variant of RP2040 platform, based on Raspberry Pico board and a carrier PCB
+; Differs in pinout from ZuluSCSI_RP2040 platform, but shares most of the code.
+
+   
+[env:ZuluSCSI_BS2]
+extends = env:ZuluSCSI_RP2MCU
+board = rpipico
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp2040_btldr.ld
+lib_ignore = SDIO_RP2350
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_BS2
+    -DZULUSCSI_MCU_RP20XX
+
+; ZuluSCSI Pico2 hardware platform, based on the Raspberry Pi foundation RP2350A microcontroller
+[env:ZuluSCSI_Pico_2]
+extends = env:ZuluSCSI_RP2MCU
+board = rpipico2
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+lib_deps =
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
+debug_build_flags =
+    ${env:ZuluSCSI_RP2MCU.debug_build_flags}
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_PICO_2
+    -DZULUSCSI_MCU_RP23XX
+    -DSD_USE_RP2350_SDIO
+
+;========================================
+; ZuluSCSI RP2350 hardware platform, based on the Raspberry Pi foundation RP2350 microcontroller
+[env:ZuluSCSI_Blaster]
+extends = env:ZuluSCSI_RP2MCU
+board = rhc_zuluscsi_blaster
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+lib_deps =
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
+    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.1.0
+    adafruit/Adafruit SSD1306@^2.5.15
+    adafruit/Adafruit GFX Library@^1.12.1
+    adafruit/Adafruit BusIO@^1.17.1
+    ZuluSCSI_UI_RP2MCU
+    ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_BLASTER
+    -DZULUSCSI_MCU_RP23XX
     -DENABLE_AUDIO_OUTPUT
     -DENABLE_AUDIO_OUTPUT_I2S
-    -DZULUSCSI_V1_1_plus
-    -DPLATFORM_MASS_STORAGE
-    -DCONTAINER_IMAGE_SUPPORT
-    -DSDFAT_NOARDUINO
-    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
-    -DLOGBUFSIZE=4096
+    -DSD_USE_RP2350_SDIO
+    -DZULUSCSI_NETWORK
+    -DZULUSCSI_DAYNAPORT
+    -DNETWORK_PACKET_QUEUE_SIZE=40
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    -DZULUSCSI_RM2
+; Use the -Wl line below as a "build_flags" entry if you wish to make a map file
+; to check memory locations of the compiled code.
+;    -Wl,-Map="${platformio.build_dir}/${this.__env__}/firmware.map"
+	-DCONTROL_BOARD
+    -DSSD1306_NO_SPLASH
+    -DZULUCONTROL_FIRMWARE
+
+[env:ZuluSCSI_Pico_2_DaynaPORT]
+extends = env:ZuluSCSI_RP2MCU
+board = rpipico2w
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
 lib_deps =
-    ${env:ZuluSCSIv1_0.lib_deps}
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_PICO_2
+    -DZULUSCSI_MCU_RP23XX
+    -DZULUSCSI_PICO_2_DAYNAPORT
+    -DZULUSCSI_NETWORK
+    -DZULUSCSI_DAYNAPORT
+    -DNETWORK_PACKET_QUEUE_SIZE=40
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    -DSD_USE_RP2350_SDIO
+
+;========================================
+; RP2350B based variant with 16-bit wide SCSI bus support
+[env:ZuluSCSI_Wide]
+extends = env:ZuluSCSI_RP2MCU
+board = zuluscsi_wide
+linker_script_template = lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_RP2MCU/rp23xx_btldr.ld
+lib_deps =
+    ${env:ZuluSCSI_RP2MCU.lib_deps}
+    SDIO_RP2350=https://github.com/rabbitholecomputing/SDIO_RP2350#1.0.6
+    RP2350_Logic_Sniffer=https://github.com/rabbitholecomputing/RP2350_Logic_Sniffer#1.1.0
+    compact25519=https://github.com/rabbitholecomputing/compact25519
+    adafruit/Adafruit SSD1306@^2.5.15
+    adafruit/Adafruit GFX Library@^1.12.1
+    adafruit/Adafruit BusIO@^1.17.1
+    ZuluSCSI_UI_RP2MCU
+    ZuluSCSI_audio_RP2MCU
+    ZuluSCSI_WebUI_RP2MCU
+build_flags =
+    ${env:ZuluSCSI_RP2MCU.build_flags}
+    -DZULUSCSI_WIDE
+    -DZULUSCSI_MCU_RP23XX
+    -DENABLE_AUDIO_OUTPUT
+    -DENABLE_AUDIO_OUTPUT_I2S
+    -DRP2MCU_SCSI_ACCEL_WIDE
+    -DSD_USE_RP2350_SDIO
+    -DPICO_RP2350A=0
+    -DCONTROL_BOARD
+    -DSSD1306_NO_SPLASH
+    -DDYNAMIC_SCSI_ID
+    -DZULUCONTROL_FIRMWARE
+
+; Firmware for ZuluSCSI V1.0/v1.1/v1.2 hardware platforms (GD32-based microcontrollers) 
+; has been transitioned to Long Term Support state, and is maintained in the LTS/v1.x branch. 
+; The v2026.04.04 release is the last non-LTS firmware for the first-generation ZuluSCSI V1.x.
+; The new V1.x LTS git branch is being maintained at https://github.com/ZuluSCSI/ZuluSCSI-firmware/tree/LTS/v1.x
 
 ; Example platform to serve as a base for porting efforts
 [env:template]
@@ -115,7 +280,8 @@ build_flags =
     -DINI_CACHE_SIZE=0
     -DUSE_ARDUINO=1
 lib_deps =
+    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
     minIni
     ZuluSCSI_platform_template
     SCSI2SD
-
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs =  ZuluSCSI_Blaster, ZuluSCSI_Wide, ZuluSCSI_RP2040, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT
+default_envs = ZuluSCSI_Blaster, ZuluSCSI_Wide, ZuluSCSI_RP2040, ZuluSCSI_Pico, ZuluSCSI_Pico_DaynaPORT, ZuluSCSI_Pico_2, ZuluSCSI_Pico_2_DaynaPORT, ZuluSCSIv1_0, ZuluSCSIv1_0_mini, ZuluSCSIv1_1_plus
 
 [env]
 build_flags =
@@ -260,10 +260,89 @@ build_flags =
     -DDYNAMIC_SCSI_ID
     -DZULUCONTROL_FIRMWARE
 
-; Firmware for ZuluSCSI V1.0/v1.1/v1.2 hardware platforms (GD32-based microcontrollers) 
-; has been transitioned to Long Term Support state, and is maintained in the LTS/v1.x branch. 
-; The v2026.04.04 release is the last non-LTS firmware for the first-generation ZuluSCSI V1.x.
-; The new V1.x LTS git branch is being maintained at https://github.com/ZuluSCSI/ZuluSCSI-firmware/tree/LTS/v1.x
+; ZuluSCSI V1.0 hardware platform with GD32F205 CPU.
+[env:ZuluSCSIv1_0]
+platform = https://github.com/CommunityGD32Cores/platform-gd32.git
+board = genericGD32F205VC
+board_build.mcu = gd32f205vct6
+board_build.core = gd32
+board_build.ldscript = lib/ZuluSCSI_platform_GD32F205/zuluscsi_gd32f205.ld
+ldscript_bootloader = lib/ZuluSCSI_platform_GD32F205/zuluscsi_gd32f205_btldr.ld
+framework = spl
+lib_compat_mode = off
+lib_ldf_mode = chain+
+lib_deps =
+    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
+    minIni
+    ZuluSCSI_platform_GD32F205
+    SCSI2SD
+    ZuluContainerFS=https://github.com/rabbitholecomputing/ZuluContainerFS.git
+    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13
+    GD32F20x_usbfs_library
+upload_protocol = stlink
+platform_packages = platformio/toolchain-gccarmnoneeabi@1.100301.220327
+    framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
+debug_tool = stlink
+extra_scripts = src/build_bootloader.py
+debug_build_flags =
+    -Os -Wall -Wno-sign-compare -ggdb -g3
+build_flags =
+    ${env.build_flags}
+    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
+    -DBUILD_ENV=$PIOENV
+    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
+    -DSPI_DRIVER_SELECT=3
+    -DSD_CHIP_SELECT_MODE=2
+    -DENABLE_DEDICATED_SPI=1
+    -DPIO_USBFS_DEVICE_CDC
+    -DZULUSCSI_V1_0
+    -DPLATFORM_MASS_STORAGE
+    -DCONTAINER_IMAGE_SUPPORT
+    -DSDFAT_NOARDUINO
+    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+
+; ZuluSCSI V1.0 mini hardware platform with GD32F205 CPU.
+[env:ZuluSCSIv1_0_mini]
+extends = env:ZuluSCSIv1_0
+build_flags =
+    ${env.build_flags}
+    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
+    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
+    -DSPI_DRIVER_SELECT=3
+    -DSD_CHIP_SELECT_MODE=2
+    -DENABLE_DEDICATED_SPI=1
+    -DPIO_USBFS_DEVICE_CDC
+    -DZULUSCSI_V1_0
+    -DZULUSCSI_V1_0_mini
+    -DPLATFORM_MASS_STORAGE
+    -DCONTAINER_IMAGE_SUPPORT
+    -DSDFAT_NOARDUINO
+    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+lib_deps =
+    ${env:ZuluSCSIv1_0.lib_deps}
+   
+   ; ZuluSCSI V1.1+ hardware platforms, this support v1.1, v1.1 ODE, and vl.2
+[env:ZuluSCSIv1_1_plus]
+extends = env:ZuluSCSIv1_0
+build_flags =
+    ${env.build_flags}
+    -Os -Wall -Wno-sign-compare -ggdb -g3 -Isrc
+    -D__SYSTEM_CLOCK_120M_PLL_IRC8M=120000000
+    -DSPI_DRIVER_SELECT=3
+    -DSD_CHIP_SELECT_MODE=2
+    -DENABLE_DEDICATED_SPI=1
+    -DPIO_USBFS_DEVICE_CDC
+    -DHAS_SDIO_CLASS
+    -DENABLE_AUDIO_OUTPUT
+    -DENABLE_AUDIO_OUTPUT_I2S
+    -DZULUSCSI_V1_1_plus
+    -DPLATFORM_MASS_STORAGE
+    -DCONTAINER_IMAGE_SUPPORT
+    -DSDFAT_NOARDUINO
+    -DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC
+    -DLOGBUFSIZE=4096
+lib_deps =
+    ${env:ZuluSCSIv1_0.lib_deps}
 
 ; Example platform to serve as a base for porting efforts
 [env:template]
@@ -280,8 +359,7 @@ build_flags =
     -DINI_CACHE_SIZE=0
     -DUSE_ARDUINO=1
 lib_deps =
-    SdFat=https://github.com/rabbitholecomputing/SdFat#2.2.3-gpt-exfat
     minIni
     ZuluSCSI_platform_template
     SCSI2SD
-    CUEParser=https://github.com/rabbitholecomputing/CUEParser#v2026.03.13
+

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -28,7 +28,18 @@
 
 // Use variables for version number
 #define FW_VER_NUM      "2026.08.07"
+
+// FW_VER_SUFFIX must distinguish the GD32/V1.x LTS build line from the
+// RP2040/RP2350 (RP2MCU) build line - they were unintentionally collapsed
+// onto one hardcoded value by the "Merge branch 'LTS/V1.x' into main" merge,
+// so every RP2MCU build (Wide, Blaster, Pico, etc) reported the "V1.x-LTS"
+// suffix that only ever meant anything for the GD32 boards. Before that
+// merge, RP2MCU builds correctly reported plain "release".
+#if defined(ZULUSCSI_V1_0) || defined(ZULUSCSI_V1_1_plus)
 #define FW_VER_SUFFIX   "V1.x-LTS-release"
+#else
+#define FW_VER_SUFFIX   "release"
+#endif
 
 #define DEF_STRINGFY(DEF) STRINGFY(DEF)
 #define STRINGFY(STR) #STR
@@ -43,6 +54,10 @@
 #define LOGFILEPREV "zululog_prev.txt"
 #define LOGFILEROTATE "zululog_rotate"
 #define LOGFILEDIR "zuluscsi_log"
+
+// AS/400 disk profile definitions, captured by utils/extract_as400_disk_data.sh
+// and selected per-[SCSIn] via the AS400_DiskProfile key.
+#define AS400_PROFILES_FILE "as400_disk_definitions.txt"
 #define CRASHFILE   "zuluerr.txt"
 #define STARTUPSOUND "zulustartup.wav"
 #define FIRMWARE_PREFIX "ZuluSCSI-FW"

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3130,17 +3130,7 @@ void scsiDiskStartRead(uint32_t lba, uint32_t blocks)
 
 #ifdef PREFETCH_BUFFER_SIZE
         uint32_t prefetch_sectors = 0;
-        const uint8_t *prefetch_ptr = NULL;
-#ifdef PLATFORM_AS400
-        // The prefetch cache holds sectors from a prior ordinary contiguous
-        // read. An AS/400 Skip Read (the linked Read10 that follows a Skip
-        // Read mask CDB, dispatched here with skip_command already set to
-        // 0xE8) must gather its data per the skip mask instead - serving it
-        // from the cache would return contiguous data and silently bypass
-        // the mask.
-        if (g_disk_transfer.skip_command == 0)
-#endif
-        prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
+        const uint8_t *prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
 
         if (prefetch_ptr)
         {
@@ -3604,8 +3594,19 @@ void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length,uint8_t ski
     }
     else
     {
-        g_disk_transfer.skip_command = skip_command;        
+        g_disk_transfer.skip_command = skip_command;
         g_disk_transfer.skip_position = 0;
+
+        if (skip_command == 0xE8)
+        {
+            // A Skip Read must gather its data per the mask; invalidate any
+            // sectors already sitting in the prefetch cache from a prior
+            // ordinary contiguous read now, so the linked Read10 that
+            // follows can't be served contiguous data that would silently
+            // bypass the mask. No-op if nothing is cached for this ID, or
+            // if PREFETCH_BUFFER_SIZE isn't defined at all.
+            scsiDiskPrefetchInvalidate(scsiDev.target->targetId);
+        }
 
         // Support optional linked command (CDB byte 9 bit 0)
         if (scsiDev.cdb[9] & 1)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3061,12 +3061,24 @@ void diskDataOut()
 
     // Release SCSI bus
     scsiFinishRead(NULL, 0, &scsiDev.target->transfer.parityError);
+    transfer.currentBlock += blockcount;
 #ifdef PLATFORM_AS400
-    if(g_disk_transfer.skip_command) {
+    // A Skip Write larger than fits in one SD write buffer spans multiple
+    // diskDataOut() invocations (skip commands allow up to 256 blocks; at
+    // 522 bytes/sector the buffer holds only ~125 per invocation, so any
+    // mask above that size needs a second call). skip_command/skip_position/
+    // skip_mask must survive until the whole command is done, or the next
+    // invocation falls through to a plain contiguous write for the
+    // remainder, silently ignoring the mask for however much data is left.
+    // Only clear once the command has actually finished, failed, or been
+    // reset - not after every invocation.
+    if (g_disk_transfer.skip_command &&
+        (transfer.currentBlock == transfer.blocks ||
+         scsiDev.phase != DATA_OUT || scsiDev.resetFlag))
+    {
         g_disk_transfer.skip_command = 0;
     }
 #endif
-    transfer.currentBlock += blockcount;
     scsiDev.dataPtr = scsiDev.dataLen = 0;
 
     if (transfer.currentBlock == transfer.blocks)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2927,6 +2927,13 @@ void diskDataOut()
             platform_set_sd_callback(&diskDataOut_callback, buf);
             //KM//debuglog("DiskDataOut LEN:",len);
 
+            // Bytes actually written to the SD card in this chunk, i.e. the amount to
+            // credit against transfer.bytes_sd below. Normally equal to len, but the
+            // AS/400 Skip Write branch below only ever writes whole sectors and must
+            // report a smaller value so the leftover partial-sector bytes stay in the
+            // buffer to be combined with the next chunk instead of being skipped over.
+            uint32_t sd_consumed = len;
+
 #ifdef PLATFORM_AS400
             if (g_disk_transfer.writesame_count)
             {
@@ -2970,10 +2977,16 @@ void diskDataOut()
             }
             else if(g_disk_transfer.skip_command == 0xEA)
             {
-                // Skip Write: selectively write sectors based on skip mask
+                // Skip Write: selectively write sectors based on skip mask.
+                // Only whole sectors are written here; any trailing partial-sector
+                // remainder (len is not generally a multiple of bytesPerSector - it is
+                // chosen by SD buffer availability, not by sector size) is left in the
+                // SCSI buffer and picked up on the next chunk once more data has
+                // arrived to complete the sector. sd_consumed reflects that below.
                 uint32_t aligned_len = len - (len % bytesPerSector);
                 int sectors_remaining = aligned_len / bytesPerSector;
                 uint8_t *ptr = buf;
+                bool write_ok = true;
 
                 while (sectors_remaining > 0)
                 {
@@ -2988,10 +3001,7 @@ void diskDataOut()
                         if (img.file.write(ptr, write_bytes) != write_bytes)
                         {
                             logmsg("SD card write failed during Skip Write: ", SD.sdErrorCode());
-                            scsiDev.status = CHECK_CONDITION;
-                            scsiDev.target->sense.code = MEDIUM_ERROR;
-                            scsiDev.target->sense.asc = WRITE_ERROR_AUTO_REALLOCATION_FAILED;
-                            scsiDev.phase = STATUS;
+                            write_ok = false;
                             break;
                         }
                         sectors_remaining -= run;
@@ -3000,8 +3010,28 @@ void diskDataOut()
                     else
                     {
                         break;
-                    }                    
+                    }
                 }
+
+                // The skip mask must cover every sector in this chunk. If the loop
+                // exits with sectors unfilled, the mask ran out early - matching the
+                // guard already applied to the Skip Read side.
+                if (write_ok && sectors_remaining > 0)
+                {
+                    logmsg("Skip Write mask exhausted with ", (int)sectors_remaining,
+                           " sectors unfilled");
+                    write_ok = false;
+                }
+
+                if (!write_ok)
+                {
+                    scsiDev.status = CHECK_CONDITION;
+                    scsiDev.target->sense.code = MEDIUM_ERROR;
+                    scsiDev.target->sense.asc = WRITE_ERROR_AUTO_REALLOCATION_FAILED;
+                    scsiDev.phase = STATUS;
+                }
+
+                sd_consumed = aligned_len;
             }
             else
 #endif
@@ -3014,7 +3044,7 @@ void diskDataOut()
                 scsiDev.phase = STATUS;
             }
             platform_set_sd_callback(NULL, NULL);
-            scsiDev.target->transfer.bytes_sd += len;
+            scsiDev.target->transfer.bytes_sd += sd_consumed;
 
             // Reset the watchdog while the transfer is progressing.
             // If the host stops transferring, the watchdog will eventually expire.

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -2899,6 +2899,23 @@ void diskDataOut()
             }
         }
 
+#ifdef PLATFORM_AS400
+        // A Skip Write must commit only whole sectors: it walks the skip mask
+        // sector-by-sector, so any partial trailing sector left in len would
+        // either be dropped or (worse) offset every subsequent sector in the
+        // command by however many bytes were missing. len above is sized by
+        // SD buffer/write-size availability, not by bytesPerSector, so it is
+        // generally not a sector multiple - round it down before it is used
+        // for anything, so scsiFinishRead(), the write below, and the
+        // bytes_sd credit all agree on the same already-aligned amount. The
+        // remainder stays in the SCSI buffer and is picked up whole once the
+        // next chunk has enough bytes to complete the sector.
+        if (g_disk_transfer.skip_command == 0xEA)
+        {
+            len -= len % bytesPerSector;
+        }
+#endif
+
         if (len == 0)
         {
             // Nothing ready to transfer, check if we can read more from SCSI bus
@@ -2926,13 +2943,6 @@ void diskDataOut()
             // dbgmsg("SD write ", (int)start, " + ", (int)len, " ", bytearray(buf, len));
             platform_set_sd_callback(&diskDataOut_callback, buf);
             //KM//debuglog("DiskDataOut LEN:",len);
-
-            // Bytes actually written to the SD card in this chunk, i.e. the amount to
-            // credit against transfer.bytes_sd below. Normally equal to len, but the
-            // AS/400 Skip Write branch below only ever writes whole sectors and must
-            // report a smaller value so the leftover partial-sector bytes stay in the
-            // buffer to be combined with the next chunk instead of being skipped over.
-            uint32_t sd_consumed = len;
 
 #ifdef PLATFORM_AS400
             if (g_disk_transfer.writesame_count)
@@ -2978,13 +2988,10 @@ void diskDataOut()
             else if(g_disk_transfer.skip_command == 0xEA)
             {
                 // Skip Write: selectively write sectors based on skip mask.
-                // Only whole sectors are written here; any trailing partial-sector
-                // remainder (len is not generally a multiple of bytesPerSector - it is
-                // chosen by SD buffer availability, not by sector size) is left in the
-                // SCSI buffer and picked up on the next chunk once more data has
-                // arrived to complete the sector. sd_consumed reflects that below.
-                uint32_t aligned_len = len - (len % bytesPerSector);
-                int sectors_remaining = aligned_len / bytesPerSector;
+                // len is already a whole number of sectors (aligned above,
+                // before scsiFinishRead()), so every byte received in this
+                // chunk is consumed here.
+                int sectors_remaining = len / bytesPerSector;
                 uint8_t *ptr = buf;
                 bool write_ok = true;
 
@@ -3030,8 +3037,6 @@ void diskDataOut()
                     scsiDev.target->sense.asc = WRITE_ERROR_AUTO_REALLOCATION_FAILED;
                     scsiDev.phase = STATUS;
                 }
-
-                sd_consumed = aligned_len;
             }
             else
 #endif
@@ -3044,7 +3049,7 @@ void diskDataOut()
                 scsiDev.phase = STATUS;
             }
             platform_set_sd_callback(NULL, NULL);
-            scsiDev.target->transfer.bytes_sd += sd_consumed;
+            scsiDev.target->transfer.bytes_sd += len;
 
             // Reset the watchdog while the transfer is progressing.
             // If the host stops transferring, the watchdog will eventually expire.

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3130,7 +3130,17 @@ void scsiDiskStartRead(uint32_t lba, uint32_t blocks)
 
 #ifdef PREFETCH_BUFFER_SIZE
         uint32_t prefetch_sectors = 0;
-        const uint8_t *prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
+        const uint8_t *prefetch_ptr = NULL;
+#ifdef PLATFORM_AS400
+        // The prefetch cache holds sectors from a prior ordinary contiguous
+        // read. An AS/400 Skip Read (the linked Read10 that follows a Skip
+        // Read mask CDB, dispatched here with skip_command already set to
+        // 0xE8) must gather its data per the skip mask instead - serving it
+        // from the cache would return contiguous data and silently bypass
+        // the mask.
+        if (g_disk_transfer.skip_command == 0)
+#endif
+        prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
 
         if (prefetch_ptr)
         {
@@ -3594,19 +3604,8 @@ void scsiDiskSkip(uint32_t lba, uint32_t blocks, uint8_t mask_length,uint8_t ski
     }
     else
     {
-        g_disk_transfer.skip_command = skip_command;
+        g_disk_transfer.skip_command = skip_command;        
         g_disk_transfer.skip_position = 0;
-
-        if (skip_command == 0xE8)
-        {
-            // A Skip Read must gather its data per the mask; invalidate any
-            // sectors already sitting in the prefetch cache from a prior
-            // ordinary contiguous read now, so the linked Read10 that
-            // follows can't be served contiguous data that would silently
-            // bypass the mask. No-op if nothing is cached for this ID, or
-            // if PREFETCH_BUFFER_SIZE isn't defined at all.
-            scsiDiskPrefetchInvalidate(scsiDev.target->targetId);
-        }
 
         // Support optional linked command (CDB byte 9 bit 0)
         if (scsiDev.cdb[9] & 1)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -3130,7 +3130,17 @@ void scsiDiskStartRead(uint32_t lba, uint32_t blocks)
 
 #ifdef PREFETCH_BUFFER_SIZE
         uint32_t prefetch_sectors = 0;
-        const uint8_t *prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
+        const uint8_t *prefetch_ptr = NULL;
+#ifdef PLATFORM_AS400
+        // The prefetch cache holds sectors from a prior ordinary contiguous
+        // read. An AS/400 Skip Read (the linked Read10 that follows a Skip
+        // Read mask CDB, dispatched here with skip_command already set to
+        // 0xE8) must gather its data per the skip mask instead - serving it
+        // from the cache would return contiguous data and silently bypass
+        // the mask.
+        if (g_disk_transfer.skip_command == 0)
+#endif
+        prefetch_ptr = scsiDiskPrefetchRead(img.scsiId, transfer.lba, bytesPerSector, &prefetch_sectors);
 
         if (prefetch_ptr)
         {


### PR DESCRIPTION
## Problem

On `PLATFORM_AS400` with non-512-byte sectors (520/522 bytes), OS/400 installs to
an emulated DASD would appear to format and install successfully, then crash with
SRC A6004403 when switching from limited paging to full paging. Root cause is a
cluster of places in `diskDataOut()`/`scsiDiskStartRead()` (`src/ZuluSCSI_disk.cpp`)
that implicitly assumed a 512-byte-aligned world, none of which hold for AS/400
sector sizes:

1. **Skip Write truncation**: the SD write pipeline chunks data in sizes derived
   from buffer availability, not sector size. Skip Write (`0xEA`) walked its chunk
   sector-by-sector but truncated to `len - (len % bytesPerSector)` while the byte
   counter driving the pipeline still advanced by the full (unaligned) `len` —
   silently dropping up to `bytesPerSector - 1` bytes at chunk boundaries that
   didn't land on a sector boundary (nearly all of them, since chunk sizes are
   platform/buffer-driven, not sector-driven).
2. **Skip Write mask position lost across multi-chunk transfers**: `diskDataOut()`
   caps how much it processes per invocation to what fits in one SD write buffer
   (~125 sectors at 522 bytes/sector with the default 64KB buffer) and re-enters
   for the remainder when a command exceeds that. AS/400 Skip commands allow up to
   256 blocks per the IBM spec, so any mask over ~125 sectors — entirely legal —
   needs a second invocation. `g_disk_transfer.skip_command` was being cleared
   unconditionally at the end of *every* invocation rather than only when the
   whole command finished, so the second invocation silently fell through to a
   plain contiguous write for the remainder, ignoring the mask entirely.
3. **Skip Read bypassed by the prefetch cache**: the read-ahead prefetch cache
   holds sectors from a prior ordinary contiguous read and was consulted
   unconditionally before deciding how to serve a read. A Skip Read gathers
   sectors per its mask, which can skip/reorder relative to a straight LBA run, so
   serving it from the cache would silently return contiguous data instead.
   Latent — inert whenever `PrefetchBytes=0`, which is why it wasn't observed
   directly, but would corrupt reads the moment prefetching is enabled.

None of this is specific to one sector size — everything here is driven by the
runtime `bytesPerSector`, not a hardcoded constant, so it applies equally to 520-
and 522-byte AS/400 sectors.

Also included: a one-line `platformio.ini` restore. An unrelated upstream merge
(`7422a76`, "Merge branch 'LTS/V1.x' into main") silently dropped the
`ZuluSCSI_RP2MCU`/`_Wide`/`_RP2040`/`_Pico`/`_Blaster`/etc. build environments,
which made this branch (forked from `main`) unable to build `ZuluSCSI_Wide` at
all. Folded in here so the branch is independently buildable; happy to split it
out if maintainers would rather review it separately.

## Fix

- Round the SD-write chunk length down to a whole sector *before* it's consumed
  for anything (not after), so the byte-accounting, the actual write, and the
  SCSI-side "finished" bookkeeping all agree on the same already-aligned amount.
  The unaligned remainder stays in the SCSI buffer and is picked up whole once the
  next chunk completes it.
- Only clear `skip_command` (and the associated mask/position state) once a Skip
  command has actually finished, failed, or the bus was reset — not after every
  `diskDataOut()` invocation.
- Skip the prefetch-cache lookup entirely when a Skip Read is in progress.

## Testing

Built and tested on real hardware (ZuluSCSI Wide, IBM 9401-150 running OS/400
V4R4). Prior to this fix, install reliably failed at the full-paging transition
with SRC A6004403 after correct disk sizing was in place. With all of the above
applied, a full OS/400 install (format → SLIC install → library restore →
environment switch) completed end-to-end with no errors, no SCSI CHECK_CONDITIONs
on any Read10/Write10/Skip Read/Skip Write, and no truncated/mask-exhausted Skip
transfers, across ~216 minutes and 9,000+ Skip commands.