### PR TITLE
Add setting DebugLogSCSIID to filter a single ID

### DIFF
--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -877,6 +877,18 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 // Setting not stored m_sys or m_dev but should be printed out
     log_ini_getbool("SCSI", "Debug", 0, CONFIGFILE, log_settings);
     log_ini_getbool("SCSI", "LogToSDCard", 1, CONFIGFILE, log_settings);
+
+    int8_t dbgLogScsiId = log_ini_getl("SCSI", "DebugLogSCSIID", -1, CONFIGFILE, log_settings);
+    if (dbgLogScsiId >= 0 && dbgLogScsiId < S2S_MAX_TARGETS)
+    {
+        g_scsi_log_mask = 1 << dbgLogScsiId;
+    }
+    else if (dbgLogScsiId != -1)
+    {
+        logmsg("---- DebugLogSCSIID value ", dbgLogScsiId, " is invalid, must be between 0 and ", PLATFORM_MAX_BUS_WIDTH - 1);
+        dbgLogScsiId = -1;
+    }
+
 #if PLATFORM_MAX_BUS_WIDTH == 1
     log_ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE, log_settings, &log_getl_16bit_hex);
 #else
@@ -901,22 +913,26 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
     log_ini_getl("SCSI", "ROMDriveSCSIID", -1, CONFIGFILE, log_settings);
 
 
-    g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE) & ZULUSCSI_DEFAULT_LOG_MASK;
-    if (!disable_logging && g_log_debug && g_scsi_log_mask == 0)
+
+    if (dbgLogScsiId == -1)
     {
+        g_scsi_log_mask = ini_getl("SCSI", "DebugLogMask", ZULUSCSI_DEFAULT_LOG_MASK, CONFIGFILE) & ZULUSCSI_DEFAULT_LOG_MASK;
+        if (!disable_logging && g_log_debug && g_scsi_log_mask == 0)
+        {
 #if PLATFORM_MAX_BUS_WIDTH == 1
-        logmsg("---- DebugLogMask set to ", (uint16_t) 0x0000, ", this will silence all debug messages when a SCSI ID has been selected");
+            logmsg("---- DebugLogMask set to ", (uint16_t) 0x0000, ", this will silence all debug messages when a SCSI ID has been selected");
 #else
-        logmsg("---- DebugLogMask set to ", (uint8_t) 0x00, ", this will silence all debug messages when a SCSI ID has been selected");
+            logmsg("---- DebugLogMask set to ", (uint8_t) 0x00, ", this will silence all debug messages when a SCSI ID has been selected");
 #endif
-    }
-    else if (!disable_logging && g_scsi_log_mask != ZULUSCSI_DEFAULT_LOG_MASK)
-    {
+        }
+        else if (!disable_logging && g_scsi_log_mask != ZULUSCSI_DEFAULT_LOG_MASK)
+        {
 #if PLATFORM_MAX_BUS_WIDTH == 1
-        logmsg("---- DebugLogMask set to ", (uint16_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
+            logmsg("---- DebugLogMask set to ", (uint16_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
 #else
-        logmsg("---- DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
+            logmsg("---- DebugLogMask set to ", (uint8_t) g_scsi_log_mask, " only SCSI ID's matching the bit mask will be logged");
 #endif
+        }
     }
 
     g_log_ignore_busy_free = ini_getbool("SCSI", "DebugIgnoreBusyFree", 0, CONFIGFILE);

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -17,7 +17,9 @@
 #System="Mac" # This will apply compatibility settings automatically for the selected system from the above list.
 
 #Debug = 0   # Same effect as DIPSW2, enables verbose log messages
-#DebugLogMask = 255 # A bit mask for SCSI IDs 0-7, filters only matching SCSI ID debug messages
+#DebugLogSCSIID = -1 # log all SCSI IDs, 0-7 and 0-15 for wide -- log only the specified SCSI ID. Overrides DebugLogMask.
+#DebugLogMask = 0xFFFF # A bit mask for SCSI IDs 0-7 or 0-15 for wide -- filters only matching SCSI ID debug messages.
+# Example 0x8005 would log only SCSI IDs 0 (first bit), 2 (third bit), 15 (16th bit). As individual hex bits 0x0001 | 0x0004 | 0x8000
 #DebugIgnoreBusyFree = 0 # Set to 1 to ignore the BUS_FREE and BUS_BUSY logging
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card


### PR DESCRIPTION
If `DebugLogSCSIID` is set set in the global`[SCSI]` section, the firmware will now log debug messages only for the selected SCSI ID. This is useful for reducing noise, and write volume, when troubleshooting with using debug logging enabled.

The value can be set to 0-7 for Narrow SCSI and 0-15 for Wide SCSI.

It will override the DebugLogMask setting if both are set.