### PR TITLE
Web UI and USB console menu display bin/cue folder

### DIFF
--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -99,6 +99,19 @@ const char* controlGetDeviceTypeName(uint8_t scsi_id)
     }
 }
 
+// Copy the name reported to UIs for a loaded image.  A multi-bin/cue CD image
+// lives in a folder and img.current_image tracks whichever .bin file inside it
+// is currently open, so report the containing folder name instead - that is
+// also the entry controlListImages() surfaces for the set.
+static void copyDisplayName(image_config_t &img, char *buf, size_t buflen)
+{
+    if (img.is_multi_bin_cue() && img.bin_container.getName(buf, buflen) > 0)
+        return;
+
+    strncpy(buf, img.current_image, buflen - 1);
+    buf[buflen - 1] = '\0';
+}
+
 bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen)
 {
     if (!buf || buflen == 0) return false;
@@ -109,8 +122,7 @@ bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen)
     if (img.ejected || !img.file.isOpen() || img.current_image[0] == '\0')
         return false;
 
-    strncpy(buf, img.current_image, buflen - 1);
-    buf[buflen - 1] = '\0';
+    copyDisplayName(img, buf, buflen);
     return true;
 }
 
@@ -131,8 +143,7 @@ bool controlGetMediaStatus(uint8_t scsi_id, char *buf, size_t buflen, bool *ejec
 
     if (!has_file) return false;
 
-    strncpy(buf, img.current_image, buflen - 1);
-    buf[buflen - 1] = '\0';
+    copyDisplayName(img, buf, buflen);
     return true;
 }
 

--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.h
@@ -41,12 +41,16 @@ const char* controlGetDeviceTypeName(uint8_t scsi_id);
 
 // Get the full path of the currently mounted image for a device.
 // Returns true if an image is loaded (not ejected); buf receives the path.
+// A multi-bin/cue CD image reports its containing folder name rather than the
+// .bin track file that happens to be open, matching controlListImages().
 // Returns false and sets buf[0]='\0' when ejected or device inactive.
 bool controlGetCurrentImage(uint8_t scsi_id, char *buf, size_t buflen);
 
 // UI-oriented media status: returns true and fills buf with the loaded image
 // path whenever a file is open, including during a SCSI media-change eject
 // (unlike controlGetCurrentImage which returns false when ejected).
+// A multi-bin/cue CD image reports its containing folder name rather than the
+// .bin track file that happens to be open, matching controlListImages().
 // ejected_out receives the actual SCSI ejected flag.
 bool controlGetMediaStatus(uint8_t scsi_id, char *buf, size_t buflen, bool *ejected_out);
 


### PR DESCRIPTION
The Web UI and the USB console was displaying the last bin file in a multi bin/cue folder. 
This fix sends just the the directory name for a multi bin/cue image.