### PR TITLE
Apply initiator wait-for-bus-free drain patch

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/scsiHostPhy.cpp
@@ -411,9 +411,11 @@ void scsiHostWaitBusFree()
     // Wait for the target to release BSY signal.
     // If the target is expecting more data, transfer dummy bytes.
     // This happens for some reason with READ6 command on IBM H3171-S2.
+    // A dead target holds BSY and REQ forever, so both loops need the deadline
+    // and the watchdog reset request or the drain below never returns.
     uint32_t start = millis();
     int extra_bytes = 0;
-    while (SCSI_IN(BSY))
+    while (SCSI_IN(BSY) && !g_scsiHostPhyReset)
     {
         platform_poll();
 
@@ -424,7 +426,8 @@ void scsiHostWaitBusFree()
              SCSI_OUT(BSY, 1);
              sleep_us(1);
 
-             while (SCSI_IN(REQ))
+             while (SCSI_IN(REQ) && !g_scsiHostPhyReset &&
+                    (uint32_t)(millis() - start) <= 10000)
              {
                 scsiHostReadOneByte(nullptr);
                 extra_bytes++;

--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -410,9 +410,7 @@ void scsiInitiatorMainLoop()
             }
             else
             {
-#ifndef ZULUSCSI_NETWORK
                 dbgmsg("Failed to connect to SCSI ID ", g_initiator_state.target_id);
-#endif
                 g_initiator_state.sectorsize = 0;
                 g_initiator_state.sectorcount = g_initiator_state.sectorcount_all = 0;
             }
@@ -764,9 +762,7 @@ int scsiInitiatorRunCommand(int target_id,
 
     if (!scsiHostPhySelect(target_id, g_initiator_state.initiator_id))
     {
-#ifndef ZULUSCSI_NETWORK
         dbgmsg("------ Target ", target_id, " did not respond");
-#endif
         scsiHostPhyRelease();
         return -1;
     }
@@ -848,9 +844,7 @@ int scsiInitiatorRunCommand(int target_id,
             uint8_t tmp = -1;
             scsiHostRead(&tmp, 1);
             status = tmp;
-#ifndef ZULUSCSI_NETWORK
             dbgmsg("------ STATUS: ", tmp);
-#endif
         }
     }
 


### PR DESCRIPTION
Rewrite and apply this patch
https://github.com/BlueSCSI/BlueSCSI-v2/commit/eb88adc4c37d9398a829bd7613f0696a4edb18c3.patch

From commit:
```
initiator: bound the wait-for-bus-free drain

Regression since https://github.com/ZuluSCSI/ZuluSCSI-firmware/commit/5d06c5885ff6cc6c478d8b54a1cc2e2e1d6230c8
also adds back the initiator scan dbgmsgs on DaynaPORT.
```