### PR TITLE
Fix media menu and log mixing in usb serial out

### DIFF
--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.cpp
@@ -44,6 +44,7 @@ extern "C" {
 const char *g_platform_name = PLATFORM_NAME;
 static bool g_enable_apple_quirks = false;
 bool g_direct_mode = false;
+bool g_log_lock = false;
 ZuluSCSIVersion_t g_zuluscsi_version = ZSVersion_unknown;
 bool g_moved_select_in = false;
 static bool g_led_blinking = false;
@@ -53,7 +54,7 @@ static bool g_led_blinking = false;
 // usb_log_poll() is called through function pointer to
 // avoid including USB in SD card bootloader.
 static void (*g_usb_log_poll_func)(void);
-static void usb_log_poll();
+static int32_t usb_log_poll();
 
 
 /*************************/
@@ -578,15 +579,15 @@ uint32_t platform_write_to_serial(uint8_t* data, uint32_t len)
 // Data is retrieved from the shared log ring buffer and
 // this function sends as much as fits in USB CDC buffer.
 
-static void usb_log_poll()
+static int32_t usb_log_poll()
 {
     static uint32_t logpos = 0;
 
+    // Retrieve pointer to log start and determine number of bytes available.
+    uint32_t available = 0;
+    const char *data = log_get_buffer(&logpos, &available);
     if (usb_serial_ready())
     {
-        // Retrieve pointer to log start and determine number of bytes available.
-        uint32_t available = 0;
-        const char *data = log_get_buffer(&logpos, &available);
         // Limit to CDC packet size
         uint32_t len = available;
         if (len == 0) return;
@@ -596,9 +597,19 @@ static void usb_log_poll()
         // If USB CDC buffer is full, this may be 0
         usb_serial_send((uint8_t*)data, len);
         logpos -= available - len;
+        return available - len;
     }
+    return available;
 }
 
+void platform_flush_usb_log()
+{
+    uint32_t flush_start = millis();
+    while (usb_log_poll() > 0 && (uint32_t)(millis() - flush_start) < 250)
+    {
+        platform_reset_watchdog();
+    }
+}
 /*****************************************/
 /* Crash handlers                        */
 /*****************************************/

--- a/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_GD32F205/ZuluSCSI_platform.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 
 extern const char *g_platform_name;
+extern bool g_log_lock;
 
 #include "platform_hw_config.h"
 
@@ -56,6 +57,9 @@ extern bool g_moved_select_in;
 
 // Debug logging functions
 void platform_log(const char *s);
+inline void log_lock() {g_log_lock = true;}
+inline void log_unlock() {g_log_lock = false;} 
+void platform_flush_usb_log();
 
 // Minimal millis() implementation as GD32F205 does not
 // have an Arduino core yet.

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.cpp
@@ -102,6 +102,7 @@ static uint8_t g_console_buttons = 0;
 static uint8_t g_enabled_eject_buttons = 0;
 static uint8_t g_enabled_cow_buttons = 0;
 static uint8_t g_cow_button_state = 0;
+bool g_log_lock = false;
 bool g_i2c_claimed = false;
 #ifdef ZULUSCSI_WIDE
 static bool g_is_sca = false;
@@ -141,7 +142,7 @@ typedef enum
 }
 menu_context_t;
 
-static void usb_log_poll();
+static int32_t usb_log_poll();
 
 #ifdef PLATFORM_AUTH_CHECK_ENABLE
 #include <compact_ed25519.h>
@@ -911,7 +912,7 @@ bool platform_emergency_log_save()
 }
 
 
-static void usb_log_poll();
+static int32_t usb_log_poll();
 static void usb_input_poll();
 static usb_input_type_t serial_menu(menu_context_t context);
 
@@ -1082,25 +1083,28 @@ uint32_t platform_write_to_serial(uint8_t* data, uint32_t len)
 // also starts calling this after 2 seconds.
 // This ensures that log messages get passed even if code hangs,
 // but does not unnecessarily delay normal execution.
