### PR TITLE
Backport WPA3 Support for Wi-Fi/DaynaPORT

### DIFF
--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -1,5 +1,6 @@
 //	Copyright (C) 2014 Michael McMaster <michael@codesrc.com>
 //	Copyright (c) 2023 joshua stein <jcs@jcs.org>
+//	Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
 //
 //	This file is part of SCSI2SD.
 //
@@ -152,7 +153,9 @@ typedef struct __attribute__((packed))
 
 	uint8_t busWidth; // Wide bus support, 0: 8-bit, 1: 16-bit, 2: 32-bit
 
-	uint8_t reserved[15]; // Pad out to 128 bytes
+	uint8_t wifiSecurity; // zuluscsi_wifi_security_t, 0: WPA/WPA2 mixed PSK
+
+	uint8_t reserved[14]; // Pad out to 128 bytes
 } S2S_BoardCfg;
 
 typedef enum

--- a/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
+++ b/lib/ZuluSCSI_platform_RP2MCU/ZuluSCSI_platform_network.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -66,6 +67,35 @@ static bool g_wifi_scan_suspend_reconnect = false;
 // has no getter for the auth mode of a live association, so remember what was
 // asked for at join time.
 static bool g_wifi_join_secured = false;
+
+// How long to wait for an association to finish before reporting it stalled.
+#define WIFI_JOIN_STALL_TIMEOUT 30000
+
+// Start of the most recent join attempt, or 0 once the link is up.
+static uint32_t wifi_join_time = 0;
+static bool wifi_join_stall_reported = false;
+
+static const char *wifi_security_name(uint8_t security)
+{
+	switch (security)
+	{
+		case WIFI_SECURITY_WPA2_AES:  return "WPA2 AES PSK";
+		case WIFI_SECURITY_WPA3:      return "WPA3 SAE";
+		case WIFI_SECURITY_WPA3_WPA2: return "WPA3/WPA2 SAE";
+		default:                      return "WPA/WPA2 PSK";
+	}
+}
+
+static uint32_t wifi_security_auth(uint8_t security)
+{
+	switch (security)
+	{
+		case WIFI_SECURITY_WPA2_AES:  return CYW43_AUTH_WPA2_AES_PSK;
+		case WIFI_SECURITY_WPA3:      return CYW43_AUTH_WPA3_SAE_AES_PSK;
+		case WIFI_SECURITY_WPA3_WPA2: return CYW43_AUTH_WPA3_WPA2_AES_PSK;
+		default:                      return CYW43_AUTH_WPA2_MIXED_PSK;
+	}
+}
 
 static void platform_network_wifi_store_reconnect_credentials(const char *ssid, const char *password)
 {
@@ -198,13 +228,23 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 	}
 	else
 	{
+		uint8_t security = scsiDev.boardCfg.wifiSecurity;
+
 		if (!reconnect)
-			logmsg("Connecting to Wi-Fi SSID \"", ssid, "\" with WPA/WPA2 PSK");
-		ret = cyw43_arch_wifi_connect_async(ssid, password, CYW43_AUTH_WPA2_MIXED_PSK);
+			logmsg("Connecting to Wi-Fi SSID \"", ssid, "\" with ", wifi_security_name(security));
+		ret = cyw43_arch_wifi_connect_async(ssid, password, wifi_security_auth(security));
 	}
 
 	if (ret == 0)
 	{
+		// Time the association from the first attempt, not from every automatic
+		// retry, otherwise the backoff below always restarts the stall timer.
+		if (!reconnect || wifi_join_time == 0)
+		{
+			wifi_join_time = millis();
+			wifi_join_stall_reported = false;
+		}
+
 		// Short single blink at start of connection sequence
 		PICO_W_LED_OFF();
 		delay(PICO_W_SHORT_BLINK_DELAY);
@@ -276,7 +316,8 @@ void platform_network_poll()
 					logmsg("Wi-Fi connected to ", ssid, " but was not assigned an IP");
 					break;
 				case CYW43_LINK_BADAUTH:
-					logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the setting \"WiFiPassword\" in ", CONFIGFILE);
+					logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the settings \"WiFiPassword\" and \"WiFiSecurity\" (currently ",
+						wifi_security_name(scsiDev.boardCfg.wifiSecurity), ") in ", CONFIGFILE);
 					break;
 				case CYW43_LINK_NONET:
 					logmsg("Wi-Fi SSID ", ssid, " not found, possible out of range or down");
@@ -301,6 +342,17 @@ void platform_network_poll()
 		logmsg("Attempting Wi-Fi reconnection to \"", ssid, "\" attempts: ", wifi_reconnect_attempts, ", next attempt in ", (int)wifi_reconnect_interval / 1000, " seconds");
 		platform_network_wifi_join(ssid, (g_wifi_reconnect_password[0]) ? g_wifi_reconnect_password : scsiDev.boardCfg.wifiPassword, true);
 
