### PR TITLE
Fix getDevicePresetFromString() only checking the first 4 presets

### DIFF
--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -129,7 +129,7 @@ void ZuluSCSISettings::deviceInitAS400(uint8_t scsiId)
 
 scsi_device_preset_t ZuluSCSISettings::getDevicePresetFromString(const char *presetName)
 {
-    for (int i = 0; i <  sizeof(devicePresetName[0]); i++)
+    for (int i = 0; i < (int)(sizeof(devicePresetName) / sizeof(devicePresetName[0])); i++)
     {
         if (strequals(presetName, devicePresetName[i]))
         {


### PR DESCRIPTION
## Summary
- `getDevicePresetFromString()` sized its lookup loop with `sizeof(devicePresetName[0])` (width of one array element -- 4 bytes for a `char*` on this 32-bit target) instead of the array's element count, so it only ever checked indices 0-3.
- Any preset name at index 4+ -- `AS400_CISC` and `AS400_PPC` -- could never match, no matter how it was spelled in the INI. An explicit per-ID `Device=` override for either silently fell through to fully generic SCSI2SD identity instead of erroring loudly.
- Not AS/400-specific in principle: any future preset added past index 3 would hit the same wall.

## Test plan
- [x] Root-caused against a real hardware failure: a 9401-P02 IPL halted very early (SRC 9143B982) with `Device = "AS400_CISC"` set explicitly per SCSI ID; log showed `Unknown Device preset name AS400_CISC, using default settings` for every ID.
- [x] Confirmed fixed on real hardware: subsequent IPL attempts with the fix applied no longer show the "Unknown Device preset name" message, and `AS400_CISC`/`AS400_PPC` presets resolve correctly for explicit per-ID `Device=` overrides.