-static void usb_log_poll()
+static int32_t usb_log_poll()
 {
 #ifndef PIO_FRAMEWORK_ARDUINO_NO_USB
     static uint32_t logpos = 0;
 
-    if (!usb_serial_connected()) return;
+    if (!usb_serial_connected()) return -1;
 
 #ifdef PLATFORM_MASS_STORAGE
-    if (platform_msc_lock_get()) return; // Avoid re-entrant USB events
+    if (platform_msc_lock_get()) return -1; // Avoid re-entrant USB events
 #endif
 
+    if (g_log_lock)
+        return -1;
+
+    uint32_t available = 0;
+    const char *data = log_get_buffer(&logpos, &available);
     if (Serial.availableForWrite())
     {
         // Retrieve pointer to log start and determine number of bytes available.
-        uint32_t available = 0;
-        const char *data = log_get_buffer(&logpos, &available);
                 // Limit to CDC packet size
         uint32_t len = available;
-        if (len == 0) return;
+        if (len == 0) return 0;
         if (len > CFG_TUD_CDC_EP_BUFSIZE) len = CFG_TUD_CDC_EP_BUFSIZE;
 
         // Update log position by the actual number of bytes sent
@@ -1108,9 +1112,19 @@ static void usb_log_poll()
         uint32_t actual = 0;
         actual = Serial.write(data, len);
         logpos -= available - actual;
+        return available - actual;
     }
-
+    return available;
 #endif // PIO_FRAMEWORK_ARDUINO_NO_USB
+}
+
+void platform_flush_usb_log()
+{
+    uint32_t flush_start = millis();
+    while (usb_log_poll() > 0 && (uint32_t)(millis() - flush_start) < 250)
+    {
+        platform_reset_watchdog();
+    }
 }
 
 // Grab input from USB Serial terminal
