### PR TITLE
Port: fix: verify the extracted firmware file before rebooting to flash it (fe34f02)

### DIFF
--- a/lib/ZipParser/zip_parser.h
+++ b/lib/ZipParser/zip_parser.h
@@ -1,5 +1,6 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2024-2025 Rabbit Hole Computing™
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
  *
@@ -46,6 +47,8 @@ namespace zipparser
             int32_t Parse(uint8_t const *buf, const size_t size);
             bool FoundMatch();
             inline uint32_t GetCompressedSize() {return compressed_data_size;}
+            // Valid once Parse() has finished the local file header
+            inline uint32_t GetCrc() {return crc;}
 
         protected:
             bool filename_match;

--- a/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
@@ -136,12 +136,17 @@ SECTIONS
          */
         *ZuluSCSI_log.cpp.o(.text .text*)
         *ZuluSCSI_log_trace.cpp.o(.text .text*)
+        /* logmsg<> instantiations land in whichever object used them first,
+         * so the rule above misses them */
+        *(.text*_Z6logmsgIJ*)
 
         /* ROM drive setup and FW upgrade that is done only during init */
         *(.text*romDriveClear*)
         *(.text*romDriveCheckPresent*)
         *(.text*zipparser*)
         *(.text*firmware_update*)
+        *(.text*verify_extracted_firmware*)
+        *(.text*crc32_update*)
 
         /* ZuluSCSI_disk functions that are only used during init */
         *ZuluSCSI_settings.cpp.o(.text .text*)

--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
@@ -140,6 +140,8 @@ SECTIONS
         *(.text*romDriveCheckPresent*)
         *(.text*zipparser*)
         *(.text*firmware_update*)
+        *(.text*verify_extracted_firmware*)
+        *(.text*crc32_update*)
 
         /* ZuluSCSI_disk functions that are only used during init */
         *ZuluSCSI_settings.cpp.o(.text .text*)

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1399,6 +1399,65 @@ static void check_for_unused_update_files()
   }
 }
 
