### PR TITLE
Warnings Cleanup

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -295,12 +295,15 @@ static const uint8_t IomegaZip100VendorPage[] =
 	0x5c, 0xf, 0xff, 0xf
 };
 
+#if 0
+/* Note: not currently used anywhere */
 static const uint8_t IomegaZip250VendorPage[] =
 {
 	0x2f, // Page Code
 	4, // Page Length
 	0x5c, 0xf, 0x3c, 0xf
 };
+#endif
 
 static void pageIn(int pc, int dataIdx, const uint8_t* pageData, int pageLen)
 {

--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -836,8 +836,8 @@ static void scsiReset()
 		}
 		scsiDev.target->reservedId = -1;
 		scsiDev.target->reserverId = -1;
-		S2S_TargetCfg* config = scsiDev.target->cfg;
 #ifdef PLATFORM_AS400
+		const S2S_TargetCfg* config = scsiDev.target->cfg;
 		if (config->quirks == S2S_CFG_QUIRKS_AS400 && config->deviceType == S2S_CFG_FIXED)
 		{
 			scsiDev.target->sense.code = UNIT_ATTENTION;

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -287,6 +287,7 @@ int controlListImages(uint8_t scsi_id,
     FsFile entry;
     while (entry.openNext(&dir, O_RDONLY))
     {
+	int ret = 0;
         if (!entry.getName(name, sizeof(name)) || entry.isHidden())
         {
             entry.close();
@@ -301,9 +302,18 @@ int controlListImages(uint8_t scsi_id,
             continue;
 
         if (root_dir)
-            snprintf(full_path, sizeof(full_path), "/%s", name);
-        else
-            snprintf(full_path, sizeof(full_path), "%s/%s", imgdir, name);
+            ret = snprintf(full_path, sizeof(full_path), "/%s", name);
+	else
+            ret = snprintf(full_path, sizeof(full_path), "%s/%s", imgdir, name);
+        if (ret >= sizeof(full_path)) {
+            /*
+             * Note: this may log an extra / but it saves two strings in the
+             * firmware image.  Sufficient C ternary operations can fix this
+             * if needed (or just log two separate strings.)
+             */
+            logmsg("Warning: full path %s/%s is too long!", imgdir, name);
+            continue;
+        }
 
         if (is_dir)
         {

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
@@ -267,7 +267,7 @@ static void handle_client_message(uint8_t cmd, const uint8_t *payload, uint16_t 
             g_subscribed = true;
             send_status_json();
             {
-                uint8_t sd_payload[1] = {g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT};
+                uint8_t sd_payload[1] = {(uint8_t) (g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT)};
                 webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
             }
             send_all_filenames();
@@ -716,7 +716,6 @@ void zuluWebUITask()
                 bool major_version_match = false;
                 if (client_ver[0] != '\0')
                 {
-                    unsigned long local_major_version;
                     char* period_location = strchr(client_ver, '.');
                     if (period_location != NULL)
                     {
@@ -845,7 +844,7 @@ void zuluWebUITask()
             if (g_subscribed && elapsed(g_last_status_ms, STATUS_INTERVAL_MS))
             {
                 send_status_json();
-                uint8_t sd_payload[1] = {g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT};
+                uint8_t sd_payload[1] = {(uint8_t) (g_sd_ready ? I2C_SERVER_SD_PRESENT : I2C_SERVER_SD_NOT_PRESENT)};
                 webuiI2CSend(I2C_SERVER_SD_STATUS_CHANGE, sd_payload, 1);
                 g_last_status_ms = ms_now();
             }

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -1469,9 +1469,24 @@ const uint8_t* platform_get_8byte_mcu_id()
     return mcu_id;
 }
 
-uint8_t platform_get_buttons()
+#if defined(ENABLE_AUDIO_OUTPUT_SPDIF) || defined(GPIO_I2C_SDA)
+static void
+platform_init_buttons()
 {
     static bool init_buttons = false;
+
+    if (!init_buttons) {
+        // SDA = button 1, SCL = button 2
+        init_buttons = true;
+        //        pin             function       pup   pdown  out    state  fast
+        gpio_conf(GPIO_I2C_SDA,   GPIO_FUNC_SIO, true, false, false, false, false);
+        gpio_conf(GPIO_I2C_SCL,   GPIO_FUNC_SIO, true, false, false, false, false);
+    }
+}
+#endif
+
+uint8_t platform_get_buttons()
+{
     uint8_t buttons = 0;
 
 #if defined(ENABLE_AUDIO_OUTPUT_SPDIF)
@@ -1481,13 +1496,7 @@ uint8_t platform_get_buttons()
     }
     else if (!g_i2c_claimed)
     {
-        if (!init_buttons)
-        {
-            init_buttons = true;
-            //        pin             function       pup   pdown  out    state  fast
-            gpio_conf(GPIO_I2C_SDA,   GPIO_FUNC_SIO, true, false, false, false, false);
-            gpio_conf(GPIO_I2C_SCL,   GPIO_FUNC_SIO, true, false, false, false, false);
-        }
+        platform_init_buttons();
         // SDA = button 1, SCL = button 2
         if (!gpio_get(GPIO_I2C_SDA)) buttons |= 1;
         if (!gpio_get(GPIO_I2C_SCL)) buttons |= 2;
@@ -1498,14 +1507,7 @@ uint8_t platform_get_buttons()
 #elif defined(GPIO_I2C_SDA)
     if (!g_i2c_claimed)
     {
-            if (!init_buttons)
-            {
-                init_buttons = true;
-                //        pin             function       pup   pdown  out    state  fast
-                gpio_conf(GPIO_I2C_SDA,   GPIO_FUNC_SIO, true, false, false, false, false);
-                gpio_conf(GPIO_I2C_SCL,   GPIO_FUNC_SIO, true, false, false, false, false);
-            }
-            // SDA = button 1, SCL = button 2
+        platform_init_buttons();
         // SDA = button 1, SCL = button 2
         if (!gpio_get(GPIO_I2C_SDA)) buttons |= 1;
         if (!gpio_get(GPIO_I2C_SCL)) buttons |= 2;

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1183,7 +1183,8 @@ static void reinitSCSI()
     }
     else
     {
-      snprintf(raw_filename, sizeof(raw_filename), "RAW:0x%X:0x%X", start, end);
+      snprintf(raw_filename, sizeof(raw_filename), "RAW:0x%lX:0x%lX",
+        (unsigned long int) start, (unsigned long int) end);
     }
 
     success = scsiDiskOpenHDDImage(scsiId, raw_filename, 0,

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -521,7 +521,16 @@ bool createImageFile(char *imgname, uint64_t size)
     if (file.truncate(size))
     {
       logmsg("---- Successfully recovered raw image without vhd footer, write speed was ", kb_per_s, " kB/s");
-      strncpy(imgname + namelen - 3, "raw", 3);
+      /*
+       * Replace the last three bytes of the image name with 'raw'.
+       * Yes, this assumes the string is at least 3 bytes long -and-
+       * its a DOS style file extension.  We really should be checking
+       * things here and handling overly short image names.
+       *
+       * Using strncpy() annoys the compiler because it really wants
+       * to copy the NUL pointer at the end.
+       */
+      memcpy(imgname + namelen - 3, "raw", 3);
       if (file.rename(imgname))
       {
         logmsg("---- Renamed image to \"", imgname, "\" to indicated the image is raw and doesn't contain a VHD footer");

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -4294,6 +4294,7 @@ void cdromLoadImage(image_config_t &img, const char* next_filename)
     }
 }
 
+#if defined(CONTROL_BOARD)
 // Eject and switch image
 static void genericLoadImage(image_config_t &img, const char* next_filename)
 {
@@ -4311,7 +4312,9 @@ static void genericLoadImage(image_config_t &img, const char* next_filename)
         scsiDiskCloseTray(img);
     }
 }
+#endif
 
+#if defined(CONTROL_BOARD)
 static void loadImageToggleEject(uint8_t id, const char* next_filename)
 {
     image_config_t &img = g_DiskImages[id];
@@ -4332,6 +4335,7 @@ static void loadImageToggleEject(uint8_t id, const char* next_filename)
         genericLoadImage(img, next_filename);
     }
 }
+#endif
 
 
 // TODO This forces a swap, the logic should use the deffered pattern

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -168,7 +168,6 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
 {
     bool loaded_default_data = false;
 
-    const S2S_TargetCfg *config = scsiDev.targets[scsiId].cfg;
     if (!((g_scsi_settings.getSystem()->quirks & S2S_CFG_QUIRKS_AS400) && type== S2S_CFG_FIXED))
         return;
 


### PR DESCRIPTION
Here's (i hope!) a set of warnings cleanup that doesn't break any functionality.

Most are straight up warnings cleanups (like typecasting where required for printf, etc) but a couple of things (like assembling file paths) were potentially going to overflow a buffer and in that case I figured erroring out was better than partially assembling a path.

For now it's been compile tested. I'll test on a couple of physical devices shortly.