### PR TITLE
Support [SCSI10] - [SCSI15] section in zuluscsi.ini

### DIFF
--- a/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
+++ b/lib/ZuluSCSI_Control/ZuluSCSI_control_api.cpp
@@ -156,8 +156,8 @@ bool controlGetImageDirectory(uint8_t scsi_id, char *buf, size_t buflen)
     image_config_t &img = scsiDiskGetImageConfig(scsi_id);
 
     // Explicit ImgDir in zuluscsi.ini takes first priority
-    char section[] = "SCSI0";
-    section[4] =  scsiEncodeID(scsi_id);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(scsi_id, section, sizeof(section));
     char dirname[MAX_FILE_PATH];
     int dirlen = ini_gets(section, "ImgDir", "", dirname, sizeof(dirname), CONFIGFILE);
     if (dirlen > 0)

--- a/lib/ZuluSCSI_UI_RP2MCU/control.cpp
+++ b/lib/ZuluSCSI_UI_RP2MCU/control.cpp
@@ -1096,8 +1096,8 @@ void patchDevice(uint8_t target_idx)
             
                 // MaxImgX
                 char filename[MAX_PATH_LEN];
-                char section[6] = "SCSI0";
-                section[4] = scsiEncodeID(target_idx);
+                char section[SCSI_INI_SECTION_SIZE];
+                scsiGetIniSection(target_idx, section, sizeof(section));
                 int j;
                 for (j=0;j<=IMAGE_INDEX_MAX;j++)
                 {

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -648,8 +648,8 @@ static bool autoCreateAS400ProfileImages()
     if (s2s_getConfigById(id))
       continue; // the scan below already found a real image for this ID
 
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(id);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(id, section, sizeof(section));
     char profileName[64];
     ini_gets(section, "AS400_DiskProfile", "", profileName, sizeof(profileName), CONFIGFILE);
     if (profileName[0] == '\0')
@@ -1206,6 +1206,7 @@ static bool mountSDCard()
   // When switching between FAT and exFAT cards the pointers
   // are invalidated and accessing old files results in crash.
   invalidate_ini_cache();
+  scsiResetIniSectionWarnings();
   g_logfile.close();
   scsiDiskCloseSDCardImages();
 

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -133,6 +133,52 @@ char scsiEncodeID(const uint8_t scsi_id)
     return '\0';
 }
 
+// One bit per SCSI ID, set once the ignored duplicate section has been logged
+static uint16_t g_reported_duplicate_sections = 0;
+
+void scsiResetIniSectionWarnings()
+{
+    g_reported_duplicate_sections = 0;
+}
+
+const char *scsiGetIniSection(const uint8_t scsi_id, char *buffer, size_t buffer_size)
+{
+    assert(buffer != NULL && buffer_size >= SCSI_INI_SECTION_SIZE);
+
+    memcpy(buffer, "SCSI", 4);
+    size_t len = 4;
+    if (scsi_id >= 10)
+        buffer[len++] = '0' + scsi_id / 10;
+    buffer[len++] = '0' + scsi_id % 10;
+    buffer[len] = '\0';
+
+    if (scsi_id < 0xA || scsi_id > 0xF)
+    {
+        // IDs 0 to 9 have only one possible spelling, higher IDs do not exist
+        return buffer;
+    }
+
+    // IDs 10 to 15 can also be written with a hexadecimal digit, e.g. [SCSIB] for ID 11.
+    char legacy_section[SCSI_INI_SECTION_SIZE];
+    memcpy(legacy_section, "SCSI", 4);
+    legacy_section[4] = scsiEncodeID(scsi_id);
+    legacy_section[5] = '\0';
+
+    if (!ini_hassection(buffer, CONFIGFILE))
+    {
+        // No decimal section for this ID, fall back to the hexadecimal one
+        memcpy(buffer, legacy_section, sizeof(legacy_section));
+    }
+    else if (ini_hassection(legacy_section, CONFIGFILE)
+             && !(g_reported_duplicate_sections & (1 << scsi_id)))
+    {
+        g_reported_duplicate_sections |= (1 << scsi_id);
+        logmsg("---- Using [", buffer, "] and ignoring [", legacy_section, "] as they both refer to SCSI ID: ", (int) scsi_id );
+    }
+
+    return buffer;
+}
+
 /************************************************/
 /* ROM drive support (in microcontroller flash) */
 /************************************************/
@@ -905,8 +951,8 @@ static void scsiDiskSetConfig(int target_idx)
 
     scsiDiskSetImageConfig(target_idx);
 
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(target_idx);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(target_idx, section, sizeof(section));
     char tmp[32];
 #ifdef DYNAMIC_SCSI_ID
     bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
