### PR TITLE
Add AS/400 disk profile loader with multi-DASD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ For AS/400 `AS400_DiskProfile=` SCSI IDs (see below), a correctly-sized image is
 
 AS/400 disk profiles
 ---------------------
-For AS/400 (`System = "AS400_PPC"` or `"AS400_CISC"`), multiple SCSI IDs can each emulate a different real DASD unit by setting `AS400_DiskProfile = "<name>"` in that ID's `[SCSIn]` section, naming a section captured by `utils/extract_as400_disk_data.sh` into `as400_disk_definitions.txt` on the SD card.
+For AS/400 (`System = "AS400_PPC"` or `"AS400_CISC"`), multiple SCSI IDs can each emulate a different real DASD unit by setting `AS400_DiskProfile = "<name>"` in that ID's `[SCSIn]` section, naming a profile from `as400_disk_definitions.txt` on the SD card.
+
+To capture a profile from a real AS/400 disk, connect it to a Linux machine with `sg3_utils` installed and run [`utils/extract_as400_disk_data.sh`](utils/extract_as400_disk_data.sh):
+
+```
+./extract_as400_disk_data.sh /dev/sgN [Label] [outfile]
+```
+
+This appends one `[Label]` section to `as400_disk_definitions.txt` (or auto-derives the label from the drive's own FRU/part number if omitted) with its real INQUIRY, VPD, MODE SENSE, and capacity data. Copy the resulting file to the SD card root.
 
 If no image file exists yet for a profiled ID, one is created automatically at the profile's real captured size — see "Creating new image files" above.
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ For AS/400 `AS400_DiskProfile=` SCSI IDs (see below), a correctly-sized image is
 
 AS/400 disk profiles
 ---------------------
-For AS/400 (`System = "AS400_PPC"` or `"AS400_CISC"`), multiple SCSI IDs can each emulate a different real DASD unit by setting `AS400_DiskProfile = "<name>"` in that ID's `[SCSIn]` section, naming a profile from `as400_disk_definitions.txt` on the SD card.
+For AS/400 (`System = "AS400_PPC"` or `"AS400_CISC"`), multiple SCSI IDs can each emulate a different real DASD unit by setting `AS400_DiskProfile = "<name>"` in that ID's `[SCSIn]` section, naming a profile from [`as400_disk_definitions.txt`](as400_disk_definitions.txt) — copy it to the SD card root.
 
-To capture a profile from a real AS/400 disk, connect it to a Linux machine with `sg3_utils` installed and run [`utils/extract_as400_disk_data.sh`](utils/extract_as400_disk_data.sh):
+This ships with real profiles already captured from several physical drives, so it's usable even without any AS/400 DASD hardware on hand. Capturing your own is optional, for drives not already in the list: connect one to a Linux machine with `sg3_utils` installed and run [`utils/extract_as400_disk_data.sh`](utils/extract_as400_disk_data.sh):
 
 ```
 ./extract_as400_disk_data.sh /dev/sgN [Label] [outfile]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ The special filename must start with "Create" and be followed by file size and t
 The file will be created next time the SD card is inserted.
 The status LED will flash rapidly while image file generation is in progress.
 
+For AS/400 `AS400_DiskProfile=` SCSI IDs (see below), a correctly-sized image is created automatically the same way, with no `Create*.txt` file needed — the size comes from the profile's own captured capacity.
+
+AS/400 disk profiles
+---------------------
+For AS/400 (`System = "AS400_PPC"` or `"AS400_CISC"`), multiple SCSI IDs can each emulate a different real DASD unit by setting `AS400_DiskProfile = "<name>"` in that ID's `[SCSIn]` section, naming a section captured by `utils/extract_as400_disk_data.sh` into `as400_disk_definitions.txt` on the SD card.
+
+If no image file exists yet for a profiled ID, one is created automatically at the profile's real captured size — see "Creating new image files" above.
+
+Each profiled ID gets that drive's real INQUIRY/VPD/MODE SENSE identity. Using the **same** profile for more than one SCSI ID currently gives them identical serial numbers, with no way to override this yet — use a different profile per ID until this is resolved.
+
 Log files and error indications
 -------------------------------
 Log messages are stored in `zululog.txt`, which is cleared on every boot.

--- a/as400_disk_definitions.txt
+++ b/as400_disk_definitions.txt
@@ -329,6 +329,7 @@ LogSense30PageListLength = 20
 LogSense31 = 00 00 00 00
 LogSense31PageLength = 0
 
+
 [45G9463]
 Vendor = IBMAS400
 Product = 0662S12
@@ -354,6 +355,44 @@ VPD02 = 00 02 00 2f 18 34 35 47 39 38 35 31 20 20 20 20 20 00 38 39 35 39 36 33 
 VPD03 = 00 03 00 14 30 00 00 00 a0 90 06 18 00 01 01 b0 00 00 00 00 00 00 00 00
 VPD80 = 00 80 00 10 20 20 20 20 20 20 20 20 30 30 31 37 35 39 39 35
 VPD82 = 00 82 00 30 19 30 36 36 32 00 53 31 32 00 30 30 31 37 35 39 39 35 00 49 42 4d 20 20 20 00 f0 f6 f6 f2 e2 f1 f2 00 f0 f0 f1 f7 f5 f9 f9 f5 c9 c2 d4 40 40 40
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = a3 00 10 08 00 1e d0 66 00 00 02 08 81 0a 04 01 30 00 00 00 01 00 00 00 82 0e 00 00 00 00 00 00 00 00 00 19 00 00 00 00 03 16 00 05 00 10 00 00 00 00 00 6a 02 08 00 01 00 08 00 10 40 00 00 00 84 16 00 10 17 05 00 00 00 00 00 00 00 00 00 10 ef 00 00 00 15 18 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 01 ff ff 00 00 ff ff ff ff 00 08 00 00 00 00 00 00 8a 06 00 00 00 00 00 00 8c 16 80 00 00 02 00 00 00 00 0e 00
+ModeSense3F_1 = 00 10 25 04 00 00 00 00 00 00 10 0c 80 0a 80 80 08 10 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 05 00 30 32 33 35
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[45G9463-1]
+Vendor = IBMAS400
+Product = 0662S12
+Revision = 101B
+BlockSize = 520
+Sectors = 2019430
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=4119 heads=5 sectors/track=106 (block size per descriptor: 520)
+; => implied capacity 2183070 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 02 02 9f 00 00 1e 49 42 4d 41 53 34 30 30 30 36 36 32 53 31 32 20 20 20 20 20 20 20 20 20 31 30 31 42 30 30 30 35 38 38 38 34 39 39 46 39 38 32 30 20 20 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 39 32 35 39 34 31 35 32 20 30 30 30 32 32 32 34 35 47 39 34 36 33 20 20 20 20 20 38 39 35 39 38 35 20 20 20 20 34 35 47 39
+SPD_1 = 38 39 39 20 20 20 20 20 38 39 35 39 37 34 20 20 20 20 00 00 00 00 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD01 = 00 01 00 2f 18 34 35 47 39 34 36 33 20 20 20 20 20 00 38 39 35 39 38 35 20 20 20 20 00 f4 f5 c7 f9 f4 f6 f3 40 40 40 40 40 f8 f9 f5 f9 f8 f5 40 40 40 40
+VPD02 = 00 02 00 2f 18 34 35 47 39 38 39 39 20 20 20 20 20 00 38 39 35 39 37 34 20 20 20 20 00 f4 f5 c7 f9 f8 f9 f9 40 40 40 40 40 f8 f9 f5 f9 f7 f4 40 40 40 40
+VPD03 = 00 03 00 14 30 00 00 00 a0 90 06 18 00 01 01 b0 00 00 00 00 00 00 00 00
+VPD80 = 00 80 00 10 20 20 20 20 20 20 20 20 30 30 30 35 38 38 38 34
+VPD82 = 00 82 00 30 19 30 36 36 32 00 53 31 32 00 30 30 30 35 38 38 38 34 00 49 42 4d 20 20 20 00 f0 f6 f6 f2 e2 f1 f2 00 f0 f0 f0 f5 f8 f8 f8 f4 c9 c2 d4 40 40 40
 
 ; --- MODE SENSE(6), page 0x3F (all pages) ---
 ModeSense3F_0 = a3 00 10 08 00 1e d0 66 00 00 02 08 81 0a 04 01 30 00 00 00 01 00 00 00 82 0e 00 00 00 00 00 00 00 00 00 19 00 00 00 00 03 16 00 05 00 10 00 00 00 00 00 6a 02 08 00 01 00 08 00 10 40 00 00 00 84 16 00 10 17 05 00 00 00 00 00 00 00 00 00 10 ef 00 00 00 15 18 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 01 ff ff 00 00 ff ff ff ff 00 08 00 00 00 00 00 00 8a 06 00 00 00 00 00 00 8c 16 80 00 00 02 00 00 00 00 0e 00

--- a/as400_disk_definitions.txt
+++ b/as400_disk_definitions.txt
@@ -1,0 +1,411 @@
+[59H7001]
+Vendor = IBMAS400
+Product = DFHSS4W
+Revision = 03B8
+Feature = #6607
+BlockSize = 522
+Sectors = 8379886
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=8143 heads=5 sectors/track=270 (block size per descriptor: 522)
+; => implied capacity 10993050 sectors. Compare against Sectors= below (from READ CAPACITY)
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 46 48 53 53 34 57 20 20 20 20 20 20 20 20 20 30 33 42 38 30 30 30 32 42 35 36 31 47 35 34 53 41 34 33 42 38 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 30 36 38 39 38 32 36 36 00 30 30 30 31 32 32 35 39 48 37 30 30 31 20 20 20 20 20 45 33 31 37 37 34 20 20 20 20 51 35 39 48
+SPD_1 = 37 31 34 38 42 30 32 00 45 33 31 37 37 37 20 20 20 20 31 39 39 38 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 08 00 01 03 80 82 83 d1 d2
+VPD01 = 00 01 00 2f 18 35 39 48 37 30 30 31 20 20 20 20 20 00 45 33 31 37 37 34 20 20 20 20 00 f5 f9 c8 f7 f0 f0 f1 40 40 40 40 40 c5 f3 f1 f7 f7 f4 40 40 40 40
+VPD03 = 00 03 00 24 00 00 00 00 a0 90 06 1d 00 01 03 b8 00 00 00 00 00 00 00 00 34 53 41 34 33 42 38 20 20 20 20 20 31 35 30 43
+VPD80 = 00 80 00 10 20 20 20 20 20 20 30 30 30 32 42 35 36 31 47 35
+VPD82 = 00 82 00 30 19 44 47 48 53 00 30 34 55 00 30 30 30 32 42 35 36 31 00 49 42 4d 20 20 20 00 c4 c7 c8 e2 f0 f4 e4 00 f0 f0 f0 f2 c2 f5 f6 f1 c9 c2 d4 40 40 40
+VPD83 = 00 83 00 32 02 01 00 22 49 42 4d 41 53 34 30 30 44 47 48 53 20 20 20 20 20 20 20 20 20 20 20 20 36 38 30 32 42 35 36 31 47 35 01 02 00 08 00 60 94 87 20 02 b5 61
+VPDD1 = 00 d1 00 50 49 42 4d 52 57 38 32 36 35 20 20 20 20 20 20 20 4d 4e 4e 32 4b 51 54 20 20 20 20 20 20 20 20 20 58 48 54 35 38 59 47 20 20 20 20 20 20 20 20 20 41 47 44 33 51 38 4d 20 20 20 20 20 20 20 20 20 36 38 30 32 42 35 36 31 47 35 20 20 20 20 20 20
+VPDD2 = 00 d2 00 20 56 4a 42 33 37 38 31 30 34 35 20 20 20 20 20 20 51 35 39 48 37 31 34 38 42 30 32 00 20 20 20 20
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = d3 00 10 08 00 7f dd ee 00 00 02 0a 81 0a c4 01 90 00 00 00 00 00 00 00 82 0e 90 80 00 00 00 00 00 00 00 30 08 00 00 00 83 16 00 05 00 02 00 00 00 00 01 0e 02 0a 00 01 00 1b 00 45 40 00 00 00 84 16 00 1f cf 05 00 00 00 00 00 00 00 00 00 20 ac 00 00 00 1c 20 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 11 ff ff 00 00 ff ff ff ff 00 08 4a 54 00 00 00 00 89 0e 00 00 00 00 00 00 00 00 00 00 00 00 01 00 8a 0a 00 00
+ModeSense3F_1 = 00 00 00 00 00 00 00 00 8c 16 80 00 00 10 00 00 00 00 13 00 00 1f e1 04 00 00 00 00 00 00 10 0c 9a 0a 00 02 00 00 00 00 00 00 00 00 9c 0a 01 0f ff ff ff ff 00 00 00 00 80 0e 80 a0 03 10 00 00 00 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0b 00 01 02 03 05 06 30 32 33 35 36
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[59H6611]
+Vendor = IBMAS400
+Product = DCHS09W
+Revision = 03B7
+Feature = #6713
+BlockSize = 522
+Sectors = 17177940
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=8152 heads=10 sectors/track=270 (block size per descriptor: 522)
+; => implied capacity 22010400 sectors. Compare against Sectors= below (from READ CAPACITY)
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 43 48 53 30 39 57 20 20 20 20 20 20 20 20 20 30 33 42 37 30 30 32 41 32 42 39 30 47 41 47 53 50 41 34 33 42 37 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 30 36 38 39 39 32 36 36 34 30 30 30 31 32 32 35 39 48 36 36 31 31 20 20 20 20 20 46 32 35 32 30 35 20 20 20 20 51 35 39 48
+SPD_1 = 37 31 34 38 41 30 34 00 45 33 31 37 37 37 20 20 20 20 31 39 39 39 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 08 00 01 03 80 82 83 d1 d2
+VPD01 = 00 01 00 2f 18 35 39 48 36 36 31 31 20 20 20 20 20 00 46 32 35 32 30 35 20 20 20 20 00 f5 f9 c8 f6 f6 f1 f1 40 40 40 40 40 c6 f2 f5 f2 f0 f5 40 40 40 40
+VPD03 = 00 03 00 24 00 00 00 00 a0 90 06 1b 00 01 03 b7 00 00 00 00 00 00 00 00 47 53 50 41 34 33 42 37 20 20 20 20 33 34 35 38
+VPD80 = 00 80 00 10 20 20 20 20 20 20 30 30 32 41 32 42 39 30 47 41
+VPD82 = 00 82 00 30 19 44 47 48 53 00 30 39 55 00 30 30 32 41 32 42 39 30 00 49 42 4d 20 20 20 00 c4 c7 c8 e2 f0 f9 e4 00 f0 f0 f2 c1 f2 c2 f9 f0 c9 c2 d4 40 40 40
+VPD83 = 00 83 00 32 02 01 00 22 49 42 4d 41 53 34 30 30 44 47 48 53 20 20 20 20 20 20 20 20 20 20 20 20 36 38 32 41 32 42 39 30 47 41 01 02 00 08 00 60 94 87 2a 2a 2b 90
+VPDD1 = 00 d1 00 50 49 42 4d 53 4a 39 32 36 35 20 20 20 20 20 20 20 4d 47 4e 39 55 34 47 20 20 20 20 20 20 20 20 20 58 48 58 4b 48 4b 4a 20 20 20 20 20 20 20 20 20 41 48 43 42 55 37 37 20 20 20 20 20 20 20 20 20 36 38 32 41 32 42 39 30 47 41 20 20 20 20 20 20
+VPDD2 = 00 d2 00 20 56 4a 41 33 38 39 31 31 35 31 20 20 20 20 20 20 51 35 39 48 37 31 34 38 41 30 34 00 20 20 20 20
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = d3 00 10 08 00 ff ff ff 00 00 02 0a 81 0a c4 01 90 00 00 00 00 00 00 00 82 0e 90 80 00 00 00 00 00 00 00 30 08 00 00 00 83 16 00 0a 00 02 00 00 00 00 01 0e 02 0a 00 01 00 1b 00 45 40 00 00 00 84 16 00 1f d8 0a 00 00 00 00 00 00 00 00 00 20 ac 00 00 00 1c 20 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 11 ff ff 00 00 ff ff ff ff 00 10 a5 2a 00 00 00 00 89 0e 00 00 00 00 00 00 00 00 00 00 00 00 01 00 8a 0a 00 00
+ModeSense3F_1 = 00 00 00 00 00 00 00 00 8c 16 80 00 00 10 00 00 00 00 0a 00 00 1f e1 09 00 00 00 00 00 00 10 0c 9a 0a 00 02 00 00 00 00 00 00 00 00 9c 0a 01 0f ff ff ff ff 00 00 00 00 80 0e 80 a0 00 10 00 00 00 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0b 00 01 02 03 05 06 30 32 33 35 36
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[34L2279]
+Vendor = IBMAS400
+Product = DGVS09U
+Revision = 1644
+Feature = #6717
+BlockSize = 522
+Sectors = 17177940
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=29550 heads=2 sectors/track=585 (block size per descriptor: 522)
+; => implied capacity 34573500 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 12 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 47 56 53 30 39 55 20 20 20 20 20 20 20 20 20 31 36 34 34 30 30 30 35 44 39 34 38 30 31 31 38 31 36 34 34 20 20 20 20 0c 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 30 30 30 32 30 32 30 31 38 37 31 41 30 31 32 32 32 31 50 36 38 35 37 20 20 20 20 20 48 36 32 36 30 38 20 20 20 20 32 31 50 36
+SPD_1 = 38 35 37 20 20 20 20 20 48 36 32 36 30 38 20 20 20 20 00 00 00 00 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 0d 00 03 80 81 c0 c1 c2 c3 c4 c7 c8 d1 d2
+VPD03 = 00 03 00 24 00 00 00 00 a1 70 02 b4 00 01 34 34 00 00 00 00 00 00 00 00 20 20 20 20 20 20 20 20 20 20 20 20 00 00 00 00
+VPD80 = 00 80 00 14 33 4a 4b 50 5a 4d 30 4b 30 30 30 30 32 32 34 37 33 4a 50 39
+VPD81 = 00 81 00 03 04 84 84
+VPDC0 = 00 c0 00 38 30 31 31 38 31 36 34 34 32 30 30 32 44 41 34 31 30 30 30 30 30 30 30 30 44 41 34 31 32 30 30 32 32 30 30 32 44 41 34 31 44 41 34 31 32 30 30 32 30 30 30 30 31 32 30 33
+VPDC1 = 00 c1 00 10 30 35 32 30 32 30 30 32 30 31 31 38 32 30 30 32
+VPDC2 = 00 c2 00 02 02 00
+VPDC3_0 = 00 c3 00 f6 03 06 00 53 54 33 31 38 33 30 35 4c 43 20 20 20 20 20 20 03 10 00 9c ac 96 e0 00 00 bd 38 68 18 20 42 d2 10 c0 00 00 40 01 02 00 00 02 c0 40 05 b4 88 05 05 00 90 00 1e 00 1e b0 40 02 01 04 00 00 00 00 04 0f 00 00 00 00 00 00 00 00 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+VPDC3_1 = 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+VPDC3_chunks = 2
+VPDC4 = 00 c4 00 06 30 35 44 39 34 38
+VPDC7 = 00 c7 00 46 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+VPDC8 = 00 c8 00 34 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+VPDD1_0 = 00 d1 00 f0 39 56 38 30 30 36 2d 30 34 31 20 20 20 20 20 20 31 30 30 31 37 33 31 36 36 20 20 20 20 20 20 20 4f 51 57 31 31 36 32 34 30 31 20 20 20 20 20 20 30 32 34 36 35 41 20 20 20 20 20 20 20 20 20 20 33 31 38 33 46 37 35 37 34 39 34 34 36 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 4b 5a 32 34 36 41 34 31 20 20 20 20 20 20 20 20 4b 5a 32 34 36 42 34 31 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20
+VPDD1_1 = 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20
+VPDD1_chunks = 2
+VPDD2_0 = 00 d2 00 f0 32 30 30 32 44 41 34 31 20 20 20 20 20 20 20 20 30 31 31 38 31 36 34 34 20 20 20 20 20 20 20 20 31 30 30 31 32 35 30 37 32 20 20 20 20 20 20 20 4e 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 32 32 34 37 33 4a 50 39 20 20 20 20 20 20 20 20 32 34 37 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20
+VPDD2_1 = 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20
+VPDD2_chunks = 2
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = c3 00 10 08 01 06 1d 54 00 00 02 0a 81 0a c4 0b 00 00 00 00 05 00 ff ff 82 0e 90 80 00 00 00 00 00 00 00 00 78 00 00 00 83 16 0e fc 00 00 00 05 00 00 02 49 02 0a 00 01 00 60 00 5a 40 00 00 00 84 16 00 73 6e 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 27 38 00 00 87 0a 04 0b f0 00 00 00 00 00 ff ff 88 12 00 11 ff ff 00 00 ff ff ff ff 80 18 00 00 00 00 00 00 8a 0a 00 00 00 00 00 00 00 00 00 f9 8c 16 80 00 00 0b 00 00
+ModeSense3F_1 = 00 00 00 00 00 73 6d 01 00 00 00 00 00 00 10 0c 9a 0a 00 00 00 00 00 00 00 00 00 00 9c 0a 00 03 00 00 00 00 00 00 00 01 80 0e 82 a0 00 30 00 00 40 00 00 1c 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0e 00 02 03 05 06 0d 0f 10 30 31 37 3a 3d 3e
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 31 00 00 24 00 01 01 06 32 30 30 32 32 31 00 02 01 06 32 30 20 20 20 20 00 03 00 04 00 00 27 10 00 04 00 04 00 00 03 1f
+LogSense31PageLength = 36
+
+[9V8006-041]
+Vendor = IBMAS400
+Product = DGVS09U
+Revision = 1340
+Feature = Unknown
+BlockSize = 522
+Sectors = 17177940
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=7049 heads=10 sectors/track=262 (block size per descriptor: 522)
+; => implied capacity 18468380 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 47 56 53 30 39 55 20 20 20 20 20 20 20 20 20 31 33 34 30 30 30 30 39 42 33 38 31 53 41 52 53 50 41 34 30 33 34 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 30 36 38 39 39 33 32 32 32 30 30 30 31 32 32 33 34 4c 32 32 37 39 20 20 20 20 20 46 32 34 38 38 33 20 20 20 20 51 30 39 4c
+SPD_1 = 31 34 33 38 42 30 34 20 45 33 32 30 34 34 20 20 20 20 31 39 39 39 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 08 00 01 03 80 82 83 d1 d2
+VPD01 = 00 01 00 2f 18 33 34 4c 32 32 37 39 20 20 20 20 20 00 46 32 34 38 38 33 20 20 20 20 00 f3 f4 d3 f2 f2 f7 f9 40 40 40 40 40 c6 f2 f4 f8 f8 f3 40 40 40 40
+VPD03 = 00 03 00 24 00 00 00 00 a0 90 06 1e 00 01 13 40 00 00 00 00 00 00 00 00 52 53 50 41 34 30 33 34 20 20 20 20 35 36 35 33
+VPD80 = 00 80 00 10 20 20 20 20 20 20 30 30 30 39 42 33 38 31 53 41
+VPD82 = 00 82 00 30 19 44 52 56 53 00 30 39 44 00 30 30 30 39 42 33 38 31 00 49 42 4d 20 20 20 00 c4 d9 e5 e2 f0 f9 c4 00 f0 f0 f0 f9 c2 f3 f8 f1 c9 c2 d4 40 40 40
+VPD83 = 00 83 00 32 02 01 00 22 49 42 4d 41 53 34 30 30 44 52 56 53 20 20 20 20 20 20 20 20 20 20 20 20 36 38 30 39 42 33 38 31 53 41 01 02 00 08 00 60 94 87 0a 09 b3 81
+VPDD1 = 00 d1 00 50 49 42 4d 52 57 39 33 32 30 20 20 20 20 20 20 20 4d 32 4e 42 57 39 52 20 20 20 20 20 20 20 20 20 58 45 42 42 56 42 45 20 20 20 20 20 20 20 20 20 41 5a 44 39 44 57 59 20 20 20 20 20 20 20 20 20 36 38 30 39 42 33 38 31 53 41 20 20 20 20 20 20
+VPDD2 = 00 d2 00 20 45 41 4b 42 39 42 43 36 35 35 36 20 20 20 20 20 51 30 39 4c 31 34 33 38 42 30 34 20 20 20 20 20
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = d3 00 10 08 00 ff ff ff 00 00 02 0a 81 0a c4 01 90 00 00 00 00 00 00 00 82 0e 90 80 00 00 00 00 00 00 00 00 08 00 00 00 83 16 00 0a 00 02 00 00 00 00 01 06 02 0a 00 01 00 23 00 51 40 00 00 00 84 16 00 1b 89 0a 00 00 00 00 00 00 00 00 00 1c 60 00 00 00 27 24 00 00 87 0a 04 01 48 00 00 00 00 00 00 00 88 12 00 11 ff ff 00 00 ff ff ff ff 00 18 5d 9a 00 00 00 00 89 0e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 8a 0a 00 00
+ModeSense3F_1 = 00 00 00 00 00 00 00 00 8c 16 80 00 00 10 00 00 00 00 0d 00 00 1b 95 09 00 00 00 00 00 00 10 0c 9a 0a 00 02 00 00 00 00 00 00 00 00 9c 0a 00 0f ff ff ff ff 00 00 00 00 80 0e 80 a0 00 10 00 00 00 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0b 00 01 02 03 05 06 30 32 33 35 36
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[86G9124]
+Vendor = IBMAS400
+Product = DFHSS2W
+Revision = 4I4I
+Feature = #6606
+BlockSize = 520
+Sectors = 4204913
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=4390 heads=8 sectors/track=128 (block size per descriptor: 520)
+; => implied capacity 4495360 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 02 02 9f 00 00 3e 49 42 4d 41 53 34 30 30 44 46 48 53 53 32 57 20 20 20 20 20 20 20 20 20 34 49 34 49 30 30 42 45 31 31 38 38 52 41 4d 53 41 30 34 52 20 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 30 36 38 39 37 31 31 33 34 30 30 30 32 32 32 38 36 47 39 31 32 34 20 20 20 20 20 34 38 36 35 30 39 20 20 20 20 32 37 48 30
+SPD_1 = 32 36 32 20 20 20 20 20 34 38 34 35 34 37 20 20 20 20 00 00 00 00 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD01 = 00 01 00 2f 18 38 36 47 39 31 32 34 20 20 20 20 20 00 34 38 36 35 30 39 20 20 20 20 00 f8 f6 c7 f9 f1 f2 f4 40 40 40 40 40 f4 f8 f6 f5 f0 f9 40 40 40 40
+VPD02 = 00 02 00 2f 18 32 37 48 30 32 36 32 20 20 20 20 20 00 34 38 34 35 34 37 20 20 20 20 00 f2 f7 c8 f0 f2 f6 f2 40 40 40 40 40 f4 f8 f4 f5 f4 f7 40 40 40 40
+VPD03 = 00 03 00 24 00 00 00 00 a0 90 06 19 00 01 04 f3 00 00 00 00 00 00 00 00 52 4f 53 53 41 31 34 52 20 20 20 20 30 45 34 38
+VPD80 = 00 80 00 10 20 20 20 20 20 20 20 20 30 30 42 45 31 31 38 38
+VPD82 = 00 82 00 30 19 44 46 48 53 00 53 32 57 00 30 30 42 45 31 31 38 38 00 49 42 4d 20 20 20 00 c4 c6 c8 e2 e2 f2 e6 00 c2 c5 f1 f1 f8 f8 40 40 c9 c2 d4 40 40 40
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = a7 00 10 08 00 40 29 71 00 00 02 08 81 0a c4 01 70 00 00 00 01 00 00 00 82 0e 90 80 00 00 00 00 00 00 00 30 00 00 00 00 03 16 00 08 00 13 00 00 00 00 00 80 02 08 00 01 00 0c 00 1e 40 00 00 00 84 16 00 11 26 08 00 00 00 00 00 00 00 00 00 12 07 00 00 00 1c 20 00 00 87 0a 04 01 30 00 00 00 00 00 00 00 88 12 00 11 ff ff 00 00 ff ff ff ff 00 08 00 00 00 00 00 00 8a 06 00 00 00 00 00 00 8c 16 80 00 00 0a 00 00 00 00 0f 00
+ModeSense3F_1 = 00 11 3d 07 00 00 00 00 00 00 10 0c 80 0e 80 a0 08 10 00 00 00 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0a 00 01 02 03 05 06 30 32 33 35
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[08K0304]
+Vendor = IBMAS400
+Product = DRVS18D
+Revision = S27E
+Feature = #4318
+BlockSize = 522
+Sectors = 34287616
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=36703 heads=2 sectors/track=658 (block size per descriptor: 522)
+; => implied capacity 48301148 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 52 56 53 31 38 44 20 20 20 20 20 20 20 20 20 53 32 37 45 30 30 43 30 44 37 32 31 30 37 4e 34 39 37 31 20 20 20 20 20 0c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 20 20 30 30 36 38 30 32 32 39 36 38 31 41 30 31 32 32 30 38 4b 30 33 30 34 20 20 20 20 20 48 33 32 32 32 34 20 20 20 20 30 37 4e 38
+SPD_1 = 36 35 38 20 20 20 20 20 48 33 32 32 32 33 20 20 20 20 32 30 30 32 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 04 00 03 80 83
+VPD03 = 00 03 00 24 00 00 00 00 a1 70 02 bc 00 01 00 0d 00 00 00 00 00 00 00 00 20 20 20 20 20 20 20 20 20 20 20 20 00 00 00 00
+VPD80 = 00 80 00 10 30 30 30 30 30 30 30 30 45 32 56 31 56 39 4b 42
+VPD83 = 00 83 00 0c 01 03 00 08 50 05 07 67 16 c0 d7 21
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = cb 00 00 08 00 ff ff ff 00 00 02 0a 81 0a c4 01 00 00 00 00 01 00 32 c8 82 0e 90 80 00 00 00 00 00 00 00 00 78 00 00 00 03 16 13 1d 00 00 00 00 00 00 02 92 02 0a 00 01 00 14 00 1b 40 00 00 00 04 16 00 8f 5f 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 27 10 00 00 87 0a 04 01 00 00 00 00 00 00 32 c8 88 12 80 11 ff ff 00 00 ff ff ff ff 40 18 00 00 00 00 00 00 8a 0a 00 00 00 00 00 00 00 00 00 00 8c 16 80 00 00 0f 00 00
+ModeSense3F_1 = 00 00 01 00 00 8f a6 01 00 00 00 00 00 00 10 0c 99 06 00 01 13 88 00 00 9a 0a 00 00 00 00 00 00 00 00 00 00 9c 0a 00 03 00 00 00 00 00 00 00 00 80 0e 80 a0 00 30 00 00 40 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0c 00 02 03 05 06 0d 0e 0f 10 2f 30 3b
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[08K0264]
+Vendor = IBMAS400
+Product = DGVS09U
+Revision = S29B
+Feature = Unknown
+BlockSize = 522
+Sectors = 17177940
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=36703 heads=3 sectors/track=658 (block size per descriptor: 522)
+; => implied capacity 72451722 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 47 56 53 30 39 55 20 20 20 20 20 20 20 20 20 53 32 39 42 30 30 45 32 33 38 30 31 30 37 4e 34 39 37 31 20 20 20 20 20 0c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 20 20 30 30 36 38 30 34 33 33 34 38 31 41 30 31 32 32 30 38 4b 30 32 36 34 20 20 20 20 20 48 33 32 32 32 34 20 20 20 20 30 37 4e 38
+SPD_1 = 36 35 38 20 20 20 20 20 48 33 32 32 32 33 20 20 20 20 32 30 30 34 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 05 00 03 80 83 c4
+VPD03 = 00 03 00 24 00 00 00 00 a1 70 02 c6 00 01 00 11 00 00 00 00 00 00 00 00 20 20 20 20 20 20 20 20 20 20 20 20 00 00 00 00
+VPD80 = 00 80 00 10 30 30 30 30 30 30 30 30 45 33 58 45 38 4b 50 43
+VPD83 = 00 83 00 0c 01 03 00 08 50 05 07 67 17 e2 38 01
+VPDC4 = 00 c4 00 24 20 20 20 20 20 20 20 20 36 38 45 32 33 38 30 31 45 33 58 45 38 4b 50 43 30 38 4b 30 32 39 34 20 20 20 20 20
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = cb 00 00 08 00 ff ff ff 00 00 02 0a 81 0a c4 01 00 00 00 00 01 00 32 c8 82 0e 90 80 00 00 00 00 00 00 00 00 78 00 00 00 03 16 1c ac 00 00 00 00 00 00 02 92 02 0a 00 01 00 14 00 1b 40 00 00 00 04 16 00 8f 5f 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 27 10 00 00 87 0a 04 01 00 00 00 00 00 00 32 c8 88 12 80 11 ff ff 00 00 ff ff ff ff 40 18 00 00 00 00 00 00 8a 0a 00 00 00 00 00 00 00 00 00 00 8c 16 80 00 00 0f 00 00
+ModeSense3F_1 = 00 00 01 00 00 8f a6 02 00 00 00 00 00 00 10 0c 99 06 00 01 13 88 00 00 9a 0a 00 00 00 00 00 00 00 00 00 00 9c 0a 00 03 00 00 00 00 00 00 00 00 80 0e 80 a0 00 30 00 00 40 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 0c 00 02 03 05 06 0d 0e 0f 10 2f 30 3b
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[55F9806]
+Vendor = IBM
+Product = 0663L12
+Revision = s 62
+Feature = Unknown
+BlockSize = 520
+Sectors = 1931265
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=2463 heads=13 sectors/track=65 (block size per descriptor: 520)
+; => implied capacity 2081235 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 02 02 99 00 00 1a 49 42 4d 20 20 20 20 20 30 36 36 33 4c 31 32 20 20 20 20 20 20 20 20 20 73 20 36 32 30 30 30 38 34 34 33 38 36 34 37 35 36 36 38 20 20 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 39 30 32 39 33 33 31 32 20 30 30 30 32 32 32 35 35 46 39 38 30 36 20 20 20 20 20 38 39 39 34 31 32 20 20 20 20 36 34 37 35
+SPD_1 = 36 34 37 20 20 20 20 20 38 39 39 34 30 36 20 20 20 20
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD01 = 00 01 00 2f 18 35 35 46 39 38 30 36 20 20 20 20 20 00 38 39 39 34 31 32 20 20 20 20 00 f5 f5 c6 f9 f8 f0 f6 00 00 00 00 00 f8 f9 f9 f4 f1 f2 40 40 40 40
+VPD02 = 00 02 00 2f 18 36 34 37 35 36 34 37 20 20 20 20 20 00 38 39 39 34 30 36 20 20 20 20 00 f6 f4 f7 f5 f6 f4 f7 40 40 40 40 40 f8 f9 f9 f4 f0 f6 40 40 40 40
+VPD03 = 00 03 00 14 00 00 00 00 a0 90 06 14 00 00 06 20 00 00 00 00 00 00 00 00
+VPD82 = 00 82 00 30 19 30 36 36 33 00 4c 31 32 00 30 30 30 38 34 34 33 38 00 49 42 4d 20 20 20 00 f0 f6 f6 f3 d3 f1 f2 00 f0 f0 f0 f8 f4 f4 f3 f8 c9 c2 d4 00 00 00
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F = 8b 00 10 08 00 1d 78 01 00 00 02 08 81 0a 04 01 30 00 00 00 01 00 00 00 82 0e 90 90 00 00 00 00 00 00 00 19 00 00 00 00 03 16 00 0d 00 00 00 00 00 00 00 41 02 08 00 01 00 04 00 0c 40 00 00 00 84 16 00 09 9f 0d 00 00 00 00 00 00 00 00 00 0a 6c 00 00 00 10 dc 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 01 ff ff 00 00 ff ff ff ff 00 07 00 00 00 00 00 00 8a 06 00 00 00 00 00 00 80 0a 80 80 07 00 00 00 00 00 00 00
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 05 00 30 32 33 35
+LogSense30 = 30 00 00 18 00 00 00 14 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 24
+LogSense30PageListLength = 20
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+[45G9463]
+Vendor = IBMAS400
+Product = 0662S12
+Feature = #6602
+Revision = 101B
+BlockSize = 520
+Sectors = 2019430
+; Decoded from MODE SENSE pages 0x03/0x04: cylinders=4119 heads=5 sectors/track=106 (block size per descriptor: 520)
+; => implied capacity 2183070 sectors. Compare against Sectors= below (from READ CAPACITY) ---
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt.
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 02 02 9f 00 00 1e 49 42 4d 41 53 34 30 30 30 36 36 32 53 31 32 20 20 20 20 20 20 20 20 20 31 30 31 42 30 30 31 37 35 39 39 35 39 39 46 39 38 32 30 20 20 20 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 39 32 35 39 34 30 37 38 20 30 30 30 32 32 32 34 35 47 39 34 36 33 20 20 20 20 20 38 39 35 39 38 35 20 20 20 20 34 35 47 39
+SPD_1 = 38 35 31 20 20 20 20 20 38 39 35 39 36 33 20 20 20 20 00 00 00 00 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD01 = 00 01 00 2f 18 34 35 47 39 34 36 33 20 20 20 20 20 00 38 39 35 39 38 35 20 20 20 20 00 f4 f5 c7 f9 f4 f6 f3 40 40 40 40 40 f8 f9 f5 f9 f8 f5 40 40 40 40
+VPD02 = 00 02 00 2f 18 34 35 47 39 38 35 31 20 20 20 20 20 00 38 39 35 39 36 33 20 20 20 20 00 f4 f5 c7 f9 f8 f5 f1 40 40 40 40 40 f8 f9 f5 f9 f6 f3 40 40 40 40
+VPD03 = 00 03 00 14 30 00 00 00 a0 90 06 18 00 01 01 b0 00 00 00 00 00 00 00 00
+VPD80 = 00 80 00 10 20 20 20 20 20 20 20 20 30 30 31 37 35 39 39 35
+VPD82 = 00 82 00 30 19 30 36 36 32 00 53 31 32 00 30 30 31 37 35 39 39 35 00 49 42 4d 20 20 20 00 f0 f6 f6 f2 e2 f1 f2 00 f0 f0 f1 f7 f5 f9 f9 f5 c9 c2 d4 40 40 40
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = a3 00 10 08 00 1e d0 66 00 00 02 08 81 0a 04 01 30 00 00 00 01 00 00 00 82 0e 00 00 00 00 00 00 00 00 00 19 00 00 00 00 03 16 00 05 00 10 00 00 00 00 00 6a 02 08 00 01 00 08 00 10 40 00 00 00 84 16 00 10 17 05 00 00 00 00 00 00 00 00 00 10 ef 00 00 00 15 18 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 00 01 ff ff 00 00 ff ff ff ff 00 08 00 00 00 00 00 00 8a 06 00 00 00 00 00 00 8c 16 80 00 00 02 00 00 00 00 0e 00
+ModeSense3F_1 = 00 10 25 04 00 00 00 00 00 00 10 0c 80 0a 80 80 08 10 00 00 00 00 00 00
+ModeSense3F_chunks = 2
+
+; --- LOG SENSE pages ---
+LogSense00 = 00 00 00 05 00 30 32 33 35
+LogSense30 = 30 00 00 30 00 00 00 2c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+LogSense30PageLength = 48
+LogSense30PageListLength = 44
+LogSense31 = 00 00 00 00
+LogSense31PageLength = 0
+
+
+; ===========================================================================
+; Fabricated entry: the firmware's built-in 09L4044/DGVS09U profile
+; (src/as400_values.cpp), reproduced byte-for-byte including the same
+; SD-card-CID-derived serial (AA000775, computed for SCSI ID 6, SD Serial
+; 0xAA0001B9) that loadAS400Defaults()'s injectSerial() would apply to it.
+; Built for a controlled test: does AS400_DiskProfile reproduce the exact
+; identity the machine originally installed against? If this profile boots
+; clean, the loader mechanism is confirmed working and the earlier
+; 34L2279-triggered SRC B1934505 was a genuine identity mismatch, not a
+; loader bug. If THIS also fails, something in the loader itself is wrong.
+; This serial is only valid for SCSI ID 6 on this specific SD card - if you
+; test on a different SCSI ID or SD card, the serial injection won't match
+; and the test stops being apples-to-apples.
+; ===========================================================================
+[09L4044]
+Vendor = IBMAS400
+Product = DGVS09U
+Revision = 02A1
+BlockSize = 522
+Sectors = 17177940
+
+; --- Standard INQUIRY (full response) ---
+SPD_0 = 00 00 03 02 9f 00 01 3a 49 42 4d 41 53 34 30 30 44 47 56 53 30 39 55 20 20 20 20 20 20 20 20 20 30 32 41 31 30 30 41 41 30 30 30 37 37 35 4d 53 50 41 34 31 41 31 20 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 30 30 36 38 30 30 30 35 36 33 30 30 30 31 32 32 30 39 4c 34 30 34 34 20 20 20 20 20 46 32 34 34 36 30 20 20 20 20 51 33 34 4c
+SPD_1 = 35 34 33 38 4d 30 33 20 46 32 34 34 35 33 20 20 20 20 32 30 30 30 00 00
+SPD_chunks = 2
+
+; --- VPD pages (space-separated hex bytes, minIni-parseable) ---
+VPD00 = 00 00 00 08 00 01 03 80 82 83 d1 d2
+VPD01 = 00 01 00 2f 18 30 39 4c 34 30 34 34 20 20 20 20 20 00 46 32 34 34 36 30 20 20 20 20 00 f0 f9 d3 f4 f0 f4 f4 40 40 40 40 40 c6 f2 f4 f4 f6 f0 40 40 40 40
+VPD03 = 00 03 00 24 00 00 00 00 a0 90 06 60 00 01 02 a1 00 00 00 00 00 00 00 00 4d 53 50 41 34 32 41 31 20 20 20 20 37 33 32 39
+VPD80 = 00 80 00 10 20 20 20 20 20 20 30 30 41 41 30 30 30 37 37 35
+VPD82 = 00 82 00 30 19 44 4d 56 53 00 30 39 44 00 30 30 41 41 30 30 30 37 37 35 42 4d 20 20 20 00 c4 d4 e5 e2 f0 f9 c4 00 f0 f0 f0 f6 f7 c1 c3 c5 c9 c2 d4 40 40 40
+VPD83 = 00 83 00 32 02 01 00 22 49 42 4d 41 53 34 30 30 44 4d 56 53 20 20 20 20 20 20 20 20 20 20 20 20 46 38 41 41 30 30 30 37 37 35 01 02 00 08 00 60 94 c7 c5 06 7a ce
+VPDD1 = 00 d1 00 50 49 42 4d 52 57 30 30 35 35 20 20 20 20 20 20 20 4d 35 41 4e 30 39 4c 37 38 20 20 20 20 20 20 20 58 53 41 42 30 34 58 47 55 20 20 20 20 20 20 20 41 4c 45 44 30 35 4b 45 4c 20 20 20 20 20 20 20 46 38 41 41 30 30 30 37 37 35 20 20 20 20 20 20
+VPDD2 = 00 d2 00 20 45 43 4c 4d 30 32 47 30 39 37 36 20 20 20 20 20 51 33 34 4c 35 34 33 38 4d 30 33 20 20 20 20 20
+
+; --- MODE SENSE(6), page 0x3F (all pages) ---
+ModeSense3F_0 = db 00 10 08 00 ff ff ff 00 00 02 0a 81 0a c4 01 90 00 00 00 00 00 00 00 82 0e 90 80 00 00 00 00 00 00 00 00 08 00 00 00 83 16 00 05 00 02 00 00 00 00 01 77 02 0a 00 01 00 32 00 71 40 00 00 00 84 16 00 2d cf 05 00 00 00 00 00 00 00 00 00 2e af 00 00 00 27 10 00 00 87 0a 04 01 00 00 00 00 00 00 00 00 88 12 80 11 ff ff 00 00 ff ff ff ff 40 0c 01 22 00 00 00 00 89 0e 00 00 00 00 00 00 00 00 00 00 00 00 01 00 8a 0a 00 00
+ModeSense3F_1 = 00 00 00 00 00 00 00 00 8c 16 80 00 00 0f 00 00 00 00 16 00 00 2d e4 04 00 00 00 00 00 00 10 0c 99 06 00 01 00 00 00 00 9a 0a 00 00 00 00 00 00 00 00 00 00 9c 0a 01 0f ff ff ff ff 00 00 00 00 80 0e 80 a0 00 10 00 00 40 00 00 00 00 00 00 00
+ModeSense3F_chunks = 2

--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -29,6 +29,7 @@
 
 #ifdef PLATFORM_AS400
 #include <as400_values.h>
+#include <custom_vendor_inquiry.h>
 #endif
 
 #include <string.h>
@@ -318,11 +319,21 @@ static void pageIn(int pc, int dataIdx, const uint8_t* pageData, int pageLen)
 static void doModeSense(int sixByteCmd, int dbd, int pc, int pageCode, int allocLength)
 {
 #ifdef PLATFORM_AS400
-	// copy of a raw capture of an AS400 drive
 	if (sixByteCmd && pageCode == 0x3F && scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_AS400 && scsiDev.target->cfg->deviceType == S2S_CFG_FIXED)
 	{
-		scsiDev.dataLen = as400_mode_sense_all_pages_len > allocLength ? allocLength : as400_mode_sense_all_pages_len;
-		memcpy(scsiDev.data, as400_mode_sense_all_pages, scsiDev.dataLen); 
+		// A loaded AS/400 disk profile (see custom_vendor_inquiry.cpp) can
+		// supply its own captured MODE SENSE response; fall back to the
+		// single built-in capture if none is configured for this target.
+		uint16_t customLen = 0;
+		if (getCustomModeSense(scsiDev.target->cfg->scsiId, scsiDev.data, &customLen))
+		{
+			scsiDev.dataLen = customLen > allocLength ? allocLength : customLen;
+		}
+		else
+		{
+			scsiDev.dataLen = as400_mode_sense_all_pages_len > allocLength ? allocLength : as400_mode_sense_all_pages_len;
+			memcpy(scsiDev.data, as400_mode_sense_all_pages, scsiDev.dataLen);
+		}
 		scsiDev.phase = DATA_IN;
 		return;
 	}

--- a/platformio.ini
+++ b/platformio.ini
@@ -208,6 +208,12 @@ build_flags =
 	-DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
     -DZULUCONTROL_FIRMWARE
+    ; Networking + DaynaPORT + audio + UI + logic sniffer leave far less RAM
+    ; headroom than other boards in this 512KB-RAM class; the default
+    ; S2S_MAX_TARGETS*6 sizing (custom_vendor_inquiry.cpp) overflowed here by
+    ; 6516 bytes on real CI. 20 fits with margin below the ~22-entry ceiling
+    ; this board's actual headroom allows.
+    -DMAX_CUSTOM_VPD_ENTRIES=20
 
 [env:ZuluSCSI_Pico_2_DaynaPORT]
 extends = env:ZuluSCSI_RP2MCU

--- a/platformio.ini
+++ b/platformio.ini
@@ -208,12 +208,16 @@ build_flags =
 	-DCONTROL_BOARD
     -DSSD1306_NO_SPLASH
     -DZULUCONTROL_FIRMWARE
-    ; Networking + DaynaPORT + audio + UI + logic sniffer leave far less RAM
-    ; headroom than other boards in this 512KB-RAM class; the default
-    ; S2S_MAX_TARGETS*6 sizing (custom_vendor_inquiry.cpp) overflowed here by
-    ; 6516 bytes on real CI. 20 fits with margin below the ~22-entry ceiling
-    ; this board's actual headroom allows.
-    -DMAX_CUSTOM_VPD_ENTRIES=20
+    ; Networking + DaynaPORT + audio + UI + logic sniffer, plus this PR's
+    ; other new AS/400 static tables (g_custom_modesense, g_as400_profile_info,
+    ; both S2S_MAX_TARGETS-sized), leave far less RAM headroom than other
+    ; boards in this 512KB-RAM class. Two real CI data points (48 entries:
+    ; 6516 bytes over; 20 entries: still 1340 bytes over) put this board's
+    ; true ceiling around 12-13 entries -- not enough to hold even one real
+    ; profile's ~13 VPD pages regardless of tuning. Blaster isn't an
+    ; AS/400-focused board in practice; 8 (S2S_MAX_TARGETS*1) just needs to
+    ; compile, with real margin below the computed ceiling this time.
+    -DMAX_CUSTOM_VPD_ENTRIES=8
 
 [env:ZuluSCSI_Pico_2_DaynaPORT]
 extends = env:ZuluSCSI_RP2MCU

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -582,6 +582,80 @@ bool createImage(const char *cmd_filename, char imgname[MAX_FILE_PATH + 1])
   return true;
 }
 
+#ifdef PLATFORM_AS400
+// Config-driven auto-creation of correctly-sized AS/400 disk images.
+// findHDDImages()'s main scan below is entirely file-driven -- it only
+// learns about a SCSI ID once a matching image file already exists on the
+// card, and only then consults that ID's [SCSIn] config. This pass runs
+// after that scan and catches the opposite case: a SCSI ID names an
+// AS400_DiskProfile but has no backing image yet. The profile itself
+// already carries the drive's real captured capacity (BlockSize/Sectors,
+// see custom_vendor_inquiry.cpp), so the image can be created at the exact
+// right size instead of requiring a hand-crafted Create*.txt file.
+static bool autoCreateAS400ProfileImages()
+{
+  bool foundImage = false;
+  char imgdir[MAX_FILE_PATH];
+  ini_gets("SCSI", "Dir", "/", imgdir, sizeof(imgdir), CONFIGFILE);
+
+  for (int id = 0; id < S2S_MAX_TARGETS; id++)
+  {
+    if (s2s_getConfigById(id))
+      continue; // the scan below already found a real image for this ID
+
+    char section[6] = "SCSI0";
+    section[4] = scsiEncodeID(id);
+    char profileName[64];
+    ini_gets(section, "AS400_DiskProfile", "", profileName, sizeof(profileName), CONFIGFILE);
+    if (profileName[0] == '\0')
+      continue;
+
+    g_scsi_settings.initDevice(id, S2S_CFG_FIXED);
+    if (g_scsi_settings.getDevice(id)->blockSize == 0)
+    {
+      g_scsi_settings.getDevice(id)->blockSize = DEFAULT_BLOCKSIZE;
+    }
+    parseCustomInquiryData(id, S2S_CFG_FIXED);
+
+    uint32_t blockSize = 0, sectors = 0;
+    if (!getAS400ProfileCapacity(id, &blockSize, &sectors) || blockSize == 0 || sectors == 0)
+    {
+      logmsg("---- SCSI ID ", id, ": AS400_DiskProfile '", profileName,
+             "' has no usable BlockSize/Sectors, cannot auto-create image");
+      continue;
+    }
+
+    char fullname[MAX_FILE_PATH * 2 + 2] = {0};
+    strncpy(fullname, imgdir, MAX_FILE_PATH);
+    if (fullname[strlen(fullname) - 1] != '/') strcat(fullname, "/");
+    char namepart[16];
+    snprintf(namepart, sizeof(namepart), "HD%c0.hda", scsiEncodeID(id));
+    strcat(fullname, namepart);
+
+    uint64_t size = (uint64_t)sectors * blockSize;
+    logmsg("---- No image found for SCSI ID ", id, ", auto-creating ",
+           (int)(size / (1024 * 1024)), " MB per AS400_DiskProfile '", profileName, "'");
+
+    if (!createImageFile(fullname, size))
+    {
+      logmsg("---- Failed to auto-create image for SCSI ID ", id);
+      continue;
+    }
+
+    if (scsiDiskOpenHDDImage(id, fullname, 0, blockSize, S2S_CFG_FIXED, true))
+    {
+      foundImage = true;
+    }
+    else
+    {
+      logmsg("---- Failed to open auto-created image for SCSI ID ", id);
+    }
+  }
+
+  return foundImage;
+}
+#endif
+
 static bool typeIsRemovable(S2S_CFG_TYPE type)
 {
   switch (type)
@@ -963,6 +1037,14 @@ bool findHDDImages()
   if(usedDefaultId > 0) {
     logmsg("Some images did not specify a SCSI ID. Last file will be used at ID ", usedDefaultId);
   }
+
+#ifdef PLATFORM_AS400
+  if (autoCreateAS400ProfileImages())
+  {
+    foundImage = true;
+  }
+#endif
+
   root.close();
 
   g_romdrive_active = scsiDiskActivateRomDrive();

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -702,6 +702,12 @@ bool findHDDImages()
   uint8_t removable_count = 0;
   uint8_t eject_btn_set = 0;
   uint8_t last_removable_device = 255;
+
+  // Reset custom-inquiry state once for the whole scan below, not per ID --
+  // parseCustomInquiryData() is called once per discovered SCSI ID inside
+  // this loop, and its own reset would wipe every other ID's custom data.
+  resetCustomInquiryData();
+
   while (1)
   {
     if (!file.openNext(&root, O_READ))

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -93,14 +93,19 @@ static struct {
 } g_as400_part_override[S2S_MAX_TARGETS];
 
 // BlockSize/Sectors captured from a loaded AS/400 disk profile (see
-// loadAS400ProfileFromFile() below), for a given SCSI ID. Not consumed by
-// anything yet -- live capacity reporting is always computed from the actual
-// backing image file's size, never from this. This is here for the upcoming
-// auto-image-creation feature, which needs to know a profile's real capacity
-// before it can create a correctly-sized image for it.
+// loadAS400ProfileFromFile() below), for a given SCSI ID. blockSize/sectors
+// are not consumed by anything yet -- live capacity reporting is always
+// computed from the actual backing image file's size, never from this. They
+// are here for the upcoming auto-image-creation feature, which needs to know
+// a profile's real capacity before it can create a correctly-sized image for
+// it. `loaded` is consumed immediately, by loadAS400Defaults() below: a
+// named profile's declared VPD page set is authoritative for that SCSI ID,
+// so any page IT doesn't have should stay absent rather than being patched
+// in from the built-in default's unrelated physical drive.
 static struct {
     uint32_t blockSize;
     uint32_t sectors;
+    bool loaded;
 } g_as400_profile_info[S2S_MAX_TARGETS];
 
 // Convert a single ASCII character to IBM EBCDIC (CP037 subset).
@@ -328,6 +333,7 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
     long sectors = ini_getl(profileName, "Sectors", 0, AS400_PROFILES_FILE);
     if (blockSize > 0) g_as400_profile_info[scsiId].blockSize = (uint32_t)blockSize;
     if (sectors > 0) g_as400_profile_info[scsiId].sectors = (uint32_t)sectors;
+    g_as400_profile_info[scsiId].loaded = true;
 
     logmsg("---- Loaded AS/400 disk profile '", profileName, "' for SCSI ID ", (int)scsiId,
            " (BlockSize=", (int)blockSize, " Sectors=", (int)sectors, ")");
@@ -368,15 +374,21 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
         loaded_default_data = true;
     }
 
-    // Default VPD pages
+    // Default VPD pages. Skipped entirely once a named profile is active for
+    // this ID (see loadAS400ProfileFromFile()): that profile's own captured
+    // page set is authoritative, and patching in a page it doesn't have from
+    // the built-in default would splice a different, unrelated physical
+    // drive's identity data into an otherwise self-consistent profile -
+    // confirmed in practice for VPD pages 0x01/0x82/0x83 on a profile that
+    // doesn't happen to capture them.
     for (size_t p = 0; p < AS400VitalPagesLen && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; p++)
     {
         uint8_t pageLen = AS400VitalPages[p][0]; // first byte is length
         if (pageLen < 2) continue;
         uint8_t pageCode = AS400VitalPages[p][2]; // page code at offset 2 in data
 
-        if (hasCustomVPD(scsiId, pageCode))
-            continue; // INI override takes precedence
+        if (hasCustomVPD(scsiId, pageCode) || g_as400_profile_info[scsiId].loaded)
+            continue; // INI override, or an active named profile, takes precedence
 
         loaded_default_data = true;
         int idx = g_custom_vpd_count;

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -92,6 +92,17 @@ static struct {
     uint8_t ebcdic[7];
 } g_as400_part_override[S2S_MAX_TARGETS];
 
+// BlockSize/Sectors captured from a loaded AS/400 disk profile (see
+// loadAS400ProfileFromFile() below), for a given SCSI ID. Not consumed by
+// anything yet -- live capacity reporting is always computed from the actual
+// backing image file's size, never from this. This is here for the upcoming
+// auto-image-creation feature, which needs to know a profile's real capacity
+// before it can create a correctly-sized image for it.
+static struct {
+    uint32_t blockSize;
+    uint32_t sectors;
+} g_as400_profile_info[S2S_MAX_TARGETS];
+
 // Convert a single ASCII character to IBM EBCDIC (CP037 subset).
 // Supports digits, uppercase A-Z, and space. Lowercase is uppercased first.
 // Anything else returns EBCDIC space (0x40).
@@ -169,6 +180,113 @@ static void injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, u
     memcpy(data + asciiOffset, g_as400_part_override[id].ascii, 7);
     if (ebcdicOffset >= 0)
         memcpy(data + ebcdicOffset, g_as400_part_override[id].ebcdic, 7);
+}
+#endif
+
+#ifdef PLATFORM_AS400
+// Read a hex-byte field from a captured AS/400 disk profile section,
+// reassembling it if the extractor split it into <field>_0, <field>_1, ...
+// <field>_chunks (see emit_hex_field() in utils/extract_as400_disk_data.sh --
+// fields short enough to fit one INI line are stored plain under <field>).
+// Returns the number of bytes decoded, 0 if the field is absent entirely.
+static int readProfileHexField(const char *section, const char *field, uint8_t *buf, int maxlen)
+{
+    char tmp[512];
+
+    if (ini_gets(section, field, "", tmp, sizeof(tmp), AS400_PROFILES_FILE) && tmp[0] != '\0')
+    {
+        return parseHexString(tmp, buf, maxlen);
+    }
+
+    char chunkKey[24];
+    snprintf(chunkKey, sizeof(chunkKey), "%s_chunks", field);
+    long numChunks = ini_getl(section, chunkKey, 0, AS400_PROFILES_FILE);
+    if (numChunks <= 0) return 0;
+
+    int total = 0;
+    for (long i = 0; i < numChunks && total < maxlen; i++)
+    {
+        snprintf(chunkKey, sizeof(chunkKey), "%s_%ld", field, i);
+        if (!ini_gets(section, chunkKey, "", tmp, sizeof(tmp), AS400_PROFILES_FILE))
+            break;
+        total += parseHexString(tmp, buf + total, maxlen - total);
+    }
+    return total;
+}
+
+// Load a named AS/400 disk profile from AS400_PROFILES_FILE
+// (as400_disk_definitions.txt, captured by utils/extract_as400_disk_data.sh)
+// into this SCSI ID's custom SPD/VPD/MODE SENSE storage. Only fills in data
+// not already supplied by this ID's own [SCSI<n>] vpdXX/spd keys -- those
+// still take precedence, same as loadAS400Defaults() below.
+//
+// Fails loud rather than silently falling back to the single built-in
+// profile: a missing/empty definitions file or a typo'd profile name should
+// be an obvious, logged error, not a quiet switch to the wrong drive.
+static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
+{
+    FsFile f = SD.open(AS400_PROFILES_FILE, O_RDONLY);
+    bool fileUsable = f.isOpen() && f.fileSize() > 0;
+    if (f.isOpen()) f.close();
+    if (!fileUsable)
+    {
+        logmsg("---- ERROR: AS/400 disk profile '", profileName, "' requested for SCSI ID ",
+               (int)scsiId, " but ", AS400_PROFILES_FILE, " is missing or empty");
+        return;
+    }
+
+    if (!ini_hassection(profileName, AS400_PROFILES_FILE))
+    {
+        logmsg("---- ERROR: AS/400 disk profile '", profileName, "' not found in ",
+               AS400_PROFILES_FILE, " for SCSI ID ", (int)scsiId);
+        return;
+    }
+
+    uint8_t tmpbuf[MAX_MODESENSE_SIZE]; // MAX_MODESENSE_SIZE == MAX_VPD_DATA_SIZE (255)
+    int len;
+
+    if (g_custom_spd[scsiId].length == 0)
+    {
+        len = readProfileHexField(profileName, "SPD", g_custom_spd[scsiId].data, MAX_SPD_SIZE);
+        if (len > 0) g_custom_spd[scsiId].length = len;
+    }
+
+    for (int page = 0; page < 0xFF && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; page++)
+    {
+        if (hasCustomVPD(scsiId, page))
+            continue; // this ID's own [SCSI<n>] vpdXX already set this page
+
+        char field[8];
+        snprintf(field, sizeof(field), "VPD%02X", page);
+        len = readProfileHexField(profileName, field, tmpbuf, MAX_VPD_DATA_SIZE);
+        if (len > 0)
+        {
+            int idx = g_custom_vpd_count;
+            g_custom_vpd[idx].scsiId = scsiId;
+            g_custom_vpd[idx].pageCode = page;
+            g_custom_vpd[idx].length = len;
+            memcpy(g_custom_vpd[idx].data, tmpbuf, len);
+            g_custom_vpd_count++;
+        }
+    }
+
+    if (g_custom_modesense[scsiId].length == 0)
+    {
+        len = readProfileHexField(profileName, "ModeSense3F", tmpbuf, MAX_MODESENSE_SIZE);
+        if (len > 0)
+        {
+            g_custom_modesense[scsiId].length = len;
+            memcpy(g_custom_modesense[scsiId].data, tmpbuf, len);
+        }
+    }
+
+    long blockSize = ini_getl(profileName, "BlockSize", 0, AS400_PROFILES_FILE);
+    long sectors = ini_getl(profileName, "Sectors", 0, AS400_PROFILES_FILE);
+    if (blockSize > 0) g_as400_profile_info[scsiId].blockSize = (uint32_t)blockSize;
+    if (sectors > 0) g_as400_profile_info[scsiId].sectors = (uint32_t)sectors;
+
+    logmsg("---- Loaded AS/400 disk profile '", profileName, "' for SCSI ID ", (int)scsiId,
+           " (BlockSize=", (int)blockSize, " Sectors=", (int)sectors, ")");
 }
 #endif
 
@@ -263,6 +381,7 @@ void resetCustomInquiryData()
 #ifdef PLATFORM_AS400
     memset(g_as400_serial_override, 0, sizeof(g_as400_serial_override));
     memset(g_as400_part_override, 0, sizeof(g_as400_part_override));
+    memset(g_as400_profile_info, 0, sizeof(g_as400_profile_info));
 #endif
 }
 
@@ -343,6 +462,16 @@ void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
             g_as400_part_override[id].length = 7;
             logmsg("---- Custom AS/400 disk part number for SCSI ID ", (int) scsiId, ": \"", tmp, "\"");
         }
+    }
+
+    // Load a named AS/400 disk profile: AS400_DiskProfile=<section name in
+    // as400_disk_definitions.txt, e.g. "59H7001">. Runs after this section's
+    // own vpdXX/spd keys above (which still win) and before the built-in
+    // defaults below (which fill in anything the profile doesn't supply).
+    if (ini_gets(section, "AS400_DiskProfile", "", tmp, sizeof(tmp), CONFIGFILE))
+    {
+        if (tmp[0] != '\0')
+            loadAS400ProfileFromFile(scsiId, tmp);
     }
 
     // Load AS/400 defaults for any IDs that don't have INI overrides

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -260,22 +260,57 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
         if (len > 0) g_custom_spd[scsiId].length = len;
     }
 
-    for (int page = 0; page < 0xFF && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; page++)
+    // Read VPD page 0x00 (the standard "supported pages" list, SPC format:
+    // byte 0 periph qualifier/type, byte 1 page code, bytes 2-3 page list
+    // length, bytes 4.. the actual page codes) first, and only attempt the
+    // specific pages it declares - typically ~8 - instead of blindly trying
+    // all 255 possible page codes. minIni has no index and re-scans the
+    // whole file from the start on every single query, so trying all 255
+    // costs ~247 wasted full-file scans per profile load: measured at ~9
+    // seconds against a real, 400+-line as400_disk_definitions.txt on real
+    // hardware, long enough to matter for AS/400 DASD-discovery timing.
+    if (!hasCustomVPD(scsiId, 0x00))
     {
-        if (hasCustomVPD(scsiId, page))
-            continue; // this ID's own [SCSI<n>] vpdXX already set this page
-
-        char field[8];
-        snprintf(field, sizeof(field), "VPD%02X", page);
-        len = readProfileHexField(profileName, field, tmpbuf, MAX_VPD_DATA_SIZE);
+        len = readProfileHexField(profileName, "VPD00", tmpbuf, MAX_VPD_DATA_SIZE);
         if (len > 0)
         {
             int idx = g_custom_vpd_count;
             g_custom_vpd[idx].scsiId = scsiId;
-            g_custom_vpd[idx].pageCode = page;
+            g_custom_vpd[idx].pageCode = 0x00;
             g_custom_vpd[idx].length = len;
             memcpy(g_custom_vpd[idx].data, tmpbuf, len);
             g_custom_vpd_count++;
+        }
+    }
+
+    uint8_t vpd00[MAX_VPD_DATA_SIZE];
+    uint8_t vpd00_len = 0;
+    getCustomVPD(scsiId, 0x00, vpd00, &vpd00_len);
+
+    if (vpd00_len >= 4)
+    {
+        int declared_len = (vpd00[2] << 8) | vpd00[3];
+        int available = vpd00_len - 4;
+        if (declared_len > available) declared_len = available;
+
+        for (int i = 0; i < declared_len && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; i++)
+        {
+            int page = vpd00[4 + i];
+            if (page == 0x00 || hasCustomVPD(scsiId, page))
+                continue; // page 0 already handled above; others already set via [SCSI<n>] vpdXX
+
+            char field[8];
+            snprintf(field, sizeof(field), "VPD%02X", page);
+            len = readProfileHexField(profileName, field, tmpbuf, MAX_VPD_DATA_SIZE);
+            if (len > 0)
+            {
+                int idx = g_custom_vpd_count;
+                g_custom_vpd[idx].scsiId = scsiId;
+                g_custom_vpd[idx].pageCode = page;
+                g_custom_vpd[idx].length = len;
+                memcpy(g_custom_vpd[idx].data, tmpbuf, len);
+                g_custom_vpd_count++;
+            }
         }
     }
 

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -607,3 +607,16 @@ bool getCustomModeSense(uint8_t scsiId, uint8_t *buf, uint16_t *length)
     return false;
 }
 
+#ifdef PLATFORM_AS400
+bool getAS400ProfileCapacity(uint8_t scsiId, uint32_t *blockSize, uint32_t *sectors)
+{
+    uint8_t id = scsiId & S2S_CFG_TARGET_ID_BITS;
+    if (!g_as400_profile_info[id].loaded)
+        return false;
+
+    *blockSize = g_as400_profile_info[id].blockSize;
+    *sectors = g_as400_profile_info[id].sectors;
+    return true;
+}
+#endif
+

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -43,14 +43,27 @@
 // guess: real AS/400 disk-profile captures declare up to ~13 VPD pages each
 // (see as400_disk_definitions.txt), so a flat 16-entry table -- fine for a
 // single profiled ID -- silently overflows with just 2-3 profiled IDs
-// loaded at once. 10 covers VPD00 plus headroom for every real capture seen
-// so far, times every possible SCSI ID.
+// loaded at once.
+//
+// The multiplier is deliberately modest (6, not enough for every possible
+// SCSI ID to carry a full 13-page profile simultaneously) rather than a
+// larger "cover every worst case" number: each entry costs 258 bytes
+// (see MAX_VPD_DATA_SIZE below), and this table is static RAM on a
+// platform with no swap. S2S_MAX_TARGETS*10 (160 entries on ZuluSCSI_Wide,
+// ~41.3KB) was tried and overflowed the linker's fixed 512KB RAM region by
+// 544 bytes on real hardware -- this firmware's other features (FreeRTOS,
+// lwIP, display/UI, USB, WebUI, audio) already consume most of the ~36.6KB
+// that was actually free before this table grew. *10 was sized from a
+// percentage of total RAM without accounting for that; *6 (96 entries,
+// ~24.8KB on Wide, a ~20.6KB growth) leaves real margin instead of just
+// barely fitting. Covers ~7 fully-profiled SCSI IDs at once, comfortably
+// above the "3+ IDs" scenario this fix was written to support.
 //
 // MAX_VPD_DATA_SIZE is 255 -- the maximum representable in the `length`
 // field below (uint8_t). The largest AS/400 disk-profile capture in tree
 // today is XCPR036 page 0xC3 at 250 bytes; pages 0xD1 / 0xD2 are 244 B.
 // Going to 255 leaves a few bytes of headroom without widening `length`.
-#define MAX_CUSTOM_VPD_ENTRIES (S2S_MAX_TARGETS * 10)
+#define MAX_CUSTOM_VPD_ENTRIES (S2S_MAX_TARGETS * 6)
 #define MAX_VPD_DATA_SIZE 255
 static struct {
     uint8_t scsiId;

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -35,14 +35,22 @@
 #include <string.h>
 #include <stdlib.h>
 
-// Storage for custom VPD pages: up to 16 entries across all SCSI IDs
-// Each entry: [0]=scsiId, [1]=pageCode, [2]=length, [3..]=data
+// Storage for custom VPD pages: entries shared across all SCSI IDs (not
+// per-device -- an ID with more declared pages than another just uses more
+// of the shared pool). Each entry: [0]=scsiId, [1]=pageCode, [2]=length, [3..]=data
+//
+// MAX_CUSTOM_VPD_ENTRIES is sized per S2S_MAX_TARGETS rather than a flat
+// guess: real AS/400 disk-profile captures declare up to ~13 VPD pages each
+// (see as400_disk_definitions.txt), so a flat 16-entry table -- fine for a
+// single profiled ID -- silently overflows with just 2-3 profiled IDs
+// loaded at once. 10 covers VPD00 plus headroom for every real capture seen
+// so far, times every possible SCSI ID.
 //
 // MAX_VPD_DATA_SIZE is 255 -- the maximum representable in the `length`
 // field below (uint8_t). The largest AS/400 disk-profile capture in tree
 // today is XCPR036 page 0xC3 at 250 bytes; pages 0xD1 / 0xD2 are 244 B.
 // Going to 255 leaves a few bytes of headroom without widening `length`.
-#define MAX_CUSTOM_VPD_ENTRIES 16
+#define MAX_CUSTOM_VPD_ENTRIES (S2S_MAX_TARGETS * 10)
 #define MAX_VPD_DATA_SIZE 255
 static struct {
     uint8_t scsiId;
@@ -277,7 +285,7 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
     if (!hasCustomVPD(scsiId, 0x00))
     {
         len = readProfileHexField(profileName, "VPD00", tmpbuf, MAX_VPD_DATA_SIZE);
-        if (len > 0)
+        if (len > 0 && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES)
         {
             int idx = g_custom_vpd_count;
             g_custom_vpd[idx].scsiId = scsiId;
@@ -285,6 +293,11 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
             g_custom_vpd[idx].length = len;
             memcpy(g_custom_vpd[idx].data, tmpbuf, len);
             g_custom_vpd_count++;
+        }
+        else if (len > 0)
+        {
+            logmsg("---- WARNING: custom VPD table full (", MAX_CUSTOM_VPD_ENTRIES,
+                   " entries), VPD page 0x00 for SCSI ID ", (int)scsiId, " was not loaded");
         }
     }
 
@@ -298,7 +311,8 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
         int available = vpd00_len - 4;
         if (declared_len > available) declared_len = available;
 
-        for (int i = 0; i < declared_len && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; i++)
+        int i;
+        for (i = 0; i < declared_len && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; i++)
         {
             int page = vpd00[4 + i];
             if (page == 0x00 || hasCustomVPD(scsiId, page))
@@ -316,6 +330,12 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
                 memcpy(g_custom_vpd[idx].data, tmpbuf, len);
                 g_custom_vpd_count++;
             }
+        }
+
+        if (i < declared_len)
+        {
+            logmsg("---- WARNING: custom VPD table full (", MAX_CUSTOM_VPD_ENTRIES,
+                   " entries), some VPD pages for SCSI ID ", (int)scsiId, " were not loaded");
         }
     }
 
@@ -381,7 +401,8 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
     // drive's identity data into an otherwise self-consistent profile -
     // confirmed in practice for VPD pages 0x01/0x82/0x83 on a profile that
     // doesn't happen to capture them.
-    for (size_t p = 0; p < AS400VitalPagesLen && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; p++)
+    size_t p;
+    for (p = 0; p < AS400VitalPagesLen && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; p++)
     {
         uint8_t pageLen = AS400VitalPages[p][0]; // first byte is length
         if (pageLen < 2) continue;
@@ -414,6 +435,11 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
             injectPartNumber(g_custom_vpd[idx].data, 5, 29, scsiId);
 
         g_custom_vpd_count++;
+    }
+    if (p < AS400VitalPagesLen)
+    {
+        logmsg("---- WARNING: custom VPD table full (", MAX_CUSTOM_VPD_ENTRIES,
+               " entries), some default VPD pages for SCSI ID ", (int)scsiId, " were not loaded");
     }
     if (loaded_default_data)
     {
@@ -450,7 +476,8 @@ void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
     section[4] = scsiEncodeID(scsiId);
 
     // Parse VPD pages: vpd00, vpd80, etc.
-    for (int page = 0; page < 0xFF && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; page++)
+    int page;
+    for (page = 0; page < 0xFF && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; page++)
     {
         snprintf(key, sizeof(key), "vpd%02x", page);
         if (ini_gets(section, key, "", tmp, sizeof(tmp), CONFIGFILE))
@@ -466,6 +493,13 @@ void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
                 g_custom_vpd_count++;
             }
         }
+    }
+
+    if (page < 0xFF)
+    {
+        logmsg("---- WARNING: custom VPD table full (", MAX_CUSTOM_VPD_ENTRIES,
+               " entries), SCSI ID ", scsiId, " vpdXX overrides for page number ",
+               page, " and above were not checked");
     }
 
     // Parse standard inquiry override: spd=

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -59,11 +59,25 @@
 // barely fitting. Covers ~7 fully-profiled SCSI IDs at once, comfortably
 // above the "3+ IDs" scenario this fix was written to support.
 //
+// *6 assumed RAM headroom tracks S2S_MAX_TARGETS, which turned out false
+// too: ZuluSCSI_Blaster is an 8-target board (same class as plain RP2040
+// boards, which build fine at 48 entries) but also carries the full
+// networking stack, DaynaPORT, audio, display/UI, and the logic sniffer on
+// top -- far less headroom than its target count alone would suggest, and
+// it overflowed the same 512KB RAM region by 6516 bytes at 48 entries on
+// real CI. Board RAM headroom depends on each board's whole feature set,
+// not just its bus width, so a single S2S_MAX_TARGETS-scaled formula can't
+// fit every board -- overridable per-board via a build flag (see
+// ZuluSCSI_Blaster's build_flags in platformio.ini), same pattern already
+// used for PREFETCH_BUFFER_SIZE.
+//
 // MAX_VPD_DATA_SIZE is 255 -- the maximum representable in the `length`
 // field below (uint8_t). The largest AS/400 disk-profile capture in tree
 // today is XCPR036 page 0xC3 at 250 bytes; pages 0xD1 / 0xD2 are 244 B.
 // Going to 255 leaves a few bytes of headroom without widening `length`.
+#ifndef MAX_CUSTOM_VPD_ENTRIES
 #define MAX_CUSTOM_VPD_ENTRIES (S2S_MAX_TARGETS * 6)
+#endif
 #define MAX_VPD_DATA_SIZE 255
 static struct {
     uint8_t scsiId;

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -62,6 +62,17 @@ static struct {
     uint8_t data[MAX_SPD_SIZE];
 } g_custom_spd[S2S_MAX_TARGETS];
 
+// Storage for a custom MODE SENSE page 0x3F ("all pages") response per SCSI ID.
+//
+// MAX_MODESENSE_SIZE matches MAX_VPD_DATA_SIZE: the firmware's built-in
+// as400_mode_sense_all_pages blob is 220 bytes, and the extractor script
+// captures MODE SENSE(6) with an allocation length of 0xFF (255).
+#define MAX_MODESENSE_SIZE 255
+static struct {
+    uint16_t length;
+    uint8_t data[MAX_MODESENSE_SIZE];
+} g_custom_modesense[S2S_MAX_TARGETS];
+
 #ifdef PLATFORM_AS400
 // Per-SCSI-ID override for the 8-byte AS/400 serial, supplied via the
 // `AS400_DiskSerialNumber` key in [SCSI<n>] sections. When length == 8,
@@ -248,6 +259,7 @@ void resetCustomInquiryData()
 {
     g_custom_vpd_count = 0;
     memset(g_custom_spd, 0, sizeof(g_custom_spd));
+    memset(g_custom_modesense, 0, sizeof(g_custom_modesense));
 #ifdef PLATFORM_AS400
     memset(g_as400_serial_override, 0, sizeof(g_as400_serial_override));
     memset(g_as400_part_override, 0, sizeof(g_as400_part_override));
@@ -359,6 +371,18 @@ bool getCustomSPD(uint8_t scsiId, uint8_t *buf, uint16_t *length)
     {
         *length = g_custom_spd[id].length;
         memcpy(buf, g_custom_spd[id].data, g_custom_spd[id].length);
+        return true;
+    }
+    return false;
+}
+
+bool getCustomModeSense(uint8_t scsiId, uint8_t *buf, uint16_t *length)
+{
+    uint8_t id = scsiId & S2S_CFG_TARGET_ID_BITS;
+    if (g_custom_modesense[id].length > 0)
+    {
+        *length = g_custom_modesense[id].length;
+        memcpy(buf, g_custom_modesense[id].data, g_custom_modesense[id].length);
         return true;
     }
     return false;

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -237,19 +237,28 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
 }
 #endif
 
-void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
+// Resets shared storage for ALL SCSI IDs. Must be called exactly once before
+// the scan loop that calls parseCustomInquiryData() once per discovered ID --
+// previously these resets lived at the top of parseCustomInquiryData() itself,
+// which meant every ID's call wiped every *other* already-processed ID's
+// custom VPD/SPD/serial/part-number data. Only the last ID scanned ever kept
+// its custom data. Not previously visible because nothing exercised custom
+// data differing across multiple IDs at once.
+void resetCustomInquiryData()
 {
-    char tmp[512];
-    char section[6] = "SCSI0";
-    char key[8];
-
     g_custom_vpd_count = 0;
     memset(g_custom_spd, 0, sizeof(g_custom_spd));
 #ifdef PLATFORM_AS400
     memset(g_as400_serial_override, 0, sizeof(g_as400_serial_override));
     memset(g_as400_part_override, 0, sizeof(g_as400_part_override));
 #endif
+}
 
+void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
+{
+    char tmp[512];
+    char section[6] = "SCSI0";
+    char key[8];
 
     section[4] = scsiEncodeID(scsiId);
 

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -191,7 +191,14 @@ static void injectPartNumber(uint8_t *data, int asciiOffset, int ebcdicOffset, u
 // Returns the number of bytes decoded, 0 if the field is absent entirely.
 static int readProfileHexField(const char *section, const char *field, uint8_t *buf, int maxlen)
 {
-    char tmp[512];
+    // static, not a stack local: this is called up to 255 times in a row from
+    // loadAS400ProfileFromFile()'s VPD-page loop, nested several calls deep
+    // inside the boot-time SCSI ID scan. A 512-byte stack local here, on top
+    // of that scan's own buffers, was enough to overflow the stack on real
+    // hardware (CFSR StackOverflow, RP2350, confirmed via a real crash log).
+    // Safe as static: this function is only ever called sequentially, never
+    // reentrantly, from this single-threaded boot-time scan.
+    static char tmp[512];
 
     if (ini_gets(section, field, "", tmp, sizeof(tmp), AS400_PROFILES_FILE) && tmp[0] != '\0')
     {
@@ -242,7 +249,9 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
         return;
     }
 
-    uint8_t tmpbuf[MAX_MODESENSE_SIZE]; // MAX_MODESENSE_SIZE == MAX_VPD_DATA_SIZE (255)
+    // static for the same reason as readProfileHexField()'s tmp[] above --
+    // one less sizable buffer stacked on top of an already-deep call chain.
+    static uint8_t tmpbuf[MAX_MODESENSE_SIZE]; // MAX_MODESENSE_SIZE == MAX_VPD_DATA_SIZE (255)
     int len;
 
     if (g_custom_spd[scsiId].length == 0)

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -365,6 +365,51 @@ static void loadAS400ProfileFromFile(uint8_t scsiId, const char *profileName)
                    " entries), some VPD pages for SCSI ID ", (int)scsiId, " were not loaded");
         }
     }
+    else
+    {
+        // No VPD page 0x00 ("supported pages") in this capture -- some
+        // CISC-era drives (e.g. 45G9463/45G9463-1/86G9124/55F9806) genuinely
+        // don't support it as a discovery mechanism, even though they still
+        // carry real data on other pages (see as400_disk_definitions.txt).
+        // Without VPD00 the discovery loop above never runs at all, so
+        // VPD01/02/03/80/82 etc. were unreachable through AS400_DiskProfile=
+        // for these profiles even though the bytes are sitting right there
+        // in the file -- confirmed on real 9401-P02 hardware: a profile
+        // like this loaded its SPD fine but served zero VPD pages, and IPL
+        // halted early. Fall back to a small, curated list of page codes
+        // actually seen across the captured dataset, instead of the full
+        // 255-code brute force the VPD00 path exists specifically to avoid
+        // (~9s on real hardware against a 400+-line definitions file).
+        static const uint8_t curatedPages[] = {
+            0x01, 0x02, 0x03, 0x80, 0x81, 0x82, 0x83,
+            0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC7, 0xC8, 0xD1, 0xD2
+        };
+        size_t i;
+        for (i = 0; i < sizeof(curatedPages) && g_custom_vpd_count < MAX_CUSTOM_VPD_ENTRIES; i++)
+        {
+            int page = curatedPages[i];
+            if (hasCustomVPD(scsiId, page))
+                continue; // already set via [SCSI<n>] vpdXX override
+
+            char field[8];
+            snprintf(field, sizeof(field), "VPD%02X", page);
+            len = readProfileHexField(profileName, field, tmpbuf, MAX_VPD_DATA_SIZE);
+            if (len > 0)
+            {
+                int idx = g_custom_vpd_count;
+                g_custom_vpd[idx].scsiId = scsiId;
+                g_custom_vpd[idx].pageCode = page;
+                g_custom_vpd[idx].length = len;
+                memcpy(g_custom_vpd[idx].data, tmpbuf, len);
+                g_custom_vpd_count++;
+            }
+        }
+        if (i < sizeof(curatedPages))
+        {
+            logmsg("---- WARNING: custom VPD table full (", MAX_CUSTOM_VPD_ENTRIES,
+                   " entries), some VPD pages for SCSI ID ", (int)scsiId, " were not loaded");
+        }
+    }
 
     if (g_custom_modesense[scsiId].length == 0)
     {

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -495,7 +495,13 @@ static void loadAS400Defaults(uint8_t scsiId,S2S_CFG_TYPE type)
         if (pageCode == 0x80 && g_custom_vpd[idx].length >= 20)
             injectSerial(g_custom_vpd[idx].data, 12, scsiId); // offset 12 in page data
         else if (pageCode == 0x82 && g_custom_vpd[idx].length >= 24)
-            injectSerial(g_custom_vpd[idx].data, 16, scsiId);
+            // Offset 14, not 16 -- landmark-verified (search for the "IBM"
+            // string terminator, read the 8 bytes before it) across 7
+            // independently captured real drives (59H7001, 59H6611,
+            // 9V8006-041, 86G9124, 55F9806, 45G9463, 45G9463-1), spanning
+            // multiple product families. The shipped offset of 16 was off
+            // by 2 relative to every real drive checked.
+            injectSerial(g_custom_vpd[idx].data, 14, scsiId);
         else if (pageCode == 0x83 && g_custom_vpd[idx].length >= 42)
             injectSerial(g_custom_vpd[idx].data, 34, scsiId);
         else if (pageCode == 0xD1 && g_custom_vpd[idx].length >= 78)

--- a/src/custom_vendor_inquiry.h
+++ b/src/custom_vendor_inquiry.h
@@ -31,8 +31,15 @@ extern "C" {
 #endif
 
 
-// Parse custom inquiry data from zuluscsi.ini for all SCSI IDs.
-// Called once during initialization.
+// Clear all per-target custom inquiry/VPD/MODE SENSE state. Call once before
+// the per-SCSI-ID scan loop that calls parseCustomInquiryData() below -- the
+// per-ID call itself must NOT reset shared storage, or each ID's call wipes
+// every previously-processed ID's custom data.
+void resetCustomInquiryData();
+
+// Parse custom inquiry data from zuluscsi.ini for one SCSI ID.
+// Called once per discovered SCSI ID during initialization, after
+// resetCustomInquiryData() has been called once for the whole scan.
 // INI format: [SCSI<id>] vpd00=XX XX XX, spd=XX XX XX (hex values)
 void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type);
 
@@ -43,6 +50,10 @@ bool getCustomVPD(uint8_t scsiId, uint8_t pageCode, uint8_t *buf, uint8_t *lengt
 // Check if custom SPD (Standard Page Data / standard inquiry override) exists for a SCSI ID.
 // If found, copies data into buf and sets *length. Returns true if custom data exists.
 bool getCustomSPD(uint8_t scsiId, uint8_t *buf, uint16_t *length);
+
+// Check if a custom MODE SENSE page 0x3F (all pages) response exists for a SCSI ID.
+// If found, copies data into buf and sets *length. Returns true if custom data exists.
+bool getCustomModeSense(uint8_t scsiId, uint8_t *buf, uint16_t *length);
 
 #ifdef __cplusplus
 }

--- a/src/custom_vendor_inquiry.h
+++ b/src/custom_vendor_inquiry.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <scsi2sd.h>
+#include <ZuluSCSI_platform_config.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,6 +55,14 @@ bool getCustomSPD(uint8_t scsiId, uint8_t *buf, uint16_t *length);
 // Check if a custom MODE SENSE page 0x3F (all pages) response exists for a SCSI ID.
 // If found, copies data into buf and sets *length. Returns true if custom data exists.
 bool getCustomModeSense(uint8_t scsiId, uint8_t *buf, uint16_t *length);
+
+#ifdef PLATFORM_AS400
+// Check if a loaded AS/400 disk profile (see AS400_DiskProfile=, parsed by
+// parseCustomInquiryData() above) supplied a capacity for this SCSI ID. If
+// so, fills *blockSize/*sectors and returns true -- used to auto-create a
+// correctly-sized image file when none exists yet for a profiled ID.
+bool getAS400ProfileCapacity(uint8_t scsiId, uint32_t *blockSize, uint32_t *sectors);
+#endif
 
 #ifdef __cplusplus
 }

--- a/utils/extract_as400_disk_data.sh
+++ b/utils/extract_as400_disk_data.sh
@@ -149,21 +149,41 @@ be_uint() {
 echo "=== Capturing AS/400 disk profile '$LABEL' from $DEV ===" >&2
 
 # ===== 1. Standard INQUIRY (full length, including vendor-specific tail) ===
+# Deliberately does NOT rely solely on `sg_inq --raw` succeeding: some real
+# AS/400-era drives answer sg_raw-issued CDBs fine but return nothing useful
+# to sg_inq's own more particular request. So: always try sg_inq first (it's
+# usually fine and simplest), but fall back to a raw INQUIRY CDB via sg_raw
+# — first a minimal 36-byte probe (the SPC-mandated standard length) to learn
+# the real additional-length field, then a full-length re-fetch — regardless
+# of whether sg_inq produced anything at all. Earlier versions of this script
+# only attempted the sg_raw path if sg_inq had *already* returned enough
+# bytes to read the additional-length field from, which meant a drive that
+# didn't answer sg_inq at all got no INQUIRY data captured whatsoever.
 info "Reading standard INQUIRY..."
 INQ_RAW="$SCRATCHDIR/inquiry.bin"
 run_capture "$INQ_RAW" sg_inq --raw "$DEV" || true
 
-if [ -s "$INQ_RAW" ]; then
-    ADDL=$(be_uint "$INQ_RAW" 4 1)
-    FULL_LEN=$((ADDL + 5))
-    if [ "$FULL_LEN" -gt 5 ]; then
-        run_capture "$INQ_RAW" sg_raw -r "$FULL_LEN" "$DEV" 12 00 00 00 "$(printf '%02x' "$FULL_LEN")" 00 || true
+ADDL=$(be_uint "$INQ_RAW" 4 1)
+if [ ! -s "$INQ_RAW" ] || [ "$ADDL" -eq 0 ]; then
+    info "sg_inq gave nothing usable, probing INQUIRY directly via sg_raw..."
+    PROBE_RAW="$SCRATCHDIR/inquiry_probe.bin"
+    if run_capture "$PROBE_RAW" sg_raw -r 36 "$DEV" 12 00 00 00 24 00; then
+        ADDL=$(be_uint "$PROBE_RAW" 4 1)
+        if [ -s "$PROBE_RAW" ] && [ "$ADDL" -gt 0 ]; then
+            cp "$PROBE_RAW" "$INQ_RAW"
+        fi
     fi
+fi
+
+if [ "$ADDL" -gt 0 ]; then
+    FULL_LEN=$((ADDL + 5))
+    run_capture "$INQ_RAW" sg_raw -r "$FULL_LEN" "$DEV" 12 00 00 00 "$(printf '%02x' "$FULL_LEN")" 00 || true
 fi
 
 INQ_SIZE=$(wc -c < "$INQ_RAW" 2>/dev/null | tr -d ' '); INQ_SIZE=${INQ_SIZE:-0}
 if [ "$INQ_SIZE" -eq 0 ]; then
-    warn "Standard INQUIRY returned no data — capture will be incomplete."
+    warn "Standard INQUIRY returned no data via sg_inq OR sg_raw — capture will be incomplete."
+    warn "Try manually: sg_raw -v -r 36 $DEV 12 00 00 00 24 00 | xxd"
 fi
 info "Standard INQUIRY: $INQ_SIZE bytes"
 
@@ -179,15 +199,16 @@ fi
 info "Reading capacity..."
 CAP_RAW="$SCRATCHDIR/readcap.bin"
 SECTORS=0 BLOCKSIZE=0
-if run_capture "$CAP_RAW" sg_raw -r 8 "$DEV" 25 00 00 00 00 00 00 00 00 00; then
-    if [ "$(wc -c < "$CAP_RAW" | tr -d ' ')" -eq 8 ]; then
-        LAST_LBA=$(be_uint "$CAP_RAW" 0 4)
-        BLOCKSIZE=$(be_uint "$CAP_RAW" 4 4)
-        SECTORS=$((LAST_LBA + 1))
-    fi
+run_capture "$CAP_RAW" sg_raw -r 8 "$DEV" 25 00 00 00 00 00 00 00 00 00 || true
+CAP_SIZE=$(wc -c < "$CAP_RAW" 2>/dev/null | tr -d ' '); CAP_SIZE=${CAP_SIZE:-0}
+if [ "$CAP_SIZE" -eq 8 ]; then
+    LAST_LBA=$(be_uint "$CAP_RAW" 0 4)
+    BLOCKSIZE=$(be_uint "$CAP_RAW" 4 4)
+    SECTORS=$((LAST_LBA + 1))
 fi
 if [ "$SECTORS" -eq 0 ]; then
-    warn "READ CAPACITY(10) failed or returned nothing usable — Sectors/BlockSize will be 0, fill in by hand."
+    warn "READ CAPACITY(10) did not return a usable 8-byte response (got $CAP_SIZE bytes) — Sectors/BlockSize will be 0, fill in by hand."
+    warn "Try manually: sg_raw -v -r 8 $DEV 25 00 00 00 00 00 00 00 00 00 | xxd"
 else
     info "Sectors=$SECTORS BlockSize=$BLOCKSIZE (=> $((SECTORS * BLOCKSIZE)) bytes exactly)"
 fi
@@ -242,13 +263,24 @@ for pc in "${PAGE_CODES[@]}"; do
 done
 
 # ===== 4. MODE SENSE(6), all pages (0x3F) ===================================
+# The sg_modes fallback must trigger on EMPTY output too, not just a nonzero
+# exit from sg_raw — sg3_utils tools generally treat "good status, fewer
+# bytes than the allocation length" as success, not failure, so a drive that
+# answers with nothing useful would previously skip the fallback entirely.
 info "Reading MODE SENSE (all pages)..."
 MS_RAW="$SCRATCHDIR/modesense.bin"
 # MODE SENSE(6): opcode=1A, DBD=0, PC=0 (current), page=3F, alloc=0xFF
-run_capture "$MS_RAW" sg_raw -r 255 "$DEV" 1a 00 3f 00 ff 00 || \
+run_capture "$MS_RAW" sg_raw -r 255 "$DEV" 1a 00 3f 00 ff 00 || true
+if [ ! -s "$MS_RAW" ]; then
+    info "sg_raw MODE SENSE gave nothing, trying sg_modes..."
     run_capture "$MS_RAW" sg_modes --raw --page=0x3f --six "$DEV" || true
+fi
 
 MS_SIZE=$(wc -c < "$MS_RAW" 2>/dev/null | tr -d ' '); MS_SIZE=${MS_SIZE:-0}
+if [ "$MS_SIZE" -eq 0 ]; then
+    warn "MODE SENSE 0x3F returned no data via sg_raw OR sg_modes."
+    warn "Try manually: sg_raw -v -r 255 $DEV 1a 00 3f 00 ff 00 | xxd"
+fi
 info "MODE SENSE 0x3F: $MS_SIZE bytes"
 
 # Decode CHS geometry for human review, if pages 0x03/0x04 are present in the

--- a/utils/extract_as400_disk_data.sh
+++ b/utils/extract_as400_disk_data.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# extract_as400_disk_data.sh — Capture a real AS/400 disk's identity data
+# extract_as400_disk_data.sh --- Capture a real AS/400 disk's identity data
 #
 # Reads standard INQUIRY, all VPD pages the drive actually reports, the full
 # MODE SENSE (all pages), READ CAPACITY, and LOG SENSE pages 0x00/0x30/0x31
@@ -8,11 +8,11 @@
 # section to a plain-text definitions file (default: as400_disk_definitions.txt,
 # meant to be copied to the root of the ZuluSCSI's SD card).
 #
-# This is deliberately NOT XML/JSON — it's a minIni-compatible INI file, using
+# This is deliberately NOT XML/JSON --- it's a minIni-compatible INI file, using
 # the same space-separated-hex-byte convention that src/custom_vendor_inquiry.cpp
 # already parses for zuluscsi.ini's [SCSIn] "spd"/"vpdXX" keys. Hex fields that
 # exceed a safe INI line length (minIni's INI_BUFFERSIZE is 512 bytes) are split
-# into NAME_0, NAME_1, ... chunks; the firmware does not yet reassemble these —
+# into NAME_0, NAME_1, ... chunks; the firmware does not yet reassemble these ---
 # capture now, load later.
 #
 # Requirements:  sg3_utils (sg_inq, sg_vpd, sg_modes, sg_logs, sg_raw), xxd
@@ -20,35 +20,41 @@
 #                sg_readcap itself is not required)
 #                Run as root or with appropriate /dev/sg* permissions.
 #
-# Usage:  ./extract_as400_disk_data.sh /dev/sgN <FeatureModel> [outfile]
+# Usage:  ./extract_as400_disk_data.sh /dev/sgN [Label] [outfile]
 #
-#   /dev/sgN      — the sg device for the target disk
-#   FeatureModel  — REQUIRED. The IBM Feature+Model designation for this disk
-#                   (e.g. "6607-050"), used as the [section] name. This is NOT
-#                   auto-detected: it is not present in the drive's own
-#                   INQUIRY/VPD data (checked — every ASCII-shaped field in a
-#                   known-real capture decodes to vendor/product/FRU/serial
-#                   strings, never a Feature+Model pair). You know it from the
-#                   physical unit's markings or system configuration records;
-#                   the drive does not.
-#   outfile       — file to append the profile to (default:
+#   /dev/sgN      --- the sg device for the target disk
+#   Label         --- OPTIONAL. [section] name for this profile. If omitted,
+#                   it's auto-derived from VPD page 0x01's 12-byte FRU/part-
+#                   number field (offset 5) --- the number actually printed on
+#                   the physical drive, per this project's labeling
+#                   convention (Feature codes are a system-level packaging
+#                   designation, only ever visible from within OS/400 itself
+#                   alongside the serial number, and are NOT present in the
+#                   drive's own INQUIRY/VPD data --- checked; every
+#                   ASCII-shaped field in a known-real capture decodes to
+#                   vendor/product/FRU/serial strings, never a Feature+Model
+#                   pair). Pass this explicitly to override auto-detection,
+#                   e.g. if VPD page 0x01 is unsupported or you want a
+#                   different name.
+#   outfile       --- file to append the profile to (default:
 #                   as400_disk_definitions.txt in the current directory).
 #                   Run once per physical drive; each run appends one section.
 #
 # Example:
-#   ./extract_as400_disk_data.sh /dev/sg3 6607-050 as400_disk_definitions.txt
+#   ./extract_as400_disk_data.sh /dev/sg3
+#   ./extract_as400_disk_data.sh /dev/sg3 59H7001 as400_disk_definitions.txt
 # ---------------------------------------------------------------------------
 
 set -uo pipefail
 
-DEV="${1:?Usage: $0 /dev/sgN <FeatureModel> [outfile]}"
-LABEL="${2:?Usage: $0 /dev/sgN <FeatureModel> [outfile] -- FeatureModel is required, e.g. 6607-050}"
+DEV="${1:?Usage: $0 /dev/sgN [Label] [outfile]}"
+LABEL="${2:-}"
 OUTFILE="${3:-as400_disk_definitions.txt}"
 
 # Max raw bytes per emitted hex field before splitting into NAME_0, NAME_1, ...
 # 3 chars per byte ("XX ") * 140 = ~420 chars of value, leaving comfortable
 # headroom under minIni's 512-byte INI_BUFFERSIZE for "KEYNAME_N = " plus
-# whatever margin minIni needs internally — measured 495/512 at 160 bytes/line
+# whatever margin minIni needs internally --- measured 495/512 at 160 bytes/line
 # in testing, too close for comfort given key names vary in length.
 MAX_HEX_BYTES_PER_LINE=140
 
@@ -57,12 +63,14 @@ if [ ! -c "$DEV" ]; then
     exit 1
 fi
 
-case "$LABEL" in
-    \[*|*\]*)
-        echo "Error: FeatureModel '$LABEL' must not contain '[' or ']' (it becomes an INI section name)." >&2
-        exit 1
-        ;;
-esac
+if [ -n "$LABEL" ]; then
+    case "$LABEL" in
+        \[*|*\]*)
+            echo "Error: Label '$LABEL' must not contain '[' or ']' (it becomes an INI section name)." >&2
+            exit 1
+            ;;
+    esac
+fi
 
 MISSING_TOOLS=()
 for tool in sg_inq sg_vpd sg_modes sg_logs sg_raw xxd; do
@@ -146,15 +154,19 @@ be_uint() {
     echo $((16#$hex))
 }
 
-echo "=== Capturing AS/400 disk profile '$LABEL' from $DEV ===" >&2
+if [ -n "$LABEL" ]; then
+    echo "=== Capturing AS/400 disk profile '$LABEL' from $DEV ===" >&2
+else
+    echo "=== Capturing AS/400 disk profile from $DEV (label will be auto-derived from VPD page 0x01) ===" >&2
+fi
 
 # ===== 1. Standard INQUIRY (full length, including vendor-specific tail) ===
 # Deliberately does NOT rely solely on `sg_inq --raw` succeeding: some real
 # AS/400-era drives answer sg_raw-issued CDBs fine but return nothing useful
 # to sg_inq's own more particular request. So: always try sg_inq first (it's
 # usually fine and simplest), but fall back to a raw INQUIRY CDB via sg_raw
-# — first a minimal 36-byte probe (the SPC-mandated standard length) to learn
-# the real additional-length field, then a full-length re-fetch — regardless
+# --- first a minimal 36-byte probe (the SPC-mandated standard length) to learn
+# the real additional-length field, then a full-length re-fetch --- regardless
 # of whether sg_inq produced anything at all. Earlier versions of this script
 # only attempted the sg_raw path if sg_inq had *already* returned enough
 # bytes to read the additional-length field from, which meant a drive that
@@ -182,7 +194,7 @@ fi
 
 INQ_SIZE=$(wc -c < "$INQ_RAW" 2>/dev/null | tr -d ' '); INQ_SIZE=${INQ_SIZE:-0}
 if [ "$INQ_SIZE" -eq 0 ]; then
-    warn "Standard INQUIRY returned no data via sg_inq OR sg_raw — capture will be incomplete."
+    warn "Standard INQUIRY returned no data via sg_inq OR sg_raw --- capture will be incomplete."
     warn "Try manually: sg_raw -v -r 36 $DEV 12 00 00 00 24 00 | xxd"
 fi
 info "Standard INQUIRY: $INQ_SIZE bytes"
@@ -195,7 +207,7 @@ if [ "$INQ_SIZE" -ge 36 ]; then
     info "Vendor='$VENDOR' Product='$PRODUCT' Revision='$REVISION'"
 fi
 
-# ===== 2. READ CAPACITY — the ground-truth size, independent of everything else
+# ===== 2. READ CAPACITY --- the ground-truth size, independent of everything else
 info "Reading capacity..."
 CAP_RAW="$SCRATCHDIR/readcap.bin"
 SECTORS=0 BLOCKSIZE=0
@@ -207,13 +219,13 @@ if [ "$CAP_SIZE" -eq 8 ]; then
     SECTORS=$((LAST_LBA + 1))
 fi
 if [ "$SECTORS" -eq 0 ]; then
-    warn "READ CAPACITY(10) did not return a usable 8-byte response (got $CAP_SIZE bytes) — Sectors/BlockSize will be 0, fill in by hand."
+    warn "READ CAPACITY(10) did not return a usable 8-byte response (got $CAP_SIZE bytes) --- Sectors/BlockSize will be 0, fill in by hand."
     warn "Try manually: sg_raw -v -r 8 $DEV 25 00 00 00 00 00 00 00 00 00 | xxd"
 else
     info "Sectors=$SECTORS BlockSize=$BLOCKSIZE (=> $((SECTORS * BLOCKSIZE)) bytes exactly)"
 fi
 
-# ===== 3. VPD pages — read the REAL supported-page list, not a guessed one ==
+# ===== 3. VPD pages --- read the REAL supported-page list, not a guessed one ==
 info "Reading VPD page list (0x00)..."
 VPD_LIST="$SCRATCHDIR/vpd00.bin"
 run_capture "$VPD_LIST" sg_vpd --raw --page=0x00 "$DEV" || true
@@ -262,9 +274,38 @@ for pc in "${PAGE_CODES[@]}"; do
     fi
 done
 
+# ===== 3b. Auto-derive the section label, if not given explicitly ===========
+# VPD page 0x01 on these drives carries a 12-byte FRU/part-number field at
+# offset 5 (byte 0: peripheral qualifier/type, byte 1: 0x01 page code, bytes
+# 2-3: page length, byte 4: a flag/count byte, bytes 5-16: the FRU string,
+# space-padded, e.g. "59H7001     "). Confirmed against this session's real
+# hardware captures. This is the number printed on the physical drive --- see
+# project memory for why that's the primary key here and Feature+Model is not.
+if [ -z "$LABEL" ]; then
+    VPD01_FILE="$SCRATCHDIR/vpd_01.bin"
+    AUTO_LABEL=""
+    if [ -s "$VPD01_FILE" ]; then
+        AUTO_LABEL=$(dd if="$VPD01_FILE" bs=1 skip=5 count=12 2>/dev/null | tr -d '\0' | sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//')
+    fi
+    if [ -n "$AUTO_LABEL" ]; then
+        LABEL="$AUTO_LABEL"
+        info "Auto-derived section label '$LABEL' from VPD page 0x01 (FRU field)"
+    else
+        warn "Could not auto-derive a label from VPD page 0x01 (page missing, empty, or unrecognized layout)."
+        LABEL=$(printf '%s_%s_%s' "${VENDOR:-unknown}" "${PRODUCT:-unknown}" "${REVISION:-unknown}" | tr -s '[:space:]?' '_')
+        warn "Falling back to '$LABEL' --- rename this section by hand to the drive's actual part number."
+    fi
+    case "$LABEL" in
+        \[*|*\]*)
+            echo "Error: derived label '$LABEL' must not contain '[' or ']'." >&2
+            exit 1
+            ;;
+    esac
+fi
+
 # ===== 4. MODE SENSE(6), all pages (0x3F) ===================================
 # The sg_modes fallback must trigger on EMPTY output too, not just a nonzero
-# exit from sg_raw — sg3_utils tools generally treat "good status, fewer
+# exit from sg_raw --- sg3_utils tools generally treat "good status, fewer
 # bytes than the allocation length" as success, not failure, so a drive that
 # answers with nothing useful would previously skip the fallback entirely.
 info "Reading MODE SENSE (all pages)..."
@@ -315,7 +356,7 @@ if [ "$MS_SIZE" -ge 4 ]; then
     if [ -n "$SPT" ] && [ -n "$CYL" ] && [ -n "$HEADS" ] && [ "$SPT" -gt 0 ] && [ "$HEADS" -gt 0 ]; then
         IMPLIED=$((CYL * HEADS * SPT))
         GEOMETRY_COMMENT="; Decoded from MODE SENSE pages 0x03/0x04: cylinders=$CYL heads=$HEADS sectors/track=$SPT (block size per descriptor: ${BPS_FROM_DESC:-unknown})
-; => implied capacity $IMPLIED sectors. Compare against Sectors= below (from READ CAPACITY) —
+; => implied capacity $IMPLIED sectors. Compare against Sectors= below (from READ CAPACITY) ---
 ; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
 ; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
 ; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
@@ -403,9 +444,9 @@ fi
 {
     echo "; ==========================================================================="
     echo "; AS/400 disk profile '$LABEL', captured from $DEV on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    echo "; Feature+Model is not auto-detected — it is not present in this drive's own"
-    echo "; INQUIRY/VPD data (checked; see project memory for the reasoning). Confirm"
-    echo "; this label is actually correct for the physical unit before relying on it."
+    echo "; Label is the drive's own part number (from VPD page 0x01, or given explicitly)."
+    echo "; Feature+Model (e.g. #6607) is a system-level packaging designation, not"
+    echo "; present in the drive's own INQUIRY/VPD data --- see project memory for why."
     echo "; ==========================================================================="
     echo "[$LABEL]"
     cat "$SECTION_BODY"
@@ -422,4 +463,4 @@ echo "LOG SENSE pages: 0x00=${LS00_SIZE}B 0x30=${LS30_SIZE}B 0x31=${LS31_SIZE}B"
 echo "" >&2
 echo "Appended profile [$LABEL] to $OUTFILE" >&2
 echo "Copy $OUTFILE to the root of the ZuluSCSI's SD card as as400_disk_definitions.txt" >&2
-echo "(the firmware does not yet load this file — capture now, loader is future work)." >&2
+echo "(the firmware does not yet load this file --- capture now, loader is future work)." >&2

--- a/utils/extract_as400_disk_data.sh
+++ b/utils/extract_as400_disk_data.sh
@@ -167,7 +167,7 @@ ADDL=$(be_uint "$INQ_RAW" 4 1)
 if [ ! -s "$INQ_RAW" ] || [ "$ADDL" -eq 0 ]; then
     info "sg_inq gave nothing usable, probing INQUIRY directly via sg_raw..."
     PROBE_RAW="$SCRATCHDIR/inquiry_probe.bin"
-    if run_capture "$PROBE_RAW" sg_raw -r 36 "$DEV" 12 00 00 00 24 00; then
+    if run_capture "$PROBE_RAW" sg_raw -o - -r 36 "$DEV" 12 00 00 00 24 00; then
         ADDL=$(be_uint "$PROBE_RAW" 4 1)
         if [ -s "$PROBE_RAW" ] && [ "$ADDL" -gt 0 ]; then
             cp "$PROBE_RAW" "$INQ_RAW"
@@ -177,7 +177,7 @@ fi
 
 if [ "$ADDL" -gt 0 ]; then
     FULL_LEN=$((ADDL + 5))
-    run_capture "$INQ_RAW" sg_raw -r "$FULL_LEN" "$DEV" 12 00 00 00 "$(printf '%02x' "$FULL_LEN")" 00 || true
+    run_capture "$INQ_RAW" sg_raw -o - -r "$FULL_LEN" "$DEV" 12 00 00 00 "$(printf '%02x' "$FULL_LEN")" 00 || true
 fi
 
 INQ_SIZE=$(wc -c < "$INQ_RAW" 2>/dev/null | tr -d ' '); INQ_SIZE=${INQ_SIZE:-0}
@@ -199,7 +199,7 @@ fi
 info "Reading capacity..."
 CAP_RAW="$SCRATCHDIR/readcap.bin"
 SECTORS=0 BLOCKSIZE=0
-run_capture "$CAP_RAW" sg_raw -r 8 "$DEV" 25 00 00 00 00 00 00 00 00 00 || true
+run_capture "$CAP_RAW" sg_raw -o - -r 8 "$DEV" 25 00 00 00 00 00 00 00 00 00 || true
 CAP_SIZE=$(wc -c < "$CAP_RAW" 2>/dev/null | tr -d ' '); CAP_SIZE=${CAP_SIZE:-0}
 if [ "$CAP_SIZE" -eq 8 ]; then
     LAST_LBA=$(be_uint "$CAP_RAW" 0 4)
@@ -270,7 +270,7 @@ done
 info "Reading MODE SENSE (all pages)..."
 MS_RAW="$SCRATCHDIR/modesense.bin"
 # MODE SENSE(6): opcode=1A, DBD=0, PC=0 (current), page=3F, alloc=0xFF
-run_capture "$MS_RAW" sg_raw -r 255 "$DEV" 1a 00 3f 00 ff 00 || true
+run_capture "$MS_RAW" sg_raw -o - -r 255 "$DEV" 1a 00 3f 00 ff 00 || true
 if [ ! -s "$MS_RAW" ]; then
     info "sg_raw MODE SENSE gave nothing, trying sg_modes..."
     run_capture "$MS_RAW" sg_modes --raw --page=0x3f --six "$DEV" || true

--- a/utils/extract_as400_disk_data.sh
+++ b/utils/extract_as400_disk_data.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# extract_as400_disk_data.sh — Capture a real AS/400 disk's identity data
+#
+# Reads standard INQUIRY, all VPD pages the drive actually reports, the full
+# MODE SENSE (all pages), READ CAPACITY, and LOG SENSE pages 0x00/0x30/0x31
+# from a real AS/400-style SCSI disk, and appends the result as one profile
+# section to a plain-text definitions file (default: as400_disk_definitions.txt,
+# meant to be copied to the root of the ZuluSCSI's SD card).
+#
+# This is deliberately NOT XML/JSON — it's a minIni-compatible INI file, using
+# the same space-separated-hex-byte convention that src/custom_vendor_inquiry.cpp
+# already parses for zuluscsi.ini's [SCSIn] "spd"/"vpdXX" keys. Hex fields that
+# exceed a safe INI line length (minIni's INI_BUFFERSIZE is 512 bytes) are split
+# into NAME_0, NAME_1, ... chunks; the firmware does not yet reassemble these —
+# capture now, load later.
+#
+# Requirements:  sg3_utils (sg_inq, sg_vpd, sg_modes, sg_logs, sg_raw), xxd
+#                (READ CAPACITY is issued via a raw CDB through sg_raw, so
+#                sg_readcap itself is not required)
+#                Run as root or with appropriate /dev/sg* permissions.
+#
+# Usage:  ./extract_as400_disk_data.sh /dev/sgN <FeatureModel> [outfile]
+#
+#   /dev/sgN      — the sg device for the target disk
+#   FeatureModel  — REQUIRED. The IBM Feature+Model designation for this disk
+#                   (e.g. "6607-050"), used as the [section] name. This is NOT
+#                   auto-detected: it is not present in the drive's own
+#                   INQUIRY/VPD data (checked — every ASCII-shaped field in a
+#                   known-real capture decodes to vendor/product/FRU/serial
+#                   strings, never a Feature+Model pair). You know it from the
+#                   physical unit's markings or system configuration records;
+#                   the drive does not.
+#   outfile       — file to append the profile to (default:
+#                   as400_disk_definitions.txt in the current directory).
+#                   Run once per physical drive; each run appends one section.
+#
+# Example:
+#   ./extract_as400_disk_data.sh /dev/sg3 6607-050 as400_disk_definitions.txt
+# ---------------------------------------------------------------------------
+
+set -uo pipefail
+
+DEV="${1:?Usage: $0 /dev/sgN <FeatureModel> [outfile]}"
+LABEL="${2:?Usage: $0 /dev/sgN <FeatureModel> [outfile] -- FeatureModel is required, e.g. 6607-050}"
+OUTFILE="${3:-as400_disk_definitions.txt}"
+
+# Max raw bytes per emitted hex field before splitting into NAME_0, NAME_1, ...
+# 3 chars per byte ("XX ") * 140 = ~420 chars of value, leaving comfortable
+# headroom under minIni's 512-byte INI_BUFFERSIZE for "KEYNAME_N = " plus
+# whatever margin minIni needs internally — measured 495/512 at 160 bytes/line
+# in testing, too close for comfort given key names vary in length.
+MAX_HEX_BYTES_PER_LINE=140
+
+if [ ! -c "$DEV" ]; then
+    echo "Error: $DEV is not a character device." >&2
+    exit 1
+fi
+
+case "$LABEL" in
+    \[*|*\]*)
+        echo "Error: FeatureModel '$LABEL' must not contain '[' or ']' (it becomes an INI section name)." >&2
+        exit 1
+        ;;
+esac
+
+MISSING_TOOLS=()
+for tool in sg_inq sg_vpd sg_modes sg_logs sg_raw xxd; do
+    if ! command -v "$tool" &>/dev/null; then
+        MISSING_TOOLS+=("$tool")
+    fi
+done
+if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
+    echo "Error: missing tools: ${MISSING_TOOLS[*]}. Install sg3_utils and xxd." >&2
+    exit 1
+fi
+
+SCRATCHDIR="$(mktemp -d)"
+trap 'rm -rf "$SCRATCHDIR"' EXIT
+
+SECTION_BODY="$SCRATCHDIR/section_body.txt"
+: > "$SECTION_BODY"
+
+warn() { echo "  ! $*" >&2; }
+info() { echo "  - $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Run a command, capture stdout to a file, and report (not hide) failures.
+# Returns the command's exit status; caller decides whether that's fatal.
+# ---------------------------------------------------------------------------
+run_capture() {
+    local outfile="$1"; shift
+    local errfile="$SCRATCHDIR/last_stderr.txt"
+    if "$@" > "$outfile" 2>"$errfile"; then
+        return 0
+    else
+        local status=$?
+        warn "command failed (exit $status): $*"
+        if [ -s "$errfile" ]; then
+            sed 's/^/      /' "$errfile" >&2
+        fi
+        return "$status"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Emit one or more "NAME = hex bytes" lines for a binary file, split so each
+# line stays under MAX_HEX_BYTES_PER_LINE raw bytes. Appends to SECTION_BODY.
+# ---------------------------------------------------------------------------
+emit_hex_field() {
+    local name="$1" file="$2"
+    local size
+    size=$(wc -c < "$file" | tr -d ' ')
+
+    if [ "$size" -eq 0 ]; then
+        echo "; $name: no data captured" >> "$SECTION_BODY"
+        return
+    fi
+
+    local hex
+    hex=$(xxd -p -c "$size" "$file" | tr -d '\n')
+    # hex is now one long lowercase hex string, 2 chars per byte.
+
+    if [ "$size" -le "$MAX_HEX_BYTES_PER_LINE" ]; then
+        printf '%s = %s\n' "$name" "$(echo "$hex" | fold -w2 | paste -s -d ' ' -)" >> "$SECTION_BODY"
+    else
+        info "$name is $size bytes, splitting into ${name}_0, ${name}_1, ... (${MAX_HEX_BYTES_PER_LINE} bytes/chunk)"
+        local chunk_hex_chars=$((MAX_HEX_BYTES_PER_LINE * 2))
+        local idx=0 offset=0 total_hex_chars=${#hex}
+        while [ "$offset" -lt "$total_hex_chars" ]; do
+            local chunk="${hex:$offset:$chunk_hex_chars}"
+            printf '%s_%d = %s\n' "$name" "$idx" "$(echo "$chunk" | fold -w2 | paste -s -d ' ' -)" >> "$SECTION_BODY"
+            offset=$((offset + chunk_hex_chars))
+            idx=$((idx + 1))
+        done
+        printf '%s_chunks = %d\n' "$name" "$idx" >> "$SECTION_BODY"
+    fi
+}
+
+# Read a big-endian unsigned integer from a binary file at a byte offset.
+be_uint() {
+    local file="$1" offset="$2" len="$3"
+    local hex
+    hex=$(xxd -p -s "$offset" -l "$len" "$file" 2>/dev/null)
+    [ -z "$hex" ] && { echo 0; return; }
+    echo $((16#$hex))
+}
+
+echo "=== Capturing AS/400 disk profile '$LABEL' from $DEV ===" >&2
+
+# ===== 1. Standard INQUIRY (full length, including vendor-specific tail) ===
+info "Reading standard INQUIRY..."
+INQ_RAW="$SCRATCHDIR/inquiry.bin"
+run_capture "$INQ_RAW" sg_inq --raw "$DEV" || true
+
+if [ -s "$INQ_RAW" ]; then
+    ADDL=$(be_uint "$INQ_RAW" 4 1)
+    FULL_LEN=$((ADDL + 5))
+    if [ "$FULL_LEN" -gt 5 ]; then
+        run_capture "$INQ_RAW" sg_raw -r "$FULL_LEN" "$DEV" 12 00 00 00 "$(printf '%02x' "$FULL_LEN")" 00 || true
+    fi
+fi
+
+INQ_SIZE=$(wc -c < "$INQ_RAW" 2>/dev/null | tr -d ' '); INQ_SIZE=${INQ_SIZE:-0}
+if [ "$INQ_SIZE" -eq 0 ]; then
+    warn "Standard INQUIRY returned no data — capture will be incomplete."
+fi
+info "Standard INQUIRY: $INQ_SIZE bytes"
+
+VENDOR="?" PRODUCT="?" REVISION="?"
+if [ "$INQ_SIZE" -ge 36 ]; then
+    VENDOR=$(dd if="$INQ_RAW" bs=1 skip=8 count=8 2>/dev/null | tr -d '\0' | sed -e 's/[[:space:]]*$//')
+    PRODUCT=$(dd if="$INQ_RAW" bs=1 skip=16 count=16 2>/dev/null | tr -d '\0' | sed -e 's/[[:space:]]*$//')
+    REVISION=$(dd if="$INQ_RAW" bs=1 skip=32 count=4 2>/dev/null | tr -d '\0' | sed -e 's/[[:space:]]*$//')
+    info "Vendor='$VENDOR' Product='$PRODUCT' Revision='$REVISION'"
+fi
+
+# ===== 2. READ CAPACITY — the ground-truth size, independent of everything else
+info "Reading capacity..."
+CAP_RAW="$SCRATCHDIR/readcap.bin"
+SECTORS=0 BLOCKSIZE=0
+if run_capture "$CAP_RAW" sg_raw -r 8 "$DEV" 25 00 00 00 00 00 00 00 00 00; then
+    if [ "$(wc -c < "$CAP_RAW" | tr -d ' ')" -eq 8 ]; then
+        LAST_LBA=$(be_uint "$CAP_RAW" 0 4)
+        BLOCKSIZE=$(be_uint "$CAP_RAW" 4 4)
+        SECTORS=$((LAST_LBA + 1))
+    fi
+fi
+if [ "$SECTORS" -eq 0 ]; then
+    warn "READ CAPACITY(10) failed or returned nothing usable — Sectors/BlockSize will be 0, fill in by hand."
+else
+    info "Sectors=$SECTORS BlockSize=$BLOCKSIZE (=> $((SECTORS * BLOCKSIZE)) bytes exactly)"
+fi
+
+# ===== 3. VPD pages — read the REAL supported-page list, not a guessed one ==
+info "Reading VPD page list (0x00)..."
+VPD_LIST="$SCRATCHDIR/vpd00.bin"
+run_capture "$VPD_LIST" sg_vpd --raw --page=0x00 "$DEV" || true
+
+PAGE_CODES=()
+if [ -s "$VPD_LIST" ]; then
+    LIST_LEN=$(wc -c < "$VPD_LIST" | tr -d ' ')
+    if [ "$LIST_LEN" -ge 4 ]; then
+        # Bytes 2-3 are the page list length (big-endian) per SPC; only that
+        # many bytes after the 4-byte header are actual page codes. Earlier
+        # versions of this script read to EOF here, which could pull in
+        # padding/garbage as bogus page codes.
+        DECLARED_LEN=$(be_uint "$VPD_LIST" 2 2)
+        AVAILABLE=$((LIST_LEN - 4))
+        USE_LEN=$DECLARED_LEN
+        if [ "$USE_LEN" -gt "$AVAILABLE" ]; then
+            warn "VPD page-0 declares $DECLARED_LEN page codes but only $AVAILABLE bytes were read; truncating."
+            USE_LEN=$AVAILABLE
+        fi
+        if [ "$USE_LEN" -gt 0 ]; then
+            PAGE_CODES=($(xxd -p -s 4 -l "$USE_LEN" "$VPD_LIST" | tr -d '\n' | fold -w2))
+        fi
+    fi
+fi
+
+if [ ${#PAGE_CODES[@]} -eq 0 ]; then
+    warn "Could not read VPD page 0x00's supported-page list; falling back to the known AS/400 page set."
+    PAGE_CODES=(00 01 03 80 82 83 d1 d2)
+fi
+info "Supported VPD pages: ${PAGE_CODES[*]}"
+
+# Plain indexed array, not an associative array: keeps this portable to bash
+# 3.2 (macOS's default /bin/bash has no declare -A), not just bash 4+.
+CAPTURED_VPD_PAGES=()
+for pc in "${PAGE_CODES[@]}"; do
+    PC_UP=$(echo "$pc" | tr '[:lower:]' '[:upper:]')
+    VPD_FILE="$SCRATCHDIR/vpd_${pc}.bin"
+    if run_capture "$VPD_FILE" sg_vpd --raw --page="0x${pc}" "$DEV"; then
+        SZ=$(wc -c < "$VPD_FILE" | tr -d ' ')
+        if [ "$SZ" -gt 0 ]; then
+            info "VPD page 0x${PC_UP}: $SZ bytes"
+            CAPTURED_VPD_PAGES+=("$pc")
+        else
+            warn "VPD page 0x${PC_UP}: empty response, skipping"
+        fi
+    fi
+done
+
+# ===== 4. MODE SENSE(6), all pages (0x3F) ===================================
+info "Reading MODE SENSE (all pages)..."
+MS_RAW="$SCRATCHDIR/modesense.bin"
+# MODE SENSE(6): opcode=1A, DBD=0, PC=0 (current), page=3F, alloc=0xFF
+run_capture "$MS_RAW" sg_raw -r 255 "$DEV" 1a 00 3f 00 ff 00 || \
+    run_capture "$MS_RAW" sg_modes --raw --page=0x3f --six "$DEV" || true
+
+MS_SIZE=$(wc -c < "$MS_RAW" 2>/dev/null | tr -d ' '); MS_SIZE=${MS_SIZE:-0}
+info "MODE SENSE 0x3F: $MS_SIZE bytes"
+
+# Decode CHS geometry for human review, if pages 0x03/0x04 are present in the
+# response. This is informational only (redundant with the raw hex capture);
+# it exists so a future reader doesn't have to hand-decode SCSI mode pages the
+# way this session did.
+GEOMETRY_COMMENT=""
+if [ "$MS_SIZE" -ge 4 ]; then
+    BLOCKDESCLEN=$(be_uint "$MS_RAW" 3 1)
+    IDX=$((4 + BLOCKDESCLEN))
+    SPT="" BPS_FROM_DESC="" CYL="" HEADS=""
+    if [ "$BLOCKDESCLEN" -ge 8 ]; then
+        BPS_FROM_DESC=$(be_uint "$MS_RAW" $((4 + 5)) 3)
+    fi
+    while [ "$IDX" -lt "$MS_SIZE" ]; do
+        PAGECODE_BYTE=$(be_uint "$MS_RAW" "$IDX" 1)
+        PAGECODE=$((PAGECODE_BYTE & 0x3F))
+        [ "$PAGECODE" -eq 0 ] && break
+        [ $((IDX + 2)) -gt "$MS_SIZE" ] && break
+        PAGELEN=$(be_uint "$MS_RAW" $((IDX + 1)) 1)
+        [ $((IDX + 2 + PAGELEN)) -gt "$MS_SIZE" ] && break
+        DATA_OFF=$((IDX + 2))
+        if [ "$PAGECODE" -eq 3 ] && [ "$PAGELEN" -ge 12 ]; then
+            SPT=$(be_uint "$MS_RAW" $((DATA_OFF + 8)) 2)
+        fi
+        if [ "$PAGECODE" -eq 4 ] && [ "$PAGELEN" -ge 4 ]; then
+            CYL=$(be_uint "$MS_RAW" "$DATA_OFF" 3)
+            HEADS=$(be_uint "$MS_RAW" $((DATA_OFF + 3)) 1)
+        fi
+        IDX=$((DATA_OFF + PAGELEN))
+    done
+    if [ -n "$SPT" ] && [ -n "$CYL" ] && [ -n "$HEADS" ] && [ "$SPT" -gt 0 ] && [ "$HEADS" -gt 0 ]; then
+        IMPLIED=$((CYL * HEADS * SPT))
+        GEOMETRY_COMMENT="; Decoded from MODE SENSE pages 0x03/0x04: cylinders=$CYL heads=$HEADS sectors/track=$SPT (block size per descriptor: ${BPS_FROM_DESC:-unknown})
+; => implied capacity $IMPLIED sectors. Compare against Sectors= below (from READ CAPACITY) —
+; if these two numbers disagree, this drive's own MODE SENSE geometry is internally
+; inconsistent the same way the firmware's built-in 09L4044 capture is (see project memory:
+; project_as400_static_data_inconsistency.md). Trust READ CAPACITY / the INQUIRY+VPD identity,
+; not the MODE SENSE geometry, when in doubt."
+        info "MODE SENSE geometry: cyl=$CYL heads=$HEADS spt=$SPT => implied $IMPLIED sectors"
+        if [ "$SECTORS" -gt 0 ] && [ "$IMPLIED" -ne "$SECTORS" ]; then
+            warn "MODE SENSE geometry ($IMPLIED sectors) disagrees with READ CAPACITY ($SECTORS sectors) for this drive too."
+        fi
+    fi
+fi
+
+# ===== 5. LOG SENSE pages 0x00 / 0x30 / 0x31 ================================
+info "Reading LOG SENSE pages..."
+LS00_RAW="$SCRATCHDIR/logsense00.bin"
+run_capture "$LS00_RAW" sg_logs --raw --page=0x00 "$DEV" || true
+LS00_SIZE=$(wc -c < "$LS00_RAW" 2>/dev/null | tr -d ' '); LS00_SIZE=${LS00_SIZE:-0}
+info "LOG SENSE page 0x00: $LS00_SIZE bytes"
+
+LS30_RAW="$SCRATCHDIR/logsense30.bin"
+run_capture "$LS30_RAW" sg_logs --raw --page=0x30 "$DEV" || true
+LS30_SIZE=$(wc -c < "$LS30_RAW" 2>/dev/null | tr -d ' '); LS30_SIZE=${LS30_SIZE:-0}
+info "LOG SENSE page 0x30: $LS30_SIZE bytes"
+PL30=0 PLL30=0
+if [ "$LS30_SIZE" -ge 4 ]; then
+    PL30=$(be_uint "$LS30_RAW" 2 2)
+    [ "$LS30_SIZE" -ge 8 ] && PLL30=$(be_uint "$LS30_RAW" 7 1)
+fi
+
+LS31_RAW="$SCRATCHDIR/logsense31.bin"
+run_capture "$LS31_RAW" sg_logs --raw --page=0x31 "$DEV" || true
+LS31_SIZE=$(wc -c < "$LS31_RAW" 2>/dev/null | tr -d ' '); LS31_SIZE=${LS31_SIZE:-0}
+info "LOG SENSE page 0x31: $LS31_SIZE bytes"
+PL31=0
+[ "$LS31_SIZE" -ge 4 ] && PL31=$(be_uint "$LS31_RAW" 2 2)
+
+# ===== 6. Assemble the [LABEL] section ======================================
+{
+    echo "Vendor = ${VENDOR:-?}"
+    echo "Product = ${PRODUCT:-?}"
+    echo "Revision = ${REVISION:-?}"
+    echo "BlockSize = ${BLOCKSIZE:-0}"
+    echo "Sectors = ${SECTORS:-0}"
+    [ -n "$GEOMETRY_COMMENT" ] && echo "$GEOMETRY_COMMENT"
+    echo ""
+    echo "; --- Standard INQUIRY (full response) ---"
+} >> "$SECTION_BODY"
+[ "$INQ_SIZE" -gt 0 ] && emit_hex_field "SPD" "$INQ_RAW"
+
+{
+    echo ""
+    echo "; --- VPD pages (space-separated hex bytes, minIni-parseable) ---"
+} >> "$SECTION_BODY"
+if [ ${#CAPTURED_VPD_PAGES[@]} -gt 0 ]; then
+    for pc in "${CAPTURED_VPD_PAGES[@]}"; do
+        PC_UP=$(echo "$pc" | tr '[:lower:]' '[:upper:]')
+        emit_hex_field "VPD${PC_UP}" "$SCRATCHDIR/vpd_${pc}.bin"
+    done
+else
+    echo "; no VPD pages captured" >> "$SECTION_BODY"
+fi
+
+{
+    echo ""
+    echo "; --- MODE SENSE(6), page 0x3F (all pages) ---"
+} >> "$SECTION_BODY"
+[ "$MS_SIZE" -gt 0 ] && emit_hex_field "ModeSense3F" "$MS_RAW"
+
+{
+    echo ""
+    echo "; --- LOG SENSE pages ---"
+} >> "$SECTION_BODY"
+[ "$LS00_SIZE" -gt 0 ] && emit_hex_field "LogSense00" "$LS00_RAW"
+if [ "$LS30_SIZE" -gt 0 ]; then
+    emit_hex_field "LogSense30" "$LS30_RAW"
+    {
+        echo "LogSense30PageLength = $PL30"
+        echo "LogSense30PageListLength = $PLL30"
+    } >> "$SECTION_BODY"
+fi
+if [ "$LS31_SIZE" -gt 0 ]; then
+    emit_hex_field "LogSense31" "$LS31_RAW"
+    echo "LogSense31PageLength = $PL31" >> "$SECTION_BODY"
+fi
+
+{
+    echo "; ==========================================================================="
+    echo "; AS/400 disk profile '$LABEL', captured from $DEV on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "; Feature+Model is not auto-detected — it is not present in this drive's own"
+    echo "; INQUIRY/VPD data (checked; see project memory for the reasoning). Confirm"
+    echo "; this label is actually correct for the physical unit before relying on it."
+    echo "; ==========================================================================="
+    echo "[$LABEL]"
+    cat "$SECTION_BODY"
+    echo ""
+} >> "$OUTFILE"
+
+echo "" >&2
+echo "=== Summary ===" >&2
+echo "Vendor/Product/Revision: '$VENDOR' / '$PRODUCT' / '$REVISION'" >&2
+echo "Capacity: $SECTORS sectors x $BLOCKSIZE bytes = $((SECTORS * BLOCKSIZE)) bytes" >&2
+echo "VPD pages captured: ${#CAPTURED_VPD_PAGES[@]}" >&2
+echo "MODE SENSE 0x3F: $MS_SIZE bytes" >&2
+echo "LOG SENSE pages: 0x00=${LS00_SIZE}B 0x30=${LS30_SIZE}B 0x31=${LS31_SIZE}B" >&2
+echo "" >&2
+echo "Appended profile [$LABEL] to $OUTFILE" >&2
+echo "Copy $OUTFILE to the root of the ZuluSCSI's SD card as as400_disk_definitions.txt" >&2
+echo "(the firmware does not yet load this file — capture now, loader is future work)." >&2

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -122,6 +122,20 @@
 # Per-ID only — must live under [SCSI<n>].
 #AS400_DiskPartNumber = "09L7654"
 
+# AS/400 only: load a captured disk profile by name from
+# as400_disk_definitions.txt on the SD card root (produced by
+# utils/extract_as400_disk_data.sh from a real drive; the name is that
+# file's [section] name, the drive's own part number, e.g. "59H7001").
+# Supplies standard INQUIRY, VPD pages, and MODE SENSE data for this SCSI ID
+# instead of the single built-in profile. This ID's own vpdXX/spd/
+# AS400_DiskSerialNumber/AS400_DiskPartNumber keys above still take
+# precedence over anything the profile supplies; the built-in default fills
+# in anything neither of those provide. Fails loud (logged error, nothing
+# loaded) if as400_disk_definitions.txt is missing/empty or the named
+# profile isn't found in it — does not silently fall back to the built-in
+# profile. Per-ID only — must live under [SCSI<n>].
+#AS400_DiskProfile = "59H7001"
+
 #Vendor = "QUANTUM"
 #Product = "FIREBALL1"
 #Version = "1.0"


### PR DESCRIPTION
Lets a [SCSIn] section load a real captured AS/400 drive identity
(INQUIRY/VPD/MODE SENSE, from as400_disk_definitions.txt via the extractor
script) instead of always presenting the single built-in profile, and
extends that to multiple simultaneous SCSI IDs each presenting a different
real DASD unit.

- AS400_DiskProfile=<name> in [SCSIn] loads a named profile's identity for
  that SCSI ID. as400_disk_definitions.txt ships with nine real captured
  profiles (520/522-byte, CISC/PPC era) plus one verified-byte-perfect
  fabricated entry matching the built-in identity - usable out of the box,
  no AS/400 DASD hardware required. utils/extract_as400_disk_data.sh adds
  more drives when you have real hardware to capture from.
- Missing image files for a profiled ID are auto-created at the profile's
  real captured size.

Verified on real AS/400 hardware (9401-150): single-ID identity loading,
auto-image-creation, and three simultaneously profiled SCSI IDs all showing
correct, distinct identities in Dedicated Service Tools with no data
corruption. Actually using the presented disks has not yet been exercised.

Known limitation, documented in the README: using the *same* profile for
more than one SCSI ID currently gives them identical serial numbers, since
loaded-profile data is copied verbatim with no per-ID override yet. Use a
different profile per ID for now.