### PR TITLE
Port of initiator: select with ATN and send IDENTIFY so SCSI-3 targets accept commands (50d6544)

### DIFF
--- a/src/ZuluSCSI_initiator.cpp
+++ b/src/ZuluSCSI_initiator.cpp
@@ -74,6 +74,9 @@ extern bool g_sdcard_present;
  * High level initiator mode logic   *
  *************************************/
 
+// Not in the SCSI_MESSAGE enum in scsi.h
+#define MSG_NO_OPERATION 0x08
+
 static struct {
     // Bitmap of all drives that have been imaged
     uint32_t drives_imaged;
@@ -82,6 +85,7 @@ static struct {
     uint8_t initiator_id;
     uint8_t max_retry_count;
     bool use_read10; // Always use read10 commands
+    bool use_identify; // Select with ATN and send IDENTIFY before each command
 
     // Is imaging a drive in progress, or are we scanning?
     bool imaging;
@@ -136,6 +140,7 @@ void scsiInitiatorInit()
     }
     g_initiator_state.max_retry_count = ini_getl("SCSI", "InitiatorMaxRetry", 5, CONFIGFILE);
     g_initiator_state.use_read10 = ini_getbool("SCSI", "InitiatorUseRead10", false, CONFIGFILE);
+    g_initiator_state.use_identify = ini_getbool("SCSI", "InitiatorIdentify", true, CONFIGFILE);
     g_initiator_state.use_vhd_format = ini_getbool("SCSI", "InitiatorVHD", false, CONFIGFILE);
 
     // treat initiator id as already imaged drive so it gets skipped
@@ -759,9 +764,20 @@ int scsiInitiatorRunCommand(int target_id,
                             const uint8_t *bufOut, size_t bufOutLen,
                             bool returnDataPhase, uint32_t timeout)
 {
+    // SCSI-3 targets take the LUN from the IDENTIFY message and reject
+    // anything selected without one (ILLEGAL REQUEST / LUN NOT SUPPORTED).
+    // The target only offers MESSAGE_OUT if we select with ATN asserted.
+    bool send_identify = g_initiator_state.use_identify;
+    bool identify_sent = false;
+
+    if (send_identify)
+    {
+        scsiHostPhySetATN(true);
+    }
 
     if (!scsiHostPhySelect(target_id, g_initiator_state.initiator_id))
     {
+        scsiHostPhySetATN(false);
         dbgmsg("------ Target ", target_id, " did not respond");
         scsiHostPhyRelease();
         return -1;
@@ -792,11 +808,23 @@ int scsiInitiatorRunCommand(int target_id,
         }
         else if (phase == MESSAGE_OUT)
         {
-            uint8_t identify_msg = 0x80;
-            scsiHostWrite(&identify_msg, 1);
+            // Negate ATN before the byte is acknowledged, otherwise the target
+            // keeps asking for more messages.
+            scsiHostPhySetATN(false);
+
+            // IDENTIFY, LUN 0, no disconnect privilege. A target that asks
+            // again gets NO OPERATION rather than a second IDENTIFY.
+            uint8_t msg = identify_sent ? MSG_NO_OPERATION : 0x80;
+            identify_sent = true;
+            scsiHostWrite(&msg, 1);
         }
         else if (phase == COMMAND)
         {
+            if (send_identify && !identify_sent)
+            {
+                // Target went straight to COMMAND, it does not use messages
+                scsiHostPhySetATN(false);
+            }
             scsiHostWrite(command, cmdLen);
         }
         else if (phase == DATA_IN)
@@ -848,6 +876,7 @@ int scsiInitiatorRunCommand(int target_id,
         }
     }
 
+    scsiHostPhySetATN(false);
     scsiHostWaitBusFree();
 
     return status;

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -68,6 +68,7 @@
 #InitiatorMaxRetry = 5 #  number of retries on failed reads 0-255, default is 5
 #InitiatorImageHandling = 0 # 0: skip existing images, 1: create new image with incrementing suffix, 2: overwrite existing image
 #InitiatorUseRead10 = 0 # 0: Always use READ6 command, 1: Always use READ10 command, not set: Autodetect READ10 support
+#InitiatorIdentify = 1 # 0: Select without ATN, 1: Select with ATN and send IDENTIFY (default) - required by SCSI-3 targets
 #InitiatorBusWidth = 0 # 0: Always 8-bit, 1: Always 16-bit, not set: Select best supported
 #InitiatorParity = 1 # 0: Disable, 1: Enable (default) - Use parity when cloning devices
 #InitiatorVHD = 0 # Set to 1 for hard drives to be imaged as fixed VHD images


### PR DESCRIPTION
Port of commit `50d6544` from
https://github.com/BlueSCSI/BlueSCSI-v2/commit/50d6544b70e69eb5e692c697acd108da681a7a14

Original Message
```
initiator: select with ATN and send IDENTIFY so SCSI-3 targets accept commands
SCSI-3 targets take the LUN from the IDENTIFY message, not from the CDB.

Opt out with InitiatorIdentify=No in the [SCSI] section
```

Added setting to example `zuluscsi.ini`