### PR TITLE
Log via USB while SD card is removed and fix control board on SD card insert

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1794,49 +1794,37 @@ extern "C" void zuluscsi_main_loop(void)
     }
   }
 
-  if (!g_sdcard_present && (uint32_t)(millis() - sd_card_check_time) > SDCARD_POLL_INTERVAL
-      && !g_msc_initiator)
-  {
-    sd_card_check_time = millis();
-
+  if (!g_sdcard_present && !g_msc_initiator)
+  { 
     // Try to remount SD card
-    do
+    if ((uint32_t)(millis() - sd_card_check_time) > SDCARD_POLL_INSERT_INTERVAL)
     {
       g_sdcard_present = mountSDCard();
+      sd_card_check_time = millis();
+    }
 
-      if (g_sdcard_present)
+    if (g_sdcard_present)
+    {
+      blink_cancel();
+      LED_OFF();
+      logmsg("SD card reinit succeeded");
+      print_sd_info();
+      reinitSCSI();
+      init_logfile();
+      init_eject_button();
+      blinkStatus(BLINK_STATUS_OK);
+      if (g_displayEnabled)
       {
-        blink_cancel();
-        LED_OFF();
-        logmsg("SD card reinit succeeded");
-        print_sd_info();
-        reinitSCSI();
-        init_logfile();
-        init_eject_button();
-        blinkStatus(BLINK_STATUS_OK);
-        if (g_displayEnabled)
-        {
-          sdCardStateChanged(g_sdcard_present, g_romdrive_active);
-        }
+        sdCardStateChanged(g_sdcard_present, g_romdrive_active);
+      }
 #ifdef ZULUCONTROL_FIRMWARE
-        zuluWebUINotifySDCardReady();
+      zuluWebUINotifySDCardReady();
 #endif
-      }
-      else if (!g_romdrive_active)
-      {
-        blinkStatus(BLINK_ERROR_NO_SD_CARD);
-        platform_reset_watchdog();
-        platform_poll();
-        if (g_displayEnabled)
-        {
-          uint32_t input_wait_start = millis();
-          while (scsiDev.phase == BUS_FREE && (uint32_t)(millis() - input_wait_start) < 500)
-          {
-              controlLoop();
-          }
-        }
-      }
-    } while (!g_sdcard_present && !g_romdrive_active && !is_initiator && !g_rebooting);
+    }
+    else if (!g_romdrive_active)
+    {
+      blinkStatus(BLINK_ERROR_NO_SD_CARD);
+    }
   }
 }
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1809,14 +1809,14 @@ extern "C" void zuluscsi_main_loop(void)
       LED_OFF();
       logmsg("SD card reinit succeeded");
       print_sd_info();
-      reinitSCSI();
-      init_logfile();
-      init_eject_button();
-      blinkStatus(BLINK_STATUS_OK);
       if (g_displayEnabled)
       {
         sdCardStateChanged(g_sdcard_present, g_romdrive_active);
       }
+      reinitSCSI();
+      init_logfile();
+      init_eject_button();
+      blinkStatus(BLINK_STATUS_OK);
 #ifdef ZULUCONTROL_FIRMWARE
       zuluWebUINotifySDCardReady();
 #endif

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -79,6 +79,9 @@
 // How often to check for SD card presence
 #define SDCARD_POLL_INTERVAL 5000
 
+// How often to check an empty SD card for insert
+#define SDCARD_POLL_INSERT_INTERVAL 1500
+
 // How often to attempt WiFi reconnection after link loss (ms)
 #define WIFI_RECONNECT_START_INTERVAL 5000
 #define WIFI_RECONECT_MAX_INTERVAL 15000


### PR DESCRIPTION
It looks like servicing and logging SCSI commands wasn't happening while the SD card is removed. This simplifies the main loop by getting rid of the do/while loop for reinsertion polling and using the main loop to exercise all the subsystem polling as usual. It also adds a timer for checking the SD card for reinsertion so the Control Board polling has a chance to be responsive without need an exclusive loop for checking state of the rotary and buttons.

The interface for the Control Board over the I2C interface stopped working when the SD card was reinserted. This switches position in the main loop for issuing a state change to Control Board to before the reinit of the SCSI interface so clearing the Control Board occurs before reinit repopulates the devices.