### PR TITLE
Log and report when log-rotation directory creation fails

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -159,7 +159,11 @@ void init_logfile()
         FsFile log_dir = SD.open(LOGFILEDIR, O_RDWR);
         if (!log_dir.isOpen())
         {
-          SD.mkdir(LOGFILEDIR);
+          if (!SD.mkdir(LOGFILEDIR))
+          {
+            logmsg("Log rotation could not create directory ", LOGFILEDIR,
+                   ", sdErrorCode: ", (int)SD.sdErrorCode());
+          }
           log_dir = SD.open(LOGFILEDIR);
         }
 


### PR DESCRIPTION
init_logfile()'s LogRotate=2 path (permanent numbered log archive in zuluscsi_log/) silently ignored SD.mkdir(LOGFILEDIR)'s return value. If mkdir failed for any reason, the code fell through to opening a directory that was never created, landing in the existing "Log rotation could not open ... as a directory" branch further down with no indication of what actually went wrong - and that message itself is only as durable as the rotation this failure is preventing, so it could be lost along with everything else.

Now logs the SD error code at the point of failure, so a user hitting a genuine mkdir failure has something actionable instead of silent, unexplained data loss across power cycles, rather than having to guess from a directory that just never appeared.

Not a fix for a confirmed real-world mkdir failure - the original report that prompted this turned out to be an invalid LogRotate value (5, only 0/1/2 are valid) silently skipping the whole code path, not mkdir() itself failing; the config already logs "LogRotate = 5: invalid" on its own. This is a defensive improvement for the case mkdir() does fail, so that scenario doesn't repeat the same silent-failure pattern.