### PR TITLE
Strip .txt.txt extension with CREATE files and verify resulting filename

### DIFF
--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -373,11 +373,14 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
   imgname[MAX_FILE_PATH] = '\0';
   int namelen = strlen(imgname);
 
-  // Strip .txt extension if any
-  if (namelen >= 4 && strncasecmp(imgname + namelen - 4, ".txt", 4) == 0)
+  // Strip possible .txt.txt extension or single .txt extension, and add .bin if no extension
+  for (uint8_t i = 0; i < 2; i++)
   {
-    namelen -= 4;
-    imgname[namelen] = '\0';
+    if (namelen >= 4 && strncasecmp(imgname + namelen - 4, ".txt", 4) == 0)
+    {
+      namelen -= 4;
+      imgname[namelen] = '\0';
+    }
   }
 
   // Add .bin if no extension
@@ -385,6 +388,28 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
   {
     namelen += 4;
     strcat(imgname, ".bin");
+  }
+  
+  if (!scsiDiskFilenameValid(imgname, true))
+  {
+    logmsg("---- Create command filename '", cmd_filename, "' creates an invalid filename '", imgname, "'");
+    logmsg("---- Renaming ", cmd_filename, " to \"-Failed-", cmd_filename, "\"");
+    strncpy(imgname, "-Failed-", MAX_FILE_PATH);
+    if (strlen(cmd_filename) < MAX_FILE_PATH - sizeof("-Failed-"))
+    {
+      strcat(imgname, cmd_filename);
+    }
+    else
+    {
+      logmsg("---- Create command filename '", cmd_filename, "' is too long to rename to \"-Failed-", cmd_filename, "\"");
+      return false;
+    }
+
+    if (!SD.rename(cmd_filename, imgname))
+    {
+      logmsg("---- Failed to rename ", cmd_filename, " to \"-Failed-", cmd_filename, "\"");
+      return false;
+    }
   }
 
   return true;

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -789,8 +789,15 @@ static void checkDiskGeometryDivisible(image_config_t &img)
     }
 }
 
-bool scsiDiskFilenameValid(const char* name)
+bool scsiDiskFilenameValid(const char* name, bool quiet)
 {
+    // Check first character
+    if (!isalnum(name[0]))
+    {
+        // ignore files that don't start with a letter or a number
+        return false;
+    }
+
     // Check file extension
     const char *extension = strrchr(name, '.');
     if (extension)
@@ -829,16 +836,10 @@ bool scsiDiskFilenameValid(const char* name)
         {
             if (strcasecmp(extension, archive_exts[i]) == 0)
             {
-                logmsg("-- Ignoring compressed file ", name);
+                if (!quiet) logmsg("-- Ignoring compressed file ", name);
                 return false;
             }
         }
-    }
-    // Check first character
-    if (!isalnum(name[0]))
-    {
-        // ignore files that don't start with a letter or a number
-        return false;
     }
     return true;
 }

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -174,7 +174,7 @@ int scsiDiskReadImgX(const char *section, int index, char *buf, size_t buflen);
 
 // Checks if a filename extension is appropriate for further processing as a disk image.
 // The current implementation does not check the the filename prefix for validity.
-bool scsiDiskFilenameValid(const char* name);
+bool scsiDiskFilenameValid(const char* name, bool quiet = false);
 
 // Check if a directory contains a .cue sheet file.
 // This is used when single .cue sheet references multiple .bin files.


### PR DESCRIPTION
Most modern file managers hide file extensions by default, making it easy to inadvertently create a file such as `CREATE 2GB hd1-my-image.txt.txt`. Now, when ZuluSCSI firmware detects a `Create` filename with `.txt.txt` as the suffix, it will verify if the filename is valid for a disk image, and strip the double `.txt.txt`

If the filename is found to be invalid, it renames the CREATE file with a `-Failed-` prefix.