### PR TITLE
Add preset for IRIX system

### DIFF
--- a/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/ZuluSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -695,7 +695,8 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
     switch (speed_grade)
     {
 #ifdef ENABLE_AUDIO_OUTPUT_I2S
-    case SPEED_GRADE_MAX:
+    case SPEED_GRADE_SYS_IRIX: [[fallthrough]];
+    case SPEED_GRADE_MAX: [[fallthrough]];
     case SPEED_GRADE_A:
         timings_index = 8;
         break;
@@ -735,16 +736,19 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
         timings_index = 9;
         break;
     case SPEED_GRADE_AUDIO_I2S:
-        timings_index  =9;
+        timings_index = 9;
         break;
     case SPEED_GRADE_BASE_203MHZ:
         timings_index = 9;
         break;
     case SPEED_GRADE_BASE_155MHZ:
         timings_index = 5;
+    case SPEED_GRADE_SYS_IRIX:
+        timings_index = 8;
         break;
 #elif defined(ENABLE_AUDIO_OUTPUT_SPDIF)
-    case SPEED_GRADE_MAX:
+    case SPEED_GRADE_SYS_IRIX: [[fallthrough]];
+    case SPEED_GRADE_MAX: [[fallthrough]];
     case SPEED_GRADE_A:
         timings_index = 8;
         break;
@@ -770,6 +774,7 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
         timings_index = 5;
         break;
 #else
+    case SPEED_GRADE_SYS_IRIX: [[fallthrough]];
     case SPEED_GRADE_MAX:
     case SPEED_GRADE_A:
         timings_index = 8;
@@ -803,6 +808,12 @@ bool set_timings(zuluscsi_speed_grade_t speed_grade)
         g_max_sync_10_period = g_zuluscsi_timings->scsi_10.max_sync;
         g_max_sync_20_period = g_zuluscsi_timings->scsi_20.max_sync;
         g_max_sync_5_period = g_zuluscsi_timings->scsi_5.max_sync;
+        if (speed_grade == SPEED_GRADE_SYS_IRIX)
+        {
+            g_zuluscsi_timings->scsi_20.rdelay1 = 9;
+            g_zuluscsi_timings->scsi_20.rtotal_period_adjust = 3;
+        }
+
         return true;
     }
     return false;

--- a/src/ZuluSCSI_settings.cpp
+++ b/src/ZuluSCSI_settings.cpp
@@ -37,7 +37,15 @@
 // SCSI system and device settings
 ZuluSCSISettings g_scsi_settings;
 
-const char *systemPresetName[] = {"", "Mac", "MacPlus", "MPC3000", "MegaSTE", "X68000", "X68000-SCSI","X68000-SASI", "DOS", "NeXT", "PC-9801-55",
+const char *systemPresetName[] = {
+    "", "Mac", "MacPlus",
+    "MPC3000",
+    "MegaSTE",
+    "X68000", "X68000-SCSI","X68000-SASI",
+    "DOS",
+    "NeXT",
+    "PC-9801-55",
+    "IRIX",
 #ifdef PLATFORM_AS400
     "AS400", "AS400_BS520", "AS400_BS522", "AS400_CISC", "AS400_PPC",
 #endif
@@ -59,7 +67,10 @@ const char * const speed_grade_strings[] =
     "A",
     "B",
     "C",
-    "WifiRM2"
+    "WifiRM2",
+    "Base203MHz",
+    "Base155MHz",
+    "SystemIRIX",
 };
 
 // Helper function for case-insensitive string compare
@@ -773,6 +784,11 @@ scsi_system_settings_t *ZuluSCSISettings::initSystem(const char *presetName, boo
         m_sysPreset = SYS_PRESET_NeXT;
         cfgDev.sectorsPerTrack = 139;
         cfgDev.headsPerCylinder= 4;
+    }
+    else if (strequals(systemPresetName[SYS_PRESET_IRIX], presetName))
+    {
+        m_sysPreset = SYS_PRESET_IRIX;
+        cfgSys.speedGrade = SPEED_GRADE_SYS_IRIX;
     }
 #ifdef PLATFORM_AS400
     else if (strequals(systemPresetName[SYS_PRESET_AS400], presetName))

--- a/src/ZuluSCSI_settings.h
+++ b/src/ZuluSCSI_settings.h
@@ -36,6 +36,7 @@ typedef enum
     SPEED_GRADE_WIFI_RM2,
     SPEED_GRADE_BASE_203MHZ,
     SPEED_GRADE_BASE_155MHZ,
+    SPEED_GRADE_SYS_IRIX,
 } zuluscsi_speed_grade_t;
 
 
@@ -69,6 +70,7 @@ typedef enum
     SYS_PRESET_DOS,
     SYS_PRESET_NeXT,
     SYS_PRESET_PC_9801_55,
+    SYS_PRESET_IRIX,
 #ifdef PLATFORM_AS400
     SYS_PRESET_AS400,
     SYS_PRESET_AS400_BS520,


### PR DESCRIPTION
A user on a SGI Tezro reported a certain timing combination worked at TurboMax (251.2MHz). Implemented a system preset that applies those timings:

```
g_zuluscsi_timings->scsi_20.rdelay1 = 9;
g_zuluscsi_timings->scsi_20.rtotal_period_adjust = 3;
```

Named the System Setting `IRIX`.
```
[SCSI]
System = "IRIX"
```
Should apply the settings