@@ -1213,8 +1259,8 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buflen)
 {
     int target_idx = img.scsiId & S2S_CFG_TARGET_ID_BITS;
 
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(target_idx);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(target_idx, section, sizeof(section));
 #ifdef DYNAMIC_SCSI_ID
     bool is_dynamic = (g_dynamic_scsi_id >= 0 && target_idx == (int)g_dynamic_scsi_id);
 #endif

--- a/src/ZuluSCSI_disk.h
+++ b/src/ZuluSCSI_disk.h
@@ -229,6 +229,18 @@ int8_t scsiParseId(const char scsi_id_text);
 // Encode ID as char
 char scsiEncodeID(const uint8_t scsi_id);
 
+// Size of a buffer that can hold any device section name, e.g. "SCSI15"
+#define SCSI_INI_SECTION_SIZE 7
+
+// Write the CONFIGFILE section name for the given SCSI ID into buffer and return it.
+// IDs 10 to 15 can be written either as [SCSI10] - [SCSI15] or as [SCSIA] - [SCSIF],
+// the decimal form takes precedence when both are present in the file.
+const char *scsiGetIniSection(const uint8_t scsi_id, char *buffer, size_t buffer_size);
+
+// Forget which duplicate device sections have already been reported so that they
+// are logged again after the config file has been re-read.
+void scsiResetIniSectionWarnings();
+
 // Store the SCSI ID read at boot (-1 = not available).
 // Must be called before readSCSIDeviceConfig().
 void scsiDiskSetDynamicId(int8_t id);

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -315,13 +315,11 @@ void log_gets_password(const char *Key, char *buffer, int BufferSize)
 
 void ZuluSCSISettings::setDefaultDriveInfo(uint8_t scsiId, const char *presetName, S2S_CFG_TYPE type, bool log_settings)
 {
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(scsiId);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(scsiId, section, sizeof(section));
 
     scsi_device_settings_t &cfgDev = m_dev[scsiId];
     scsi_device_settings_t &cfgDefault = m_dev[SCSI_SETTINGS_SYS_IDX];
-    
-
 
     static const char * const driveinfo_fixed[4]     = DRIVEINFO_FIXED;
     static const char * const driveinfo_removable[4] = DRIVEINFO_REMOVABLE;
@@ -948,8 +946,8 @@ scsi_device_settings_t* ZuluSCSISettings::initDevice(uint8_t scsiId, S2S_CFG_TYP
 {
     scsi_device_settings_t& cfg = m_dev[scsiId];
     char presetName[32] = {};
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(scsiId);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(scsiId, section, sizeof(section));
     bool log_settings = false; 
 
 #ifdef ZULUSCSI_HARDWARE_CONFIG

--- a/src/custom_vendor_inquiry.cpp
+++ b/src/custom_vendor_inquiry.cpp
@@ -653,10 +653,10 @@ void resetCustomInquiryData()
 void parseCustomInquiryData(uint8_t scsiId, S2S_CFG_TYPE type)
 {
     char tmp[512];
-    char section[6] = "SCSI0";
+    char section[SCSI_INI_SECTION_SIZE];
     char key[8];
 
-    section[4] = scsiEncodeID(scsiId);
+    scsiGetIniSection(scsiId, section, sizeof(section));
 
     // Parse VPD pages: vpd00, vpd80, etc.
     int page;

--- a/src/uiDiskUtils.cpp
+++ b/src/uiDiskUtils.cpp
@@ -27,8 +27,8 @@
 
 extern "C" void getImgXByIndex(uint8_t id, int index, char* buf, size_t buflen, u_int64_t &size)
 {
-    char section[6] = "SCSI0";
-    section[4] = scsiEncodeID(id);
+    char section[SCSI_INI_SECTION_SIZE];
+    scsiGetIniSection(id, section, sizeof(section));
 
     scsiDiskReadImgX(section, index, buf, buflen);
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -196,8 +196,25 @@
 #   timing depends on the WiFi router
 
 # Settings can be overridden for individual devices.
+# The section name is "SCSI" followed by the SCSI ID of the device, e.g. [SCSI2] for ID 2.
 #[SCSI2]
 #Product = "Disk with ID2"
+
+#[SCSIn]
+# settings under this section apply to dynamically assigned SCSI id images
+# like "hdn - my sca image.bin" for Wide SCA boards
+
+# On wide boards the IDs 10 to 15 can be written either in decimal as
+# [SCSI10] - [SCSI15], or with a hexadecimal digit as [SCSIA] - [SCSIF].
+# If both are present for the same ID, the decimal one is read and the 
+# hexadecimal one is ignored
+#[SCSI12]
+#Product = "Disk with ID12"
+# or
+#[SCSIC]
+#Product = "Same as [SCSI12]" # Useful because images are always prefixed
+# with hexadecimal e.g. "HDC-my-hdd-image-on-id-11.img".
+# "HD12-not-the-same.img" would be SCSI ID 1 LUN 2.
 
 #[SCSI3]
 #Product = "CD-ROM Drive"
@@ -206,10 +223,6 @@
 # If IMG0..IMG9 are specified, they are cycled after each eject command.
 #IMG0 = FirstCD.iso
 #IMG1 = SecondCD.bin
-
-#[SCSIn]
-# settings under this section apply to dynamically assigned SCSI id images
-# like "hdn - my sca image.bin" for Wide SCA boards
 
 #[SCSI4]
 #Type = 5


### PR DESCRIPTION
Added [SCSI10] - [SCSI15] sections for wide boards. These take precedent over [SCSIA] - [SCSIF] with hexadecimal SCSI IDs. If both are defined in an ini file, priority is given to the numeric/decimal SCSI ID.