### PR TITLE
Fix Test Unit Ready for removable devices with no SD

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -656,21 +656,6 @@ static bool autoCreateAS400ProfileImages()
 }
 #endif
 
-static bool typeIsRemovable(S2S_CFG_TYPE type)
-{
-  switch (type)
-  {
-  case S2S_CFG_OPTICAL:
-  case S2S_CFG_MO:
-  case S2S_CFG_FLOPPY_14MB:
-  case S2S_CFG_ZIP100:
-  case S2S_CFG_REMOVABLE:
-  case S2S_CFG_SEQUENTIAL:
-    return true;
-  default:
-    return false;
-  }
-}
 static bool mountSDCard();
 static void spin_for_reboot(bool rebooting);
 
@@ -1083,7 +1068,7 @@ bool findHDDImages()
               ", BlockSize: ", (int)cfg->bytesPerSector,
               ", Sectors: ", (int) cfg->scsiSectors,
               ", Size: ", capacity_kB, "kB",
-              typeIsRemovable((S2S_CFG_TYPE)cfg->deviceType) ? ", Removable" : ""
+              scsiDiskTypeIsRemovable((S2S_CFG_TYPE)cfg->deviceType) ? ", Removable" : ""
               );
        }
     }
@@ -1094,7 +1079,7 @@ bool findHDDImages()
     const S2S_TargetCfg* cfg = s2s_getConfigByIndex(id);
     if (cfg  && (cfg->scsiId & S2S_CFG_TARGET_ENABLED ))
     {
-       if (typeIsRemovable((S2S_CFG_TYPE)cfg->deviceType))
+       if (scsiDiskTypeIsRemovable((S2S_CFG_TYPE)cfg->deviceType))
         {
           removable_count++;
           last_removable_device = id;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -190,6 +190,21 @@ bool scsiDiskActivateRomDrive()
 #endif
 }
 
+bool scsiDiskTypeIsRemovable(S2S_CFG_TYPE type)
+{
+  switch (type)
+  {
+  case S2S_CFG_OPTICAL:
+  case S2S_CFG_MO:
+  case S2S_CFG_FLOPPY_14MB:
+  case S2S_CFG_ZIP100:
+  case S2S_CFG_REMOVABLE:
+  case S2S_CFG_SEQUENTIAL:
+    return true;
+  default:
+    return false;
+  }
+}
 
 /***********************/
 /* Image configuration */
@@ -2083,10 +2098,18 @@ int doTestUnitReady()
     {
         ready = 0;
         scsiDev.status = CHECK_CONDITION;
-         // AS/400: preserve pending sense (e.g. UNIT ATTENTION / POWER ON RESET)
-        // so the host sees it before we overwrite with NOT_READY
-        if (scsiDev.target->sense.code == NO_SENSE)
+        if (scsiDev.target->started
+            && !img.file.isOpen()
+            && scsiDiskTypeIsRemovable((S2S_CFG_TYPE)img.deviceType))
         {
+            // Removable device and the image file is not open, likely because the SD card was removed.
+            scsiDev.target->sense.code = NOT_READY;
+            scsiDev.target->sense.asc = MEDIUM_NOT_PRESENT;
+        }
+        else if (scsiDev.target->sense.code == NO_SENSE)
+        {
+            // AS/400: preserve pending sense (e.g. UNIT ATTENTION / POWER ON RESET)
+            // so the host sees it before we overwrite with NOT_READY
             scsiDev.target->sense.code = NOT_READY;
             scsiDev.target->sense.asc = LOGICAL_UNIT_NOT_READY_INITIALIZING_COMMAND_REQUIRED;
         }

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -260,3 +260,5 @@ const uint8_t *scsiDiskPrefetchRead(uint8_t scsiId, uint32_t firstSector, uint32
 // If scsiId is given, only invalidate if that device has data in buffer.
 // If scsiId is not given (value -1), invalidate for all devices.
 void scsiDiskPrefetchInvalidate(uint8_t scsiId = (uint8_t)-1);
+
+bool scsiDiskTypeIsRemovable(S2S_CFG_TYPE type);


### PR DESCRIPTION
The TEST UNIT READY command was retuning a check condition for hard drives that hadn't started or there was no image when the device was actually removable. This fix returns Medium Not Present for these devices when on image is present, most likely because the SD card was removed.

This is attempting to address an emulated MO device not reading reading media after the SD card was removed and reinserted.