### PR TITLE
Strip zuluscsi.ini when writing it to cache

### DIFF
--- a/lib/minIni/minIni_cache.cpp
+++ b/lib/minIni/minIni_cache.cpp
@@ -3,7 +3,9 @@
 // after boot or SD-card removal.
 
 #include <minGlue.h>
+#include <minIni_cache.h>
 #include <SdFat.h>
+#include <string.h>
 
 // This can be overridden in platformio.ini
 // Set to 0 to disable the cache.
@@ -14,6 +16,9 @@
 // Use the SdFs instance from main program
 extern SdFs SD;
 
+// Called by the main program while the .ini file is read from the SD card
+static ini_keep_alive_callback_t g_ini_keep_alive_callback = nullptr;
+
 static struct {
     bool valid;
     INI_FILETYPE *fp;
@@ -21,6 +26,7 @@ static struct {
 #if INI_CACHE_SIZE > 0
     const char *filename;
     uint32_t filelen;
+    uint32_t cachelen;
     INI_FILEPOS current_pos;
     char cachedata[INI_CACHE_SIZE];
 #endif
@@ -30,28 +36,286 @@ static struct {
 void invalidate_ini_cache()
 {
     g_ini_cache.valid = false;
-    g_ini_cache.fp = NULL;
+    g_ini_cache.fp = nullptr;
+
+#if INI_CACHE_SIZE > 0
+    g_ini_cache.filelen = 0;
+    g_ini_cache.cachelen = 0;
+#endif
 }
+
+#if INI_CACHE_SIZE > 0
+
+// Line buffer used while filling the cache.
+// Lines longer than this are stored unmodified, because minIni cannot parse
+// them in one piece either (it reads at most INI_BUFFERSIZE bytes per line).
+#ifndef INI_CACHE_LINE_SIZE
+#define INI_CACHE_LINE_SIZE 512
+#endif
+
+// Whitespace as minIni's skipleading() / skiptrailing() see it.
+static bool is_ini_space(char c)
+{
+    return c > '\0' && c <= ' ';
+}
+
+// Find where a trailing comment starts inside a value.
+// Uses the same quoting and escaping rules as minIni's cleanstring(), so a
+// ';' or '#' inside a "quoted string", doubled as "" or escaped as \" is kept.
+// Returns the index of the comment character, or 'end' if there is no comment.
+static size_t find_value_comment(const char *line, size_t pos, size_t end)
+{
+    bool isstring = false;
+
+    while (pos < end)
+    {
+        char c = line[pos];
+
+        if ((c == ';' || c == '#') && !isstring)
+        {
+            break;
+        }
+
+        if (c == '"')
+        {
+            if (pos + 1 < end && line[pos + 1] == '"')
+                pos++;                  // skip "" (both quotes)
+            else
+                isstring = !isstring;   // single quote, toggle isstring
+        }
+        else if (c == '\\' && pos + 1 < end && line[pos + 1] == '"')
+        {
+            pos++;                      // skip \" (both quotes)
+        }
+
+        pos++;
+    }
+
+    return pos;
+}
+
+// Copy a single line into the cache with comments and surrounding whitespace
+// removed. Blank lines and comment-only lines are dropped entirely.
+// Returns the number of bytes written to dst, or -1 if dst is too small.
+static int strip_ini_line(const char *line, size_t linelen, char *dst, size_t dstsize)
+{
+    // Drop leading whitespace and the trailing line terminator
+    size_t start = 0;
+    size_t end = linelen;
+    while (start < end && is_ini_space(line[start]))
+        start++;
+    while (end > start && is_ini_space(line[end - 1]))
+        end--;
+
+    // Empty line, or a line that is nothing but a comment
+    if (start == end || line[start] == ';' || line[start] == '#')
+    {
+        return 0;
+    }
+
+    size_t content_end = end;
+
+    if (line[start] == '[')
+    {
+        // Section header. minIni takes the section name from the last ']' on
+        // the line, so anything following it is a trailing comment.
+        // A line without ']' is not a valid header and is kept unmodified.
+        size_t bracket = end;
+        while (bracket > start && line[bracket - 1] != ']')
+            bracket--;
+
+        if (bracket > start)
+        {
+            content_end = bracket;
+        }
+    }
+    else
+    {
+        // Possible "key = value" or "key : value" entry. minIni looks for a
+        // comment only in the value, so the key is copied as-is.
+        // A line without a separator is not an entry and is kept unmodified.
+        const char *sep = (const char *)memchr(line + start, '=', end - start);
+        if (sep == nullptr)
+            sep = (const char *)memchr(line + start, ':', end - start);
+
+        if (sep != nullptr)
+        {
+            content_end = find_value_comment(line, (size_t)(sep - line) + 1, end);
+        }
+    }
+
+    // Drop the whitespace that separated the content from a removed comment
+    while (content_end > start && is_ini_space(line[content_end - 1]))
+        content_end--;
+
+    size_t len = content_end - start;
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    if (len + 1 > dstsize)
+    {
+        return -1;
+    }
+
+    memcpy(dst, line + start, len);
+    dst[len] = '\n';
+    return (int)(len + 1);
+}
+
+#endif
 
 // Read the config file into RAM
 void reload_ini_cache(const char *filename)
 {
     g_ini_cache.valid = false;
-    g_ini_cache.fp = NULL;
+    g_ini_cache.fp = nullptr;
 
 #if INI_CACHE_SIZE > 0
     g_ini_cache.filename = filename;
+    g_ini_cache.filelen = 0;
+    g_ini_cache.cachelen = 0;
+
     FsFile config = SD.open(filename, O_RDONLY);
-    g_ini_cache.filelen = config.fileSize();
-    if (config.isOpen() && g_ini_cache.filelen <= INI_CACHE_SIZE)
+    if (!config.isOpen())
     {
-        if (config.read(g_ini_cache.cachedata, g_ini_cache.filelen) == g_ini_cache.filelen)
+        // Not an error: without a config file the firmware uses its defaults.
+        return;
+    }
+
+    g_ini_cache.filelen = config.fileSize();
+
+    // Read the file one line at a time and store only what minIni parses.
+    // Leaving out comments and blank lines lets .ini files that are larger
+    // than the cache still be served from RAM.
+    char linebuf[INI_CACHE_LINE_SIZE];
+    uint32_t cachepos = 0;
+    bool copy_verbatim = false;
+    bool ok = true;
+
+    while (ok)
+    {
+        int linelen = config.fgets(linebuf, sizeof(linebuf));
+
+        if (linelen == 0)
         {
-            g_ini_cache.valid = true;
+            break; // End of file
+        }
+        else if (linelen < 0)
+        {
+            ok = false; // Read error, fall back to reading from SD card
+            break;
+        }
+
+        // A full buffer without a line terminator means the line continues in
+        // the next read. Such lines are stored unmodified, as a partial line
+        // cannot be checked for quotes and comments reliably.
+        bool truncated = (linelen == (int)sizeof(linebuf) - 1 && linebuf[linelen - 1] != '\n');
+
+        if (copy_verbatim || truncated)
+        {
+            if (cachepos + (uint32_t)linelen > INI_CACHE_SIZE)
+            {
+                ok = false;
+            }
+            else
+            {
+                memcpy(&g_ini_cache.cachedata[cachepos], linebuf, linelen);
+                cachepos += linelen;
+                copy_verbatim = truncated;
+            }
+        }
+        else
+        {
+            int written = strip_ini_line(linebuf, linelen,
+                                         &g_ini_cache.cachedata[cachepos],
+                                         INI_CACHE_SIZE - cachepos);
+            if (written < 0)
+            {
+                ok = false; // Does not fit in the cache
+            }
+            else
+            {
+                cachepos += written;
+            }
         }
     }
+
     config.close();
+
+    if (ok)
+    {
+        g_ini_cache.cachelen = cachepos;
+        g_ini_cache.valid = true;
+    }
 #endif
+}
+
+// Get the length of the .ini file as stored on the SD card
+uint32_t get_ini_file_length()
+{
+#if INI_CACHE_SIZE > 0
+    return g_ini_cache.filelen;
+#else
+    return 0;
+#endif
+}
+
+// Get the length of the cached copy of the .ini file
+uint32_t get_ini_cache_length()
+{
+#if INI_CACHE_SIZE > 0
+    if (g_ini_cache.valid)
+    {
+        return g_ini_cache.cachelen;
+    }
+#endif
+
+    return 0;
+}
+
+// Get the total space available for caching the .ini file
+uint32_t get_ini_cache_capacity()
+{
+    return INI_CACHE_SIZE;
+}
+
+// Check whether the .ini file is being served from the cache
+bool is_ini_cached()
+{
+    return g_ini_cache.valid;
+}
+
+// Write the cached copy of the .ini file to the SD card
+bool dump_ini_cache(const char *filename)
+{
+#if INI_CACHE_SIZE > 0
+    if (!g_ini_cache.valid)
+    {
+        return false;
+    }
+
+    FsFile dump = SD.open(filename, O_WRONLY | O_CREAT | O_TRUNC);
+    if (!dump.isOpen())
+    {
+        return false;
+    }
+
+    bool ok = (dump.write(g_ini_cache.cachedata, g_ini_cache.cachelen) == g_ini_cache.cachelen);
+    ok = dump.sync() && ok;
+    dump.close();
+    return ok;
+#else
+    (void)filename;
+    return false;
+#endif
+}
+
+// Set the callback used while reading an .ini file that is not cached
+void set_ini_keep_alive_callback(ini_keep_alive_callback_t callback)
+{
+    g_ini_keep_alive_callback = callback;
 }
 
 // Open .ini file either from cache or from SD card
@@ -68,6 +332,15 @@ bool ini_openread(const char *filename, INI_FILETYPE *fp)
     }
 #endif
 
+    // The file did not fit in the cache, so it is opened and scanned from the
+    // SD card once per setting that is read. On a large .ini file that adds up
+    // to more time than the watchdog allows, even though the firmware is still
+    // making progress, so let the main program keep the watchdog fed here.
+    if (g_ini_keep_alive_callback != nullptr)
+    {
+        g_ini_keep_alive_callback();
+    }
+
     return fp->open(SD.vol(), filename, O_RDONLY);
 }
 
@@ -77,7 +350,7 @@ bool ini_close(INI_FILETYPE *fp)
 #if INI_CACHE_SIZE > 0
     if (g_ini_cache.fp == fp)
     {
-        g_ini_cache.fp = NULL;
+        g_ini_cache.fp = nullptr;
         return true;
     }
     else
@@ -96,7 +369,7 @@ bool ini_read(char *buffer, int size, INI_FILETYPE *fp)
         // Read one line from cache
         uint32_t srcpos = g_ini_cache.current_pos.position;
         int dstpos = 0;
-        while (srcpos < g_ini_cache.filelen &&
+        while (srcpos < g_ini_cache.cachelen &&
                dstpos < size - 1)
         {
             char b = g_ini_cache.cachedata[srcpos++];

--- a/lib/minIni/minIni_cache.h
+++ b/lib/minIni/minIni_cache.h
@@ -4,7 +4,40 @@
 
 #pragma once
 
+#include <stdint.h>
+
+// Called each time an .ini file that does not fit in the cache is opened
+typedef void (*ini_keep_alive_callback_t)(void);
+
+// Set a callback to be run while an .ini file is read from the SD card because
+// it does not fit in the cache. Reading a large .ini file that way takes one
+// full scan of the file per setting, which can run longer than the watchdog
+// allows even though progress is being made. Pass nullptr to remove the callback.
+void set_ini_keep_alive_callback(ini_keep_alive_callback_t callback);
+
 void invalidate_ini_cache();
 
 // Note: filename must be statically allocated, pointer is stored.
 void reload_ini_cache(const char *filename);
+
+// Get the length in bytes of the .ini file as stored on the SD card.
+// Returns 0 if the file has not been read, or if the cache is disabled.
+uint32_t get_ini_file_length();
+
+// Get the length in bytes of the cached copy of the .ini file.
+// This is smaller than the file length because comments, blank lines and
+// surrounding whitespace are stripped when the file is cached.
+// Returns 0 if the file is not cached and is read from the SD card instead.
+uint32_t get_ini_cache_length();
+
+// Get the total space in bytes available for caching the .ini file.
+// Returns 0 if the cache is disabled.
+uint32_t get_ini_cache_capacity();
+
+// Check whether the .ini file is currently served from the cache.
+// When false, minIni reads the file from the SD card on every access.
+bool is_ini_cached();
+
+// Write the cached copy of the .ini file to 'filename' on the SD card.
+// Returns false if nothing is cached, or if the file could not be written.
+bool dump_ini_cache(const char *filename);

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -1200,6 +1200,54 @@ void readSCSIDeviceConfig()
 /* Main SCSI handling loop       */
 /*********************************/
 
+// Report how much of the settings cache the config file uses, and warn if it
+// was too large to cache and has to be read from the SD card on every access.
+// Called from reinitSCSI() rather than from the reload in mountSDCard(), so
+// that the debug message is also shown when Debug is enabled in the config
+// file itself instead of by the DIP switch.
+static void logIniCacheUsage()
+{
+  uint32_t capacity = get_ini_cache_capacity();
+
+  if (is_ini_cached())
+  {
+    dbgmsg("Original ", CONFIGFILE, " is ", (int)get_ini_file_length()," bytes, takes up ", (int)get_ini_cache_length(),
+           " bytes in cache out of ", (int)capacity, " bytes after being processed");
+  }
+  else if (get_ini_file_length() > 0)
+  {
+    logmsg("WARNING: '", CONFIGFILE, "' stripped of comments does not fit in the ", (int)capacity,
+           " byte settings cache and will be read from the SD card instead");
+    dbgmsg("'", CONFIGFILE, "' is ", (int)get_ini_file_length(),
+           " bytes and overflows the ", (int)capacity, " byte settings cache");
+  }
+}
+
+// Write out the cached copy of the config file when DumpCachedSettings is set
+static void dumpIniCache()
+{
+  if (!g_scsi_settings.getSystem()->dumpCachedSettings)
+  {
+    return;
+  }
+
+  if (dump_ini_cache(CONFIGFILECACHED))
+  {
+    logmsg("DumpCachedSettings: wrote ", (int)get_ini_cache_length(),
+           " bytes of cached settings to '", CONFIGFILECACHED, "'");
+  }
+  else if (!is_ini_cached())
+  {
+    logmsg("WARNING: DumpCachedSettings is set but '", CONFIGFILE,
+           "' is not cached, nothing to write to '", CONFIGFILECACHED, "'");
+  }
+  else
+  {
+    logmsg("WARNING: DumpCachedSettings failed to write '", CONFIGFILECACHED,
+           "', SD error code: ", (int)SD.sdErrorCode());
+  }
+}
+
 static bool mountSDCard()
 {
   // Prepare for mounting new SD card by closing all old files.
@@ -1256,6 +1304,9 @@ static void reinitSCSI()
       logmsg(" performance and is not recommended for normal use.        ");
       logmsg("===========================================================");
   }
+
+  logIniCacheUsage();
+  dumpIniCache();
 
 #ifdef PLATFORM_HAS_INITIATOR_MODE
   if (platform_is_initiator_mode_enabled())
@@ -1837,6 +1888,10 @@ extern "C" void zuluscsi_setup(void)
 {
   platform_init();
   platform_late_init();
+
+  // An .ini file too large to cache is rescanned from the SD card for every
+  // setting that is read, which can take longer than the watchdog allows.
+  set_ini_keep_alive_callback(&platform_reset_watchdog);
 
   bool is_initiator = false;
 #ifdef PLATFORM_HAS_INITIATOR_MODE

--- a/src/ZuluSCSI_config.h
+++ b/src/ZuluSCSI_config.h
@@ -51,6 +51,7 @@
 
 // Configuration and log file paths
 #define CONFIGFILE  "zuluscsi.ini"
+#define CONFIGFILECACHED "zuluscsi-cached.ini"
 #define LOGFILE     "zululog.txt"
 #define LOGFILEPREV "zululog_prev.txt"
 #define LOGFILEROTATE "zululog_rotate"

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -656,6 +656,8 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
 
     cfgSys.wifi_keep_alive_s = WIFI_KEEPALIVE_INTERVAL;
 
+    cfgSys.dumpCachedSettings = false;
+
 #ifdef ENABLE_COW
     cfgSys.cowBufferSize = DEFAULT_COW_BUFFER_SIZE;
 #endif
@@ -869,6 +871,9 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
     cfgSys.wifi_keep_alive_s = log_ini_getl("SCSI", "WiFiKeepAliveSecs", cfgSys.wifi_keep_alive_s, CONFIGFILE, log_settings);
 
     cfgSys.initiatorParity = log_ini_getbool("SCSI", "InitiatorParity", cfgSys.initiatorParity, CONFIGFILE, log_settings);
+
+    cfgSys.dumpCachedSettings = log_ini_getbool("SCSI", "DumpCachedSettings", cfgSys.dumpCachedSettings, CONFIGFILE, log_settings);
+
 
 #if ENABLE_COW
     cfgSys.cowBufferSize = log_ini_getl("SCSI", "CowBufferSize", cfgSys.cowBufferSize, CONFIGFILE, log_settings);

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -137,6 +137,8 @@ typedef struct __attribute__((__packed__)) scsi_system_settings_t
 
     uint32_t wifi_keep_alive_s;
 
+    bool dumpCachedSettings;
+
 #if ENABLE_COW
     uint16_t cowBufferSize;
 #endif

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -24,6 +24,7 @@
 #LogIniSettings = 1 # Set to 0 to quiet log of settings in this file
 #LogToSDCard = 1 # Set to 0 to stop logging to 'zululog.txt' on the SD card
 #LogRotate = 1 # 0: disable log rotation, 1: single log rotation, 2: save all rotated logs in /zuluscsi_log/
+#DumpCachedSettings = 0 # Set to 1 to write the cached copy of this file, with comments and blank lines removed, to 'zuluscsi-cached.ini'
 #SelectionDelay = 255   # Millisecond delay after selection, 255 = automatic, 0 = no delay
 #Dir = "/"   # Optionally look for image files in subdirectory
 #Dir2 = "/images"  # Multiple directories can be specified Dir1...Dir9


### PR DESCRIPTION
This strips the `zuluscsi.ini` file of whitespace and comments while writing it to cache. If it overflows the cache it goes back to reading directly from the SD card.

When the new setting `DumpCachedSettings` under the `[SCSI]` section is set to 1 it will write the cached `zuluscsi.ini` to `zuluscsi-cached.ini` on the SD card.