+	}
+
+	// An association that never completes sits at CYW43_LINK_JOIN forever
+	if (!wifi_join_stall_reported
+		&& wifi_join_time != 0
+		&& status == CYW43_LINK_JOIN
+		&& (uint32_t)(millis() - wifi_join_time) > WIFI_JOIN_STALL_TIMEOUT)
+	{
+		wifi_join_stall_reported = true;
+		logmsg("Wi-Fi association to \"", ssid, "\" has not completed after 30 seconds, if it does not connect check that \"WiFiSecurity\" (currently ",
+			wifi_security_name(scsiDev.boardCfg.wifiSecurity), ") in ", CONFIGFILE, " matches the access point");
 	}
 
 	last_network_status = status;
@@ -591,6 +643,10 @@ void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf)
 void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 {
 	char *ssid = platform_network_wifi_ssid();
+
+	// The link is genuinely up, so stop watching for a stalled association.
+	wifi_join_time = 0;
+	wifi_join_stall_reported = false;
 
 	if (ssid)
 	{

--- a/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp2040-template.ld
@@ -166,6 +166,12 @@ SECTIONS
         *(.text*setNameFromImage*)
         *(.text*getBlockSize*)
 
+        /* Wi-Fi association, only used during init and reconnect. Keeps the
+         * packet path (platform_network_send/receive) in RAM. */
+        *(.text*platform_network_wifi_join*)
+        *(.text*wifi_security_name*)
+        *(.text*wifi_security_auth*)
+
         /* SCSI commands that don't require high performance */
         *(.text*scsiToolboxCommand*)
         *(.text*scsi*Diagnostic*)

--- a/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
+++ b/lib/ZuluSCSI_platform_RP2MCU/rp23xx-template.ld
@@ -172,6 +172,12 @@ SECTIONS
         *(.text*setNameFromImage*)
         *(.text*getBlockSize*)
 
+        /* Wi-Fi association, only used during init and reconnect. Keeps the
+         * packet path (platform_network_send/receive) in RAM. */
+        *(.text*platform_network_wifi_join*)
+        *(.text*wifi_security_name*)
+        *(.text*wifi_security_auth*)
+
         /* SCSI commands that don't require high performance */
         *(.text*scsiToolboxCommand*)
         *(.text*scsi*Diagnostic*)

--- a/src/ZuluSCSI_disk.cpp
+++ b/src/ZuluSCSI_disk.cpp
@@ -1,7 +1,7 @@
 /**
  * SCSI2SD V6 - Copyright (C) 2013 Michael McMaster <michael@codesrc.com>
  * Portions Copyright (C) 2014 Doug Brown <doug@downtowndougbrown.com>
- * Portions Copyright (C) 2023 Eric Helgeson
+ * Portions Copyright (C) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * ZuluSCSI™ - Copyright (c) 2022-2026 Rabbit Hole Computing™
  *
  * This file is licensed under the GPL version 3 or any later version. 
@@ -1883,6 +1883,14 @@ void s2s_configInit(S2S_BoardCfg* config)
     memset(tmp, 0, sizeof(tmp));
     ini_gets("SCSI", "WiFiPassword", "", tmp, sizeof(tmp), CONFIGFILE);
     if (tmp[0]) memcpy(config->wifiPassword, tmp, sizeof(config->wifiPassword));
+
+    memset(tmp, 0, sizeof(tmp));
+    ini_gets("SCSI", "WiFiSecurity", "", tmp, sizeof(tmp), CONFIGFILE);
+    if (tmp[0])
+    {
+        config->wifiSecurity = g_scsi_settings.stringToWifiSecurity(tmp);
+        logmsg("-- WiFiSecurity = ", tmp);
+    }
 
 }
 

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -1,6 +1,6 @@
 /**
- * ZuluSCSI™ - Copyright (c) 2023-2025 Rabbit Hole Computing™
- * Copyright (c) 2023 Eric Helgeson
+ * ZuluSCSI™ - Copyright (c) 2023-2026 Rabbit Hole Computing™
+ * Copyright (c) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * 
  * This file is licensed under the GPL version 3 or any later version.  
  * 
@@ -60,6 +60,15 @@ const char * const speed_grade_strings[] =
     "B",
     "C",
     "WifiRM2"
+};
+
+// must be in the same order as zuluscsi_wifi_security_t in ZuluSCSI_settings.h
+const char * const wifi_security_strings[] =
+{
+    "WPA2",
+    "WPA2AES",
+    "WPA3",
+    "WPA3WPA2"
 };
 
 // Helper function for case-insensitive string compare
@@ -911,6 +920,7 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
     log_ini_gets("SCSI", "WiFiMACAddress", "", tmp, sizeof(tmp), CONFIGFILE, log_settings);
     log_ini_gets("SCSI", "WiFiSSID", "", tmp, sizeof(tmp), CONFIGFILE, log_settings);
     log_ini_gets("SCSI", "WiFiPassword", "", tmp, sizeof(tmp), CONFIGFILE, log_settings, &log_gets_password);
+    log_ini_gets("SCSI", "WiFiSecurity", "", tmp, sizeof(tmp), CONFIGFILE, log_settings);
 
     log_ini_getbool("SCSI", "DisableROMDrive", 0, CONFIGFILE, log_settings);
     log_ini_getl("SCSI", "ROMDriveSCSIID", -1, CONFIGFILE, log_settings);
@@ -1086,6 +1096,20 @@ zuluscsi_speed_grade_t ZuluSCSISettings::stringToSpeedGrade(const char *speed_gr
     }
 
     return grade;
+}
+
+zuluscsi_wifi_security_t ZuluSCSISettings::stringToWifiSecurity(const char *wifi_security_target)
+{
+    for (uint8_t i = 0; i < sizeof(wifi_security_strings)/sizeof(wifi_security_strings[0]); i++)
+    {
+        if (strequals(wifi_security_target, wifi_security_strings[i]))
+        {
+            return (zuluscsi_wifi_security_t)i;
+        }
+    }
+
+    logmsg("Setting \"", wifi_security_target, "\" does not match any known Wi-Fi security mode, using WPA2");
+    return WIFI_SECURITY_WPA2;
 }
 
 const char *ZuluSCSISettings::getSpeedGradeString()

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -1,6 +1,6 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2023-2025 Rabbit Hole Computing™
- * Copyright (c) 2023 Eric Helgeson
+ * Copyright (c) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * 
  * This file is licensed under the GPL version 3 or any later version.  
  * 
@@ -37,6 +37,18 @@ typedef enum
     SPEED_GRADE_BASE_203MHZ,
     SPEED_GRADE_BASE_155MHZ,
 } zuluscsi_speed_grade_t;
+
+// Wi-Fi security mode requested by the WiFiSecurity setting.
+// WIFI_SECURITY_WPA2 must stay 0 so a zeroed S2S_BoardCfg keeps the
+// long-standing default when the setting is absent.
+// must be in the same order as wifi_security_strings[] in ZuluSCSI_settings.cpp
+typedef enum
+{
+    WIFI_SECURITY_WPA2 = 0,  // WPA/WPA2 mixed PSK, widest compatibility
+    WIFI_SECURITY_WPA2_AES,  // WPA2 AES PSK only, refuses TKIP
+    WIFI_SECURITY_WPA3,      // WPA3 SAE only
+    WIFI_SECURITY_WPA3_WPA2, // WPA3 SAE, also programming the WPA2 PSK
+} zuluscsi_wifi_security_t;
 
 
 typedef enum {
@@ -226,6 +238,9 @@ public:
 
     // convert string to speed grade
     zuluscsi_speed_grade_t stringToSpeedGrade(const char *speed_grade_str, size_t length);
+
+    // convert string to Wi-Fi security mode
+    zuluscsi_wifi_security_t stringToWifiSecurity(const char *wifi_security_str);
 
     const char* getSpeedGradeString();
 

--- a/zuluscsi.ini
+++ b/zuluscsi.ini
@@ -191,6 +191,11 @@
 # SCSI DaynaPORT settings
 #WiFiSSID = "Wifi SSID string"
 #WiFiPassword = "WiFi Password"
+#WiFiSecurity = WPA2 # security mode used to associate, defaults to WPA2
+#   WPA2     = WPA/WPA2 mixed PSK, widest compatibility
+#   WPA2AES  = WPA2 AES PSK only, refuses TKIP
+#   WPA3     = WPA3 SAE only
+#   WPA3WPA2 = WPA3 SAE, also programming the WPA2 PSK
 #WiFiMACAddress = "01:23:45:67:89:42"
 #WiFiKeepAliveSecs = 120 # defaults is 2 mins (120 seconds), 0 to disable
 #   the interval, in seconds, to keep the connection alive to avoid silently deauthenticating from the router


### PR DESCRIPTION
Ported: https://github.com/BlueSCSI/BlueSCSI-v2/commit/c46920e8c718a429552a0a4b6494e37d2b98ae1b.patch

From commit c46920e
```
[PATCH] network: add opt-in WiFiSecurity setting for WPA2/WPA3
 selection

Adds `WiFiSecurity = WPA2 | WPA2AES | WPA3 | WPA3WPA2` to [SCSI], defaulting to
WPA2 (WPA/WPA2 mixed PSK) so existing configurations are unchanged.
```