### PR TITLE
Add debug warning and fix logging features

### DIFF
--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -31,6 +31,8 @@ extern "C" {
 
 #define S2S_CFG_SIZE (S2S_MAX_TARGETS * sizeof(S2S_TargetCfg) + sizeof(S2S_BoardCfg))
 
+#define S2S_CFG_TARGETS_BITMAP ((1 << S2S_MAX_TARGETS) - 1)
+
 typedef enum
 {
 	S2S_CFG_TARGET_ID_BITS = (S2S_MAX_TARGETS - 1),

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -77,7 +77,7 @@ bool g_rawdrive_active;
 bool g_romdrive_active;
 bool g_sdcard_present;
 bool g_rebooting = false;
-bool g_log_to_sd;
+bool g_log_to_sd = true;
 #ifndef SD_SPEED_CLASS_WARN_BELOW
 #define SD_SPEED_CLASS_WARN_BELOW 10
 #endif
@@ -239,7 +239,27 @@ void init_logfile()
   {
     logmsg("Failed to open log file: ", SD.sdErrorCode());
   }
+
+  bool temp_log_to_sd = ini_getbool("SCSI", "LogToSDCard", 1, CONFIGFILE);
+  if (!temp_log_to_sd)
+  {
+    logmsg("========================================================");
+    logmsg(" Warning LogToSDCard is disabled, no further log messages");
+    logmsg(" will written to the SD card's ", LOGFILE);
+    logmsg("=========================================================");
+  }
+
+  if (!g_log_to_sd && temp_log_to_sd)
+  {
+    logmsg("========================================================");
+    logmsg(" LogToSDCard is has been reenabled, log messages will");
+    logmsg(" be written to the SD card's ", LOGFILE);
+    logmsg("=========================================================");
+    g_log_to_sd = temp_log_to_sd;
+  }
+
   save_logfile(true);
+  g_log_to_sd = temp_log_to_sd;
 
   first_open_after_boot = false;
 }
@@ -1211,34 +1231,22 @@ static bool mountSDCard()
 static void reinitSCSI()
 {
 #if defined(ZULUSCSI_HARDWARE_CONFIG)
-  if (!g_hw_config.is_active() && ini_getbool("SCSI", "Debug", 0, CONFIGFILE))
+  if (!g_hw_config.is_active())
   {
-    g_log_debug = true;
+    g_log_debug = ini_getbool("SCSI", "Debug", g_log_debug, CONFIGFILE);
   }
 #else
-  if (ini_getbool("SCSI", "Debug", 0, CONFIGFILE))
-  {
-    g_log_debug = true;
-  }
+  g_log_debug = ini_getbool("SCSI", "Debug", g_log_debug, CONFIGFILE);
 #endif
+
   if (g_log_debug)
   {
-    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", 0xFF, CONFIGFILE) & 0xFF;
-    if (g_scsi_log_mask == 0)
-    {
-      dbgmsg("DebugLogMask set to 0x00, this will silence all debug messages when a SCSI ID has been selected");
-    }
-    else if (g_scsi_log_mask != 0xFF)
-    {
-      dbgmsg("DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
-    }
-
-    g_log_ignore_busy_free = ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE);
-    if (g_log_ignore_busy_free)
-    {
-      dbgmsg("DebugIgnoreBusyFree enabled, BUS_FREE/BUS_BUSY messages suppressed");
-    }
+      logmsg("===========================================================");
+      logmsg(" Debug logging has been enabled. This will severely impact ");
+      logmsg(" performance and is not recommended for normal use.        ");
+      logmsg("===========================================================");
   }
+
 #ifdef PLATFORM_HAS_INITIATOR_MODE
   if (platform_is_initiator_mode_enabled())
   {
@@ -1751,7 +1759,7 @@ static void zuluscsi_setup_sd_card(bool wait_for_card = true)
     char presetName[32];
     ini_gets("SCSI", "System", "", presetName, sizeof(presetName), CONFIGFILE);
     scsi_system_settings_t *cfg = g_scsi_settings.initSystem(presetName, true);
-    g_log_to_sd = g_scsi_settings.getSystem()->logToSDCard;
+
     initUIPostSDInit(true);
 
     #ifdef RECLOCKING_SUPPORTED

--- a/src/ZuluSCSI_log.cpp
+++ b/src/ZuluSCSI_log.cpp
@@ -77,6 +77,19 @@ void log_raw(uint8_t value)
     log_raw(hexbuf);
 }
 
+// Log byte as hex
+void log_raw(uint16_t value)
+{
+    const char *nibble = "0123456789ABCDEF";
+    char hexbuf[7] = {
+        '0', 'x', 
+        nibble[(value >> 12) & 0xF], nibble[(value >>  8) & 0xF],
+        nibble[(value >>  4) & 0xF], nibble[(value >>  0) & 0xF],
+        0
+    };
+    log_raw(hexbuf);
+}
+
 // Log integer as hex
 void log_raw(uint32_t value)
 {

--- a/src/ZuluSCSI_log.h
+++ b/src/ZuluSCSI_log.h
@@ -30,7 +30,7 @@
 #include <stddef.h>
 #include <scsiPhy.h>
 
- # define ZULUSCSI_DEFAULT_LOG_MASK S2S_CFG_TARGET_ID_BITS
+#define ZULUSCSI_DEFAULT_LOG_MASK S2S_CFG_TARGETS_BITMAP
 
 
 // Get total number of bytes that have been written to log
@@ -45,6 +45,7 @@ const char *log_get_buffer(uint32_t *startpos, uint32_t *available = nullptr);
 extern "C" bool g_log_debug;
 extern "C" bool g_log_ignore_busy_free;
 extern "C" uint32_t g_scsi_log_mask;
+extern "C" bool g_log_to_sd;
 
 // Firmware version string
 extern const char *g_log_firmwareversion;
@@ -55,6 +56,9 @@ void log_raw(const char *str);
 
 // Log byte as hex
 void log_raw(uint8_t value);
+
+// Log byte as hex
+void log_raw(uint16_t value);
 
 // Log integer as hex
 void log_raw(uint32_t value);

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -225,6 +225,11 @@ void log_getl_8bit_hex_with_negative(const char *Key, long value)
     }
 }
 
+void log_getl_16bit_hex(const char *Key, long value)
+{
+    logmsg("---- ", Key, " = ", (uint16_t) value);
+}
+
 void log_getl_quirks(const char *Key, long value)
 {
     if (value == 0)
@@ -578,19 +583,6 @@ static void readIniSCSIDeviceSetting(scsi_device_settings_t &cfg, const char *se
 #endif
 
 
-
-    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE) & ZULUSCSI_DEFAULT_LOG_MASK;
-    if (g_scsi_log_mask == 0)
-    {
-      dbgmsg("DebugLogMask set to 0x00, this will silence all debug messages when a SCSI ID has been selected");
-    }
-    else if (g_scsi_log_mask != ZULUSCSI_DEFAULT_LOG_MASK)
-    {
-      dbgmsg("DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
-    }
-
-    g_log_ignore_busy_free = ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE);
-
 }
 
 scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, bool disable_logging)
