### PR TITLE
Fix file renames if target file already exists

### DIFF
--- a/src/ROMDrive.cpp
+++ b/src/ROMDrive.cpp
@@ -177,9 +177,18 @@ bool scsiDiskProgramRomDrive(const char *filename, int scsi_id, int blocksize, S
     char newname[MAX_FILE_PATH * 2] = "";
     strlcat(newname, filename, sizeof(newname));
     strlcat(newname, "_loaded", sizeof(newname));
-    SD.rename(filename, newname);
-    logmsg("---- ROM drive programming successful, image file renamed to ", newname);
-
+    if (SD.exists(newname))
+    {
+        SD.remove(newname);
+    }
+    if (SD.rename(filename, newname))
+    {
+        logmsg("---- ROM drive programming successful, image file renamed to ", newname);
+    }
+    else
+    {
+        logmsg("---- ROM drive programming successful, but failed to rename image to ", newname);
+    }
     return true;
 }
 

--- a/src/ZuluSCSI.cpp
+++ b/src/ZuluSCSI.cpp
@@ -405,9 +405,13 @@ static bool parseCreateCommand(const char *cmd_filename, uint64_t &size, char im
       return false;
     }
 
+    if (SD.exists(imgname))
+    {
+      SD.remove(imgname);
+    }
     if (!SD.rename(cmd_filename, imgname))
     {
-      logmsg("---- Failed to rename ", cmd_filename, " to \"-Failed-", cmd_filename, "\"");
+      logmsg("---- Failed to rename \"", cmd_filename, "\" to \"", imgname, "\"");
       return false;
     }
   }


### PR DESCRIPTION
SD.rename fails if the target file already exists. This removes the file first in two cases where rename should overwrite the target.