### PR TITLE
Fix hardcoded SCSI ID limits and masks

### DIFF
--- a/lib/ZuluSCSI_UI_RP2MCU/BrowseScreenFlat.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/BrowseScreenFlat.cpp
@@ -98,7 +98,7 @@ void BrowseScreenFlat::initPrefix(int index)
 {
   char pre[4];
   strcpy(pre, typeToShortString(_deviceMap->DeviceType));
-  pre[2] = '0' + index;
+  pre[2] = scsiEncodeID(index);
   pre[3] = 0;
 
   if (SDNavTotalPrefixFiles.TotalItems(pre, _totalObjects))
@@ -330,10 +330,7 @@ void BrowseScreenFlat::getCurrentFilename()
     {
       char pre[4];
       strcpy(pre, typeToShortString(_deviceMap->DeviceType));
-      if (_scsiId >= 0 && _scsiId <= 9)
-        pre[2] = '0' + _scsiId;
-      else if (_scsiId >= 10  && _scsiId <= 15)
-        pre[2] = 'A' + (_scsiId - 10);
+      pre[2] = scsiEncodeID(_scsiId);
       pre[3] = '\0';
       SDNavPrefixFileByIndex.GetFileByIndex(pre, _currentObjectIndex, _currentObjectName, MAX_PATH_LEN, _currentObjectSize);
       strcpy(_currentObjectDisplayName, _currentObjectName);

--- a/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
+++ b/lib/ZuluSCSI_WebUI_RP2MCU/ZuluSCSI_WebUI.cpp
@@ -239,7 +239,7 @@ static void send_filenames_for_device(uint8_t scsi_id)
 static void send_all_filenames()
 {
     uint8_t ids[S2S_MAX_TARGETS];
-    int count = controlListRemovableDevices(ids, 8);
+    int count = controlListRemovableDevices(ids, S2S_MAX_TARGETS);
     for (int i = 0; i < count; i++)
     {
         send_filenames_for_device(ids[i]);

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1585,7 +1585,7 @@ static void diskEjectAction(uint8_t buttonId)
                     && img.ejectFixedDiskEnable)
             {
                 found = true;
-                uint8_t target = img.scsiId & 7;
+                uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
                 if (!img.ejectFixedDiskPending && !img.ejectFixedDiskWriteBlocked)
                 {
                     logmsg("Eject button ", (int)img.ejectButton, " pressed, scheduling eject for fixed disk SCSI ID: ", (int)i);
@@ -1641,7 +1641,7 @@ uint8_t diskEjectButtonUpdate(bool immediate)
         if (ejectors)
         {
             uint8_t mask = 1;
-            for (uint8_t i = 0; i < 8; i++)
+            for (uint8_t i = 0; i < S2S_MAX_TARGETS; i++)
             {
                 if (ejectors & mask) diskEjectAction(ejectors & mask);
                 mask = mask << 1;
@@ -4323,7 +4323,7 @@ void scsiDiskInit()
 // Switch image on ejection.
 void cdromLoadImage(image_config_t &img, const char* next_filename)
 {
-    uint8_t target = img.scsiId & 7;
+    uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
 #if ENABLE_AUDIO_OUTPUT
     // terminate audio playback if active on this target (MMC-1 Annex C)
     audio_stop(target);
@@ -4347,7 +4347,7 @@ void cdromLoadImage(image_config_t &img, const char* next_filename)
 // Eject and switch image
 static void genericLoadImage(image_config_t &img, const char* next_filename)
 {
-    uint8_t target = img.scsiId & 7;
+    uint8_t target = img.scsiId & S2S_CFG_TARGET_ID_BITS;
     if (!img.ejected)
     {
         blink_cancel();
@@ -4401,7 +4401,7 @@ extern "C" void loadImage()
 {
 #if defined(CONTROL_BOARD)
    loadImageToggleEject(g_pendingLoadIndex, g_filenameToLoad); // first will eject
-   loadImageToggleEject(g_pendingLoadIndex, g_filenameToLoad); // secind will clode
+   loadImageToggleEject(g_pendingLoadIndex, g_filenameToLoad); // second will close
 
    g_pendingLoadComplete = g_pendingLoadIndex;
    g_pendingLoadIndex = -1;


### PR DESCRIPTION
This addresses an issue of selecting prefixed images with the Control Board when SCSI IDs and equal to hex 0xA or higher. The browser screen would display images outside of the correct SCSI ID prefix.

It also fixes an issue where the eject button on the Wide Board for Wide SCSI IDs of 8 and above were ejecting both the proper SCSI ID and a lower (0-7) SCSI ID and logging the eject of the lower SCSI ID even if the device doesn't exist.