@@ -657,8 +649,6 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 #else
     cfgSys.maxBusWidth = 0;
 #endif
-
-    cfgSys.logToSDCard = true;
 
     cfgSys.logRotate = 1;
 
@@ -874,7 +864,6 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
     }
 
     cfgSys.maxBusWidth = log_ini_getl("SCSI", "MaxBusWidth", cfgSys.maxBusWidth, CONFIGFILE, log_settings, log_getl_bus_width);
-    cfgSys.logToSDCard = log_ini_getbool("SCSI", "LogToSDCard", cfgSys.logToSDCard, CONFIGFILE, log_settings);
     cfgSys.logRotate = log_ini_getl("SCSI", "LogRotate", cfgSys.logRotate, CONFIGFILE, log_settings, log_getl_log_rotate);
     
     cfgSys.wifi_keep_alive_s = log_ini_getl("SCSI", "WiFiKeepAliveSecs", cfgSys.wifi_keep_alive_s, CONFIGFILE, log_settings);
@@ -887,7 +876,12 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 
 // Setting not stored m_sys or m_dev but should be printed out
     log_ini_getbool("SCSI", "Debug", 0, CONFIGFILE, log_settings);
-    log_ini_getl("SCSI", "DebugLogMask", 0xFF, CONFIGFILE, log_settings, &log_getl_8bit_hex);
+    log_ini_getbool("SCSI", "LogToSDCard", 1, CONFIGFILE, log_settings);
+#if PLATFORM_MAX_BUS_WIDTH == 1
+    log_ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE, log_settings, &log_getl_16bit_hex);
+#else
+    log_ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE, log_settings, &log_getl_8bit_hex);
+#endif
     log_ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE, log_settings);
     log_ini_getbool("SCSI", "DisableStatusLED", false, CONFIGFILE, log_settings);
 
@@ -905,6 +899,32 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 
     log_ini_getbool("SCSI", "DisableROMDrive", 0, CONFIGFILE, log_settings);
     log_ini_getl("SCSI", "ROMDriveSCSIID", -1, CONFIGFILE, log_settings);
+
+
+    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE) & ZULUSCSI_DEFAULT_LOG_MASK;
+    if (!disable_logging && g_log_debug && g_scsi_log_mask == 0)
+    {
+#if PLATFORM_MAX_BUS_WIDTH == 1
+        logmsg("---- DebugLogMask set to ", (uint16_t) 0x0000, ", this will silence all debug messages when a SCSI ID has been selected");
+#else
+        logmsg("---- DebugLogMask set to ", (uint8_t) 0x00, ", this will silence all debug messages when a SCSI ID has been selected");
+#endif
+    }
+    else if (!disable_logging && g_scsi_log_mask != ZULUSCSI_DEFAULT_LOG_MASK)
+    {
+#if PLATFORM_MAX_BUS_WIDTH == 1
+        logmsg("---- DebugLogMask set to ", (uint16_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
+#else
+        logmsg("---- DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
+#endif
+    }
+
+    g_log_ignore_busy_free = ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE);
+    if (!disable_logging && g_log_debug && g_log_ignore_busy_free)
+    {
+        logmsg("---- DebugIgnoreBusyFree enabled, BUS_FREE/BUS_BUSY messages suppressed");
+    }
+
     return &cfgSys;
 }
 

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -133,8 +133,6 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
 
     bool initiatorParity;
 
-    bool logToSDCard;
-
     int logRotate;
 
     uint32_t wifi_keep_alive_s;


### PR DESCRIPTION
- Add a warning banner if debug is on
- Add a warning banner if LogToSDCard is off
- Allow turning on and off Debug and LogToSDCard when they are changed in the zuluscsi.ini file and the SD card is reinserted
- Fix DebugLogMask for wide bus widths
- Move reading in certain debug settings for better readability in the log