### PR TITLE
network: report auth flag in WiFi INFO response

### DIFF
--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023-2026 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -123,6 +124,8 @@ void scsiNetworkWifiInfo(void)
 	wifi_cur.rssi = platform_network_wifi_rssi();
 
 	wifi_cur.channel = platform_network_wifi_channel();
+
+	wifi_cur.flags = platform_network_wifi_flags();
 
 	scsiDev.data[0] = (entrysize >> 8) & 0xff;
 	scsiDev.data[1] = entrysize & 0xff;

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -62,6 +62,11 @@ static int wifi_reconnect_attempts = 0;
 static bool g_wifi_scan_restore_connection = false;
 static bool g_wifi_scan_suspend_reconnect = false;
 
+// Whether the current association was made with a passphrase. The CYW43 driver
+// has no getter for the auth mode of a live association, so remember what was
+// asked for at join time.
+static bool g_wifi_join_secured = false;
+
 static void platform_network_wifi_store_reconnect_credentials(const char *ssid, const char *password)
 {
 	if (ssid != NULL)
@@ -182,6 +187,8 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 		wifi_reconnect_interval = WIFI_RECONNECT_START_INTERVAL;
 		wifi_reconnect_time = millis();
 	}
+
+	g_wifi_join_secured = (password != NULL && password[0] != 0);
 
 	if (password == NULL || password[0] == 0)
 	{
@@ -540,6 +547,18 @@ char * platform_network_wifi_bssid()
 	/* TODO */
 
 	return bssid;
+}
+
+uint8_t platform_network_wifi_flags()
+{
+	if (!g_wifi_join_secured)
+		return 0;
+
+	// Only claim authentication for an association that actually happened
+	if (cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA) < CYW43_LINK_JOIN)
+		return 0;
+
+	return WIFI_NETWORK_FLAG_AUTH;
 }
 
 int platform_network_wifi_channel()

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -35,6 +36,8 @@ void platform_network_wifi_dump_scan_list();
 int platform_network_wifi_rssi();
 char * platform_network_wifi_ssid();
 char * platform_network_wifi_bssid();
+// WIFI_NETWORK_FLAG_* bits describing the current association
+uint8_t platform_network_wifi_flags();
 int platform_network_wifi_channel();
 int platform_network_send(uint8_t *buf, size_t len);
 // Test if the communication between the network device and the ZuluIDE works


### PR DESCRIPTION
Applied patch https://github.com/BlueSCSI/BlueSCSI-v2/commit/4a1d728e99ccadea32f94216ee104849055be186.patch
Renamed global wifi_join_secured to g_wifi_join_secured