@@ -1937,7 +1951,7 @@ static usb_input_type_t serial_menu(menu_context_t context)
             *scratch0 = 0;
             logmsg(
                 "\r\n"                
-                "  Available ZuluSCSI Console Commands:\r\n"
+                "  Available ZuluSCSI (",g_log_short_firmwareversion,") Console Commands:\r\n"
                 "  ===================================================\r\n"
                 , context == MENU_CONTEXT_TARGET_MSC ?
                 "    'x' - exit from mass storage mode, eject USB drive(s)\r\n" : 

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform.h
@@ -72,6 +72,7 @@ extern "C" {
 /* These are used in debug output and default SCSI strings */
 extern const char *g_platform_name;
 extern bool g_i2c_claimed;
+extern bool g_log_lock;
 // NOTE: The driver supports synchronous speeds higher than 10MB/s, but this
 // has not been tested due to lack of fast enough SCSI adapter.
 // #define PLATFORM_MAX_SCSI_SPEED S2S_CFG_SPEED_SYNC_20
@@ -79,6 +80,9 @@ extern bool g_i2c_claimed;
 // Debug logging function, can be used to print to e.g. serial port.
 // May get called from interrupt handlers.
 void platform_log(const char *s);
+inline void log_lock() {g_log_lock = true;}
+inline void log_unlock() {g_log_lock = false;} 
+void platform_flush_usb_log();
 bool platform_emergency_log_save();
 
 // Timing and delay functions.

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -96,7 +96,7 @@ void save_logfile(bool always = false)
     return;
 #endif
 
-  if (!g_log_to_sd)
+  if (!g_log_to_sd || g_log_lock)
     return;
   
   static uint32_t prev_log_pos = 0;

--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -48,6 +48,7 @@ extern "C" uint32_t g_scsi_log_mask;
 
 // Firmware version string
 extern const char *g_log_firmwareversion;
+extern const char *g_log_short_firmwareversion;
 
 // Log string
 void log_raw(const char *str);

--- a/src/ZuluSCSI_usb_console_media.cpp
+++ b/src/ZuluSCSI_usb_console_media.cpp
@@ -22,6 +22,7 @@
 #include "ZuluSCSI_usb_console_media.h"
 #include "ZuluSCSI_platform.h"
 #include "ZuluSCSI_config.h"
+#include <ZuluSCSI_log.h>
 #include <ZuluSCSI_control_api.h>
 #include <string.h>
 #include <stdlib.h>
@@ -103,9 +104,36 @@ static int  s_num_len = 0;
 // Display helpers
 // -----------------------------------------------------------------------
 
+// Print the media status of a device:
+//   "image.iso"            - media loaded and inserted
+//   "(ejected) image.iso"  - ejected, but this image is still the selected one
+//   "(ejected)"            - ejected with no image selected
+static void print_media_status(uint8_t id)
+{
+    char cur[MAX_FILE_PATH];
+    bool ejected = true;
+    bool has_img = controlGetMediaStatus(id, cur, sizeof(cur), &ejected);
+
+    if (!has_img)
+    {
+        serial_out("(no image) [ejected]");
+        return;
+    }
+
+    const char *slash = strrchr(cur, '/');
+    serial_out(slash ? slash + 1 : cur);
+
+
+    if (ejected)
+        serial_out(" [ejected]");
+
+}
+
 static void show_device_list()
 {
+    platform_flush_usb_log();
     serial_println("");
+    serial_out("  ZuluSCSI ("); serial_out(g_log_short_firmwareversion); serial_println(")");
     serial_println("  Media Management");
     serial_println("  ================================================");
     serial_println("  Removable devices:");
@@ -119,15 +147,6 @@ static void show_device_list()
         for (int i = 0; i < s_removable_count; i++)
         {
             uint8_t id = s_removable_ids[i];
-            char cur[MAX_FILE_PATH];
-            bool has_img = controlGetCurrentImage(id, cur, sizeof(cur));
-
-            const char *basename = "(ejected)";
-            if (has_img)
-            {
-                const char *slash = strrchr(cur, '/');
-                basename = slash ? slash + 1 : cur;
-            }
 
             serial_out("    ");
             serial_out_int(i);
@@ -136,7 +155,7 @@ static void show_device_list()
             serial_out("  ");
             serial_out(controlGetDeviceTypeName(id));
             serial_out("  [");
-            serial_out(basename);
+            print_media_status(id);
             serial_println("]");
         }
     }
@@ -150,22 +169,17 @@ static void show_device_list()
 static void show_device_actions()
 {
     uint8_t id = s_removable_ids[s_selected_idx];
-    char cur[MAX_FILE_PATH];
-    bool has_img = controlGetCurrentImage(id, cur, sizeof(cur));
-    const char *basename = "(ejected)";
-    if (has_img)
-    {
-        const char *slash = strrchr(cur, '/');
-        basename = slash ? slash + 1 : cur;
-    }
-
+    platform_flush_usb_log();
+    log_lock();
     serial_println("");
+    serial_out("  ZuluSCSI ("); serial_out(g_log_short_firmwareversion); serial_println(")");
     serial_out("  Device SCSI ID ");
     serial_out_int((int)id);
     serial_out(": ");
     serial_println(controlGetDeviceTypeName(id));
     serial_out("  Current: ");
-    serial_println(basename);
+    print_media_status(id);
+    serial_println("");
     serial_println("  ================================================");
     serial_println("    'l' - list and select image");
     serial_println("    'n' - load next image");
@@ -173,6 +187,7 @@ static void show_device_actions()
     serial_println("    'i' - insert");
     serial_println("    'b' - back to device list");
     serial_println("  Or enter image number + Enter to load directly:");
+    log_unlock();
 }
 
 // Callback used by controlListImages() to print each entry
@@ -194,7 +209,8 @@ static void print_image_cb(int idx, const char *filename,
 static void show_image_list()
 {
     uint8_t id = s_removable_ids[s_selected_idx];
-
+    platform_flush_usb_log();
+    log_lock();
     serial_println("");
     serial_out("  Available images for SCSI ID ");
     serial_out_int((int)id);
@@ -324,11 +340,13 @@ void serialMediaMenuProcess(char c)
                     serial_out("' on SCSI ID ");
                     serial_out_int((int)id);
                     serial_println(" ...");
-
+                    platform_flush_usb_log();
+                    log_lock();
                     if (controlLoadImage(id, s_findNth.path))
                         serial_println("  Image loaded. Host will see a media change.");
                     else
                         serial_println("  Failed to load image.");
+                    log_unlock();
                 }
                 show_device_actions();
                 break;
@@ -366,6 +384,8 @@ void serialMediaMenuProcess(char c)
                 case 'e':
                 case 'E':
                 {
+                    platform_flush_usb_log();
+                    log_lock();
                     char id_str[4];
                     snprintf(id_str, sizeof(id_str), "%d", (int)id);
                     if (controlEjectMedia(id))
@@ -378,6 +398,7 @@ void serialMediaMenuProcess(char c)
                     {
                         serial_println("  Eject failed.");
                     }
+                    log_unlock();
                     show_device_actions();
                     break;
                 }
@@ -387,6 +408,9 @@ void serialMediaMenuProcess(char c)
                 {
                     char id_str[4];
                     snprintf(id_str, sizeof(id_str), "%d", (int)id);
+                    platform_flush_usb_log();
+                    log_lock();
+
                     if (controlInsertMedia(id))
                     {
                         serial_out("  SCSI ID ");
@@ -397,6 +421,7 @@ void serialMediaMenuProcess(char c)
                     {
                         serial_println("  Insert failed.");
                     }
+                    log_unlock();
                     show_device_actions();
                     break;
                 }


### PR DESCRIPTION
- Add flushing of the USB serial log out
- Add blocking of USB serial and SD card log out
- Log ZuluSCSI version in all USB serial menu systems

With the first two features, the media menu, which bypasses log functionality, can output the the USB serial without interleaving log messages when a action like images selection or ejection occurs.