+// CRC32 nibble table, PKZIP polynomial
+static const uint32_t g_crc32_nibbles[16] = {
+  0x00000000, 0x1DB71064, 0x3B6E20C8, 0x26D930AC,
+  0x76DC4190, 0x6B6B51F4, 0x4DB26158, 0x5005713C,
+  0xEDB88320, 0xF00F9344, 0xD6D6A3E8, 0xCB61B38C,
+  0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C
+};
+
+__attribute__((optimize("Os")))
+static uint32_t crc32_update(uint32_t crc, const uint8_t *data, size_t len)
+{
+  for (size_t i = 0; i < len; i++)
+  {
+    crc ^= data[i];
+    crc = (crc >> 4) ^ g_crc32_nibbles[crc & 0x0F];
+    crc = (crc >> 4) ^ g_crc32_nibbles[crc & 0x0F];
+  }
+  return crc;
+}
+
+// Checks the extracted image against the size and CRC32 from the zip header.
+// Takes an already open file to keep firmware_update()'s stack frame down.
+__attribute__((optimize("Os"), noinline))
+static bool verify_extracted_firmware(FsFile &check, uint32_t expected_size,
+                                      uint32_t expected_crc, uint8_t *buf, size_t bufsize)
+{
+  if (check.fileSize() != expected_size)
+  {
+    logmsg("Extracted firmware is ", (int)check.fileSize(), " bytes on the card");
+    logmsg("Firmware package says ", (int)expected_size, " bytes");
+    return false;
+  }
+
+  uint32_t crc = 0xFFFFFFFF;
+  uint32_t total = 0;
+  int bytes_read;
+  while ((bytes_read = check.read(buf, bufsize)) > 0)
+  {
+    crc = crc32_update(crc, buf, bytes_read);
+    total += bytes_read;
+  }
+  crc ^= 0xFFFFFFFF;
+
+  if (total != expected_size)
+  {
+    logmsg("Could only read back ", (int)total, " bytes of the extracted firmware");
+    return false;
+  }
+
+  if (crc != expected_crc)
+  {
+    logmsg("Firmware CRC on the card: ", crc);
+    logmsg("Firmware CRC in the package: ", expected_crc);
+    return false;
+  }
+
+  return true;
+}
+
 // Update firmware by unzipping the firmware package
 static void firmware_update()
 {
@@ -1437,19 +1496,20 @@ static void firmware_update()
   while ((bytes_read = file.read(buf, sizeof(buf))) > 0)
   {
     parsed_length = parser.Parse(buf, bytes_read);
-    if (parsed_length == sizeof(buf))
+    // bytes_read, not sizeof(buf): a short read would break both seeks below
+    if (parsed_length == bytes_read)
        continue;
     if (parsed_length >= 0)
     {
       if (!parser.FoundMatch())
       {
         parser.Reset();
-        file.seekSet(file.position() - (sizeof(buf) - parsed_length) + parser.GetCompressedSize());
+        file.seekSet(file.position() - (bytes_read - parsed_length) + parser.GetCompressedSize());
       }
       else
       {
         // seek to start of data in matching file
-        file.seekSet(file.position() - (sizeof(buf) - parsed_length));
+        file.seekSet(file.position() - (bytes_read - parsed_length));
         break;
       }
     }
@@ -1471,37 +1531,81 @@ static void firmware_update()
     char firmware_name[64] = {0};
     memcpy(firmware_name, FIRMWARE_NAME_PREFIX, sizeof(FIRMWARE_NAME_PREFIX) - 1);
     memcpy(firmware_name + sizeof(FIRMWARE_NAME_PREFIX) - 1, ".bin", sizeof(".bin"));
-    target_firmware.open(&root, firmware_name, O_BINARY | O_WRONLY | O_CREAT | O_TRUNC);
-    uint32_t position = 0;
-    while ((bytes_read = file.read(buf, sizeof(buf))) > 0)
+
+    const uint32_t expected_size = parser.GetCompressedSize();
+    const uint32_t expected_crc = parser.GetCrc();
+    bool extracted = false;
+
+    if (!target_firmware.open(&root, firmware_name, O_BINARY | O_WRONLY | O_CREAT | O_TRUNC))
     {
-      if (bytes_read > parser.GetCompressedSize() - position)
-        bytes_read =  parser.GetCompressedSize() - position;
-      target_firmware.write(buf, bytes_read);
-      position += bytes_read;
-      if (position >= parser.GetCompressedSize())
+      logmsg("Could not create the firmware image on the SD card");
+    }
+    else
+    {
+      uint32_t position = 0;
+      bool write_ok = true;
+      while (position < expected_size && (bytes_read = file.read(buf, sizeof(buf))) > 0)
       {
-        break;
+        if ((uint32_t)bytes_read > expected_size - position)
+          bytes_read = expected_size - position;
+
+        if (target_firmware.write(buf, bytes_read) != (size_t)bytes_read)
+        {
+          logmsg("SD card write failed at offset ", (int)position, " while extracting firmware");
+          write_ok = false;
+          break;
+        }
+        position += bytes_read;
+      }
+
+      if (write_ok && target_firmware.getWriteError())
+      {
+        logmsg("SD card reported a write error while extracting firmware");
+        write_ok = false;
+      }
+      target_firmware.close();
+
+      if (write_ok && position != expected_size)
+      {
+        logmsg("Firmware package ended early at byte ", (int)position, ", it is truncated");
+        write_ok = false;
+      }
+
+      if (write_ok)
+      {
+        // A write that never reached the card looks fine from the write side
+        if (!target_firmware.open(&root, firmware_name, O_BINARY | O_RDONLY))
+        {
+          logmsg("Could not reopen the extracted firmware to verify it");
+        }
+        else
+        {
+          extracted = verify_extracted_firmware(target_firmware, expected_size,
+                                                expected_crc, buf, sizeof(buf));
+          target_firmware.close();
+        }
       }
     }
-    // zip file has a central directory at the end of the file,
-    // so the compressed data should never hit the end of the file
-    // so bytes read should always be greater than 0 for a valid datastream
-    if (bytes_read > 0)
+
+    file.close();
+
+    if (extracted)
     {
-      target_firmware.close();
-      file.close();
+      // Drop the package only once the image verifies, so a bad
+      // extraction can still be retried
       root.remove(name);
       root.close();
       logmsg("Update extracted from package, rebooting MCU");
+      platform_flush_usb_log();
       g_rebooting = true;
     }
     else
     {
-      target_firmware.close();
-      logmsg("Error reading firmware package file");
       root.remove(firmware_name);
+      logmsg("Firmware update failed, keeping the package - power cycle to retry");
+      root.close();
     }
+    return;
   }
   file.close();
   root.close();

--- a/src/ZuluSCSI_bootloader.cpp
+++ b/src/ZuluSCSI_bootloader.cpp
@@ -1,5 +1,6 @@
-/** 
+/**
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * Copyright (c) 2025-2026 Eric Helgeson <eric@bluescsi.com>
  * 
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
  * 
@@ -63,6 +64,14 @@ bool find_firmware_image(FsFile &file, char name[MAX_FILE_PATH + 1])
 bool program_firmware(FsFile &file)
 {
     uint32_t filesize = file.size();
+
+    if (filesize <= PLATFORM_BOOTLOADER_SIZE)
+    {
+        logmsg("Firmware file too small: ", (int)filesize, " bytes, minimum ",
+               (int)PLATFORM_BOOTLOADER_SIZE);
+        return false;
+    }
+
     uint32_t fwsize = filesize - PLATFORM_BOOTLOADER_SIZE;
     uint32_t num_pages = (fwsize + PLATFORM_FLASH_PAGE_SIZE - 1) / PLATFORM_FLASH_PAGE_SIZE;
 
@@ -89,10 +98,22 @@ bool program_firmware(FsFile &file)
         else
             LED_OFF();
         
-        if (file.read(buffer, PLATFORM_FLASH_PAGE_SIZE) <= 0)
+        int bytes_read = file.read(buffer, PLATFORM_FLASH_PAGE_SIZE);
+        if (bytes_read <= 0)
         {
             logmsg("Firmware file read failed on page ", i);
             return false;
+        }
+
+        if (bytes_read < (int)PLATFORM_FLASH_PAGE_SIZE)
+        {
+            // Only the final page may be short, elsewhere the tail is stale
+            if (i != (int)num_pages - 1)
+            {
+                logmsg("Short read on page ", i, ", got bytes: ", bytes_read);
+                return false;
+            }
+            memset(buffer + bytes_read, 0xFF, PLATFORM_FLASH_PAGE_SIZE - bytes_read);
         }
 
         if (!platform_rewrite_flash_page(PLATFORM_BOOTLOADER_SIZE + i * PLATFORM_FLASH_PAGE_SIZE, buffer))
@@ -120,6 +141,28 @@ bool program_firmware(FsFile &file)
 }
 
 #endif // PLATFORM_FLASH_SECTOR_ERASE
+
+// Keep a rejected image, but out of the way so the next boot does not retry it
+static void move_bad_firmware_aside(const char *name)
+{
+    char badname[MAX_FILE_PATH + 5];
+    size_t namelen = strlen(name);
+    if (namelen > MAX_FILE_PATH) return;
+
+    memcpy(badname, name, namelen);
+    memcpy(badname + namelen, ".bad", sizeof(".bad"));
+
+    SD.remove(badname); // rename() will not overwrite an existing file
+    if (SD.rename(name, badname))
+    {
+        logmsg("Renamed rejected firmware to ", badname);
+    }
+    else if (SD.remove(name))
+    {
+        logmsg("Removed rejected firmware ", name);
+    }
+    logmsg("Copy the firmware .zip to the SD card again to retry the update");
+}
 
 static bool mountSDCard()
 {
@@ -165,6 +208,8 @@ int bootloader_main(void)
             else
             {
                 logmsg("Firmware update failed!");
+                fwfile.close();
+                move_bad_firmware_aside(name);
                 platform_emergency_log_save();
             }
             


### PR DESCRIPTION
Check CRC of extracted firmware file from universal zip and add more firmware file size checks.

Port of commit `fe34f02`
https://github.com/BlueSCSI/BlueSCSI-v2/commit/fe34f02cd971fb3a0de91c71bba8f3123f55232e

Original commit message:
```
fix: verify the extracted firmware file before rebooting to flash it
```