### PR TITLE
Fix permanent SD-card log lockout after opening the media menu's image list

### DIFF
--- a/src/ZuluSCSI_usb_console_media.cpp
+++ b/src/ZuluSCSI_usb_console_media.cpp
@@ -226,6 +226,7 @@ static void show_image_list()
 
     serial_println("  ------------------------------------------------");
     serial_println("  Enter image number then Enter, or 'b' to cancel:");
+    log_unlock();
 }
 
 // Callback to resolve the Nth image to a full path


### PR DESCRIPTION
show_image_list() took log_lock() to guard its screen output but never released it - none of the three ways to leave MEDIA_MENU_IMAGE_LIST (cancel, invalid index, successful load) called log_unlock() either. save_logfile() checks the lock and bails out immediately if held, so opening this screen once silently stopped all SD-card log writes for the rest of that boot, with console output unaffected.

Fixed at the source: release the lock at the end of show_image_list() itself, right after the screen finishes printing, matching how every other menu action in this file already brackets log_lock()/log_unlock() tightly around the print instead of holding it across a